### PR TITLE
feat: validate ssh properties before launching workspaces

### DIFF
--- a/src/sshSupport.test.ts
+++ b/src/sshSupport.test.ts
@@ -1,5 +1,5 @@
 import { it, expect } from "vitest"
-import { sshSupportsSetEnv, sshVersionSupportsSetEnv } from "./sshSupport"
+import { computeSSHProperties, sshSupportsSetEnv, sshVersionSupportsSetEnv } from "./sshSupport"
 
 const supports = {
   "OpenSSH_8.9p1 Ubuntu-3ubuntu0.1, OpenSSL 3.0.2 15 Mar 2022": true,
@@ -16,4 +16,24 @@ Object.entries(supports).forEach(([version, expected]) => {
 
 it("current shell supports ssh", () => {
   expect(sshSupportsSetEnv()).toBeTruthy()
+})
+
+it("computes the config for a host", () => {
+  const properties = computeSSHProperties(
+    "coder-vscode--testing",
+    `Host *
+  StrictHostKeyChecking yes
+
+# --- START CODER VSCODE ---
+Host coder-vscode--*
+  StrictHostKeyChecking no
+  Another=true
+# --- END CODER VSCODE ---
+`,
+  )
+
+  expect(properties).toEqual({
+    Another: "true",
+    StrictHostKeyChecking: "yes",
+  })
 })

--- a/src/sshSupport.ts
+++ b/src/sshSupport.ts
@@ -36,3 +36,55 @@ export function sshVersionSupportsSetEnv(sshVersionString: string): boolean {
   }
   return false
 }
+
+// computeSSHProperties accepts an SSH config and a host name and returns
+// the properties that should be set for that host.
+export function computeSSHProperties(host: string, config: string): Record<string, string> {
+  let currentConfig:
+    | {
+        Host: string
+        properties: Record<string, string>
+      }
+    | undefined
+  const configs: Array<typeof currentConfig> = []
+  config.split("\n").forEach((line) => {
+    line = line.trim()
+    if (line === "") {
+      return
+    }
+    const [key, ...valueParts] = line.split(/\s+|=/)
+    if (key.startsWith("#")) {
+      // Ignore comments!
+      return
+    }
+    if (key === "Host") {
+      if (currentConfig) {
+        configs.push(currentConfig)
+      }
+      currentConfig = {
+        Host: valueParts.join(" "),
+        properties: {},
+      }
+      return
+    }
+    if (!currentConfig) {
+      return
+    }
+    currentConfig.properties[key] = valueParts.join(" ")
+  })
+  if (currentConfig) {
+    configs.push(currentConfig)
+  }
+
+  const merged: Record<string, string> = {}
+  configs.reverse().forEach((config) => {
+    if (!config) {
+      return
+    }
+    if (!new RegExp("^" + config?.Host.replace(/\*/g, ".*") + "$").test(host)) {
+      return
+    }
+    Object.assign(merged, config.properties)
+  })
+  return merged
+}


### PR DESCRIPTION
This was reported by a member in Discord, and displayed a poor error by VS Code when it failed before.

Users cannot override our config options otherwise connections may fail or have unexpected behavior.