### PR TITLE
add coder to the Open a Remote Window list

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
       {
         "command": "coder.open",
         "title": "Coder: Open Workspace",
-        "icon": "$(play)"
+        "icon": "$(play)",
+        "category": "Coder"
       },
       {
         "command": "coder.openFromSidebar",
@@ -165,6 +166,17 @@
           "command": "coder.navigateToWorkspaceSettings",
           "when": "coder.authenticated && viewItem == coderWorkspaceSingleAgent || coder.authenticated && viewItem == coderWorkspaceMultipleAgents",
           "group": "inline"
+        }
+      ],
+      "statusBar/remoteIndicator": [
+        {
+          "command": "coder.open",
+          "group": "remote_11_ssh_coder@1"
+        },
+        {
+          "command": "coder.createWorkspace",
+          "group": "remote_11_ssh_coder@2",
+          "when": "coder.authenticated"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
       },
       {
         "command": "coder.open",
-        "title": "Coder: Open Workspace",
+        "title": "Open Workspace",
         "icon": "$(play)",
         "category": "Coder"
       },

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -106,7 +106,9 @@ class AgentMetadataTreeItem extends vscode.TreeItem {
       metadataEvent.description.display_name.trim() + ": " + metadataEvent.result.value.replace(/\n/g, "").trim()
 
     super(label, vscode.TreeItemCollapsibleState.None)
-    this.tooltip = "Collected at " + metadataEvent.result.collected_at
+    const collected_at = new Date(metadataEvent.result.collected_at).toLocaleString()
+
+    this.tooltip = "Collected at " + collected_at
     this.contextValue = "coderAgentMetadata"
   }
 }


### PR DESCRIPTION
Closes #93 

We added  Coder actions to the "Open a Remote Window" menu list. 

![image](https://github.com/coder/vscode-coder/assets/2081077/881fbefd-4c60-4c29-bf1e-d1e090abe421)
 