### PR TITLE
feat: Add extension settings for customizing ssh config

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
           "type": "array",
           "items": {
             "title": "SSH Config Value",
-            "type": "string"
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]+[=\\s].*$"
           },
           "scope": "machine",
           "default": []

--- a/package.json
+++ b/package.json
@@ -29,6 +29,21 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "configuration": {
+      "title": "Coder",
+      "properties": {
+        "coder.sshConfig": {
+          "markdownDescription": "These values will be included in the ssh config file. Eg: `'ConnectTimeout=10'` will set the timeout to 10 seconds. Any values included here will override anything provided by default or by the deployment. To unset a value that is written by default, set the value to the empty string, Eg: `'ConnectTimeout='` will unset it.",
+          "type": "array",
+          "items": {
+            "title": "SSH Config Value",
+            "type": "string"
+          },
+          "scope": "machine",
+          "default": []
+        }
+      }
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -8,7 +8,7 @@ import {
   startWorkspace,
   getDeploymentSSHConfig,
 } from "coder/site/src/api/api"
-import { ProvisionerJobLog, SSHConfigResponse, Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
+import { ProvisionerJobLog, Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
 import EventSource from "eventsource"
 import find from "find-process"
 import * as fs from "fs/promises"

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -198,7 +198,7 @@ Host coder-vscode--*
   ProxyCommand some-command-here
   ConnectTimeout 500
   UserKnownHostsFile /dev/null
-  LogLevel DEBUG
+  loglevel DEBUG
   Buzz baz
   ExtraKey ExtraValue
   Foo bar

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -30,11 +30,11 @@ it("creates a new file and adds the config", async () => {
 
   const expectedOutput = `# --- START CODER VSCODE ---
 Host coder-vscode--*
-  ProxyCommand some-command-here
   ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  LogLevel ERROR
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
@@ -43,12 +43,12 @@ Host coder-vscode--*
 
 it("adds a new coder config in an existent SSH configuration", async () => {
   const existentSSHConfig = `Host coder.something
-  HostName coder.something
   ConnectTimeout=0
-  StrictHostKeyChecking=no
-  UserKnownHostsFile=/dev/null
   LogLevel ERROR
-  ProxyCommand command`
+  HostName coder.something
+  ProxyCommand command
+  StrictHostKeyChecking=no
+  UserKnownHostsFile=/dev/null`
   mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
@@ -66,11 +66,11 @@ it("adds a new coder config in an existent SSH configuration", async () => {
 
 # --- START CODER VSCODE ---
 Host coder-vscode--*
-  ProxyCommand some-command-here
   ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  LogLevel ERROR
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
@@ -90,11 +90,11 @@ it("updates an existent coder config", async () => {
 
 # --- START CODER VSCODE ---
 Host coder-vscode--*
-  ProxyCommand some-command-here
   ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  LogLevel ERROR
 # --- END CODER VSCODE ---`
   mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
 
@@ -119,11 +119,11 @@ Host coder-vscode--*
 
 # --- START CODER VSCODE ---
 Host coder--updated--vscode--*
-  ProxyCommand some-command-here
   ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  LogLevel ERROR
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
@@ -134,12 +134,12 @@ Host coder--updated--vscode--*
 
 it("removes old coder SSH config and adds the new one", async () => {
   const existentSSHConfig = `Host coder-vscode--*
-  HostName coder.something
   ConnectTimeout=0
-  StrictHostKeyChecking=no
-  UserKnownHostsFile=/dev/null
+  HostName coder.something
   LogLevel ERROR
-  ProxyCommand command`
+  ProxyCommand command
+  StrictHostKeyChecking=no
+  UserKnownHostsFile=/dev/null`
   mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
@@ -155,11 +155,11 @@ it("removes old coder SSH config and adds the new one", async () => {
 
   const expectedOutput = `# --- START CODER VSCODE ---
 Host coder-vscode--*
-  ProxyCommand some-command-here
   ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-  LogLevel ERROR
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
@@ -199,9 +199,9 @@ Host coder-vscode--*
   ConnectTimeout 500
   ExtraKey ExtraValue
   Foo bar
-  LogLevel DEBUG
   ProxyCommand some-command-here
   UserKnownHostsFile /dev/null
+  logLevel DEBUG
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -182,17 +182,14 @@ it("override values", async () => {
       LogLevel: "ERROR",
     },
     {
-      ssh_config_options: {
-        loglevel: "DEBUG", // This tests case insensitive
-        ConnectTimeout: "500",
-        ExtraKey: "ExtraValue",
-        Foo: "bar",
-        Buzz: "baz",
-        // Remove this key
-        StrictHostKeyChecking: "",
-        ExtraRemove: "",
-      },
-      hostname_prefix: "",
+      loglevel: "DEBUG", // This tests case insensitive
+      ConnectTimeout: "500",
+      ExtraKey: "ExtraValue",
+      Foo: "bar",
+      Buzz: "baz",
+      // Remove this key
+      StrictHostKeyChecking: "",
+      ExtraRemove: "",
     },
   )
 

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -201,7 +201,7 @@ Host coder-vscode--*
   Foo bar
   ProxyCommand some-command-here
   UserKnownHostsFile /dev/null
-  logLevel DEBUG
+  loglevel DEBUG
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -195,13 +195,13 @@ it("override values", async () => {
 
   const expectedOutput = `# --- START CODER VSCODE ---
 Host coder-vscode--*
-  ProxyCommand some-command-here
-  ConnectTimeout 500
-  UserKnownHostsFile /dev/null
-  loglevel DEBUG
   Buzz baz
+  ConnectTimeout 500
   ExtraKey ExtraValue
   Foo bar
+  LogLevel DEBUG
+  ProxyCommand some-command-here
+  UserKnownHostsFile /dev/null
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -57,6 +57,7 @@ export function mergeSSHConfigValues(
     if (caseInsensitiveOverrides[lower]) {
       const correctCaseKey = caseInsensitiveOverrides[lower]
       const value = overrides[correctCaseKey]
+      delete caseInsensitiveOverrides[lower]
 
       // If the value is empty, do not add the key. It is being removed.
       if (value === "") {
@@ -69,6 +70,12 @@ export function mergeSSHConfigValues(
     if (config[key] !== "") {
       merged[key] = config[key]
     }
+  })
+
+  // Add remaining overrides.
+  Object.keys(caseInsensitiveOverrides).forEach((lower) => {
+    const correctCaseKey = caseInsensitiveOverrides[lower]
+    merged[correctCaseKey] = overrides[correctCaseKey]
   })
 
   return merged

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -170,7 +170,8 @@ export class SSHConfig {
     // configValues is the merged values of the defaults and the overrides.
     const configValues = mergeSSHConfigValues(otherValues, overrides)
 
-    const keys = Object.keys(configValues) as Array<keyof typeof configValues>
+    // keys is the sorted keys of the merged values.
+    const keys = (Object.keys(configValues) as Array<keyof typeof configValues>).sort()
     keys.forEach((key) => {
       const value = configValues[key]
       if (value !== "") {

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -75,7 +75,9 @@ export function mergeSSHConfigValues(
   // Add remaining overrides.
   Object.keys(caseInsensitiveOverrides).forEach((lower) => {
     const correctCaseKey = caseInsensitiveOverrides[lower]
-    merged[correctCaseKey] = overrides[correctCaseKey]
+    if (overrides[correctCaseKey] !== "") {
+      merged[correctCaseKey] = overrides[correctCaseKey]
+    }
   })
 
   return merged

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -75,9 +75,7 @@ export function mergeSSHConfigValues(
   // Add remaining overrides.
   Object.keys(caseInsensitiveOverrides).forEach((lower) => {
     const correctCaseKey = caseInsensitiveOverrides[lower]
-    if (overrides[correctCaseKey] !== "") {
-      merged[correctCaseKey] = overrides[correctCaseKey]
-    }
+    merged[correctCaseKey] = overrides[correctCaseKey]
   })
 
   return merged
@@ -174,7 +172,10 @@ export class SSHConfig {
 
     const keys = Object.keys(configValues) as Array<keyof typeof configValues>
     keys.forEach((key) => {
-      lines.push(this.withIndentation(`${key} ${configValues[key]}`))
+      const value = configValues[key]
+      if (value !== "") {
+        lines.push(this.withIndentation(`${key} ${value}`))
+      }
     })
 
     lines.push(this.endBlockComment)


### PR DESCRIPTION
Allow users to override the default SSH config options, just like the coder cli allows with flags. This affects what is written to `~/.ssh/config`.

![Screenshot from 2023-03-29 12-47-57](https://user-images.githubusercontent.com/5446298/228624529-74a6cfeb-4207-4fc6-9064-82da2df3d5a2.png)



