### PR TITLE
fix: allow `~` to work when resolving `remote.SSH.configFile` on Windows

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -444,6 +444,12 @@ export class Remote {
     if (!sshConfigFile) {
       sshConfigFile = path.join(os.homedir(), ".ssh", "config")
     }
+    // VS Code Remote resolves ~ to the home directory.
+    // This is required for the tilde to work on Windows.
+    if (sshConfigFile.startsWith("~")) {
+      sshConfigFile = path.join(os.homedir(), sshConfigFile.slice(1))
+    }
+
     const sshConfig = new SSHConfig(sshConfigFile)
     await sshConfig.load()
 


### PR DESCRIPTION
This was causing a Windows user troubles!

cc @pcgeek86 thank you for reporting and helping :sunglasses: 

Fixes #67