### PR TITLE
feat: Align remote ssh naming with coder cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,12 @@
           },
           "scope": "machine",
           "default": []
+        },
+        "coder.userHostPrefix": {
+          "markdownDescription": "Override the default host prefix",
+          "type": "string",
+          "scope": "machine",
+          "default": ""
         }
       }
     },
@@ -185,7 +191,7 @@
     "@types/which": "^2.0.1",
     "@types/ws": "^8.5.3",
     "@typescript-eslint/eslint-plugin": "^5.47.1",
-    "@typescript-eslint/parser": "^4.14.1",
+    "@typescript-eslint/parser": "^5.47.1",
     "@vscode/test-electron": "^1.6.2",
     "@vscode/vsce": "^2.16.0",
     "bufferutil": "^4.0.7",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -217,7 +217,8 @@ export class Commands {
 
     // A workspace can have multiple agents, but that's handled
     // when opening a workspace unless explicitly specified.
-    const remoteAuthority = `ssh-remote+${Remote.Prefix}${workspaceOwner}--${workspaceName}`
+    // search for workspace name in the ssh config
+    const remoteAuthority = `ssh-remote+${Remote.Prefix}.${workspaceName}.main` //main is the default agent
 
     let newWindow = true
     // Open in the existing window if no workspaces are open.


### PR DESCRIPTION
coder's cli tool allow users to configure ssh conection to their remote hosts.
as part of it's configuration, he generate ssh config  host to the dedicated user's machine.
The patten used by the cli tool, is not align with the one user by the vscode extension. 
This mismatch between  coder cli and the vscode extension, cause errors when trying to connect to remote host.

Key differences:
1. the host pattern [generated](https://github.com/coder/coder/blob/929589ddfa90ee55928fe0830d225f030cba7344/cli/configssh.go#L352) by the coder cli is `coder.<workspace-name>.<agent>`. currently the default agent is main
   the vscode extension is expecting the pattern `coder-vscode--<workspace-owner>--<workspace-name>--<agent?>`
2. owner / user is not encoded in the ssh host name genereated by coder cli
3. the cli [allows](https://github.com/coder/coder/blob/929589ddfa90ee55928fe0830d225f030cba7344/cli/configssh.go#L507) the user to set different prefix other then `coder`


This PR is set to close the gap between the 2 and make sure hosts created by the cli can be connected from the vscode extension