### PR TITLE
fix: keep binary in same place, update if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "build": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",
+    "package:prerelease": "npx vsce package --pre-release",
     "lint": "eslint . --ext ts,md",
     "tsc:compile": "tsc",
     "tsc:watch": "tsc -w",

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -105,6 +105,7 @@ export class Storage {
       }
     }
     const etag = await this.getBinaryETag()
+    this.output.appendLine(`Using binName: ${binName}`)
     this.output.appendLine(`Using binPath: ${binPath}`)
     this.output.appendLine(`Using ETag: ${etag}`)
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -114,7 +114,7 @@ export class Storage {
       responseType: "stream",
       headers: {
         "Accept-Encoding": "gzip",
-        "If-None-Match": `"${await this.getBinaryETag()}"`,
+        "If-None-Match": `"${etag}"`,
       },
       decompress: true,
       // Ignore all errors so we can catch a 404!

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -182,7 +182,6 @@ export class Storage {
         }
         this.output.appendLine(`Downloaded binary: ${binPath}`)
         await fs.rename(tempFile, binPath)
-        await fs.rm(tempFile)
         return binPath
       }
       case 304: {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -80,7 +80,7 @@ export class Storage {
     const baseURI = vscode.Uri.parse(baseURL)
 
     const buildInfo = await getBuildInfo()
-    const binPath = this.binaryPath(buildInfo.version)
+    const binPath = this.binaryPath()
     const exists = await fs
       .stat(binPath)
       .then(() => true)
@@ -264,10 +264,10 @@ export class Storage {
     }
   }
 
-  private binaryPath(version: string): string {
+  private binaryPath(): string {
     const os = goos()
     const arch = goarch()
-    let binPath = path.join(this.getBinaryCachePath(), `coder-${os}-${arch}-${version}`)
+    let binPath = path.join(this.getBinaryCachePath(), `coder-${os}-${arch}`)
     if (os === "windows") {
       binPath += ".exe"
     }


### PR DESCRIPTION
## Description

@deansheather filed a bug related to the Windows Firewall prompt coming up with every new binary (i.e. every time we download `coder` to an updated version).

After some initial testing, it appears keeping the binary in the same place will make the prompt only appear on the first time.

Previous implementation kept the version in the path.

We decided to refactor things to add support for [ETag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) on the server and then use those changes on the client (aka in the extension).

This means now the client will tell the server "Here's the version I have. What should I do?" and send the appropriate headers.

### Checklist
- [x] if needed, change path/name of location to not include version
- [x] if the binary exists, SHA1 it and use it as the `If-None-Match` header in your request
- [x] Server Response changes
  - [x] on 200 OK: move the binary on top of the old one
  - [x] on 304 Not Modified: delete the temp file and use the old binary

### Testing Plan

TBD

Fixes #23 