### PR TITLE
fixed sessionToken execution error and stop with try-catch

### DIFF
--- a/src/storage.ts
+++ b/src/storage.ts
@@ -52,7 +52,11 @@ export class Storage {
   }
 
   public async getSessionToken(): Promise<string | undefined> {
-    return this.secrets.get("sessionToken")
+    try {
+      return this.secrets.get("sessionToken");
+    } catch {
+      return undefined;
+    }
   }
 
   // getRemoteSSHLogPath returns the log path for the "Remote - SSH" output panel.

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -53,9 +53,9 @@ export class Storage {
 
   public async getSessionToken(): Promise<string | undefined> {
     try {
-      return this.secrets.get("sessionToken");
+      return this.secrets.get("sessionToken")
     } catch {
-      return undefined;
+      return undefined
     }
   }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -51,12 +51,12 @@ export class Storage {
     })
   }
 
-  // this.secrets.get sometimes fails on Apple Silicon. Instead of returning 
-  // undefined it breaks the code and stops it. The try-catch is a workaround 
+  // this.secrets.get sometimes fails on Apple Silicon. Instead of returning
+  // undefined it breaks the code and stops it. The try-catch is a workaround
   // in case the function fails. The user needs to renew the session then.
   public async getSessionToken(): Promise<string | undefined> {
     try {
-      return this.secrets.get("sessionToken")
+      return await this.secrets.get("sessionToken")
     } catch {
       return undefined
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -51,6 +51,9 @@ export class Storage {
     })
   }
 
+  // this.secrets.get sometimes fails on Apple Silicon. Instead of returning 
+  // undefined it breaks the code and stops it. The try-catch is a workaround 
+  // in case the function fails. The user needs to renew the session then.
   public async getSessionToken(): Promise<string | undefined> {
     try {
       return this.secrets.get("sessionToken")


### PR DESCRIPTION
Hello coder team 

this pull request solves the error in #87 

It seemed like the MacOS (Apple Silicon) version from VSCode have some issues with processing the stored sessionToken in the SecretStorage. When the extension tried to get the token the code execution got interrupted by the error mentioned in #87.

I fixed that interruption by using a try-catch and return undefined if the process could not be completed. If it's not possible to retrieve the session token, the user needs to reauthenticate.