### PR TITLE
fix: use the proper path separator

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -171,7 +171,7 @@ export class Commands {
       if (opened.length > 1) {
         const items: vscode.QuickPickItem[] = opened.map((folder): vscode.QuickPickItem => {
           return {
-            label: folder.folderUri.fsPath,
+            label: folder.folderUri.path,
           }
         })
         const item = await vscode.window.showQuickPick(items, {


### PR DESCRIPTION
This was using `fsPath` which normalizes for the OS. This should prevent that!

Fixes #21