### PR TITLE
Add customizable header command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,13 @@
     }],
     "import/no-unresolved": ["error", {
       "ignore": ["vscode"]
-    }]
+    }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "varsIgnorePattern": "^_"
+      }
+    ]
   },
   "ignorePatterns": [
     "out",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
           "markdownDescription": "The full path of the directory into which the Coder CLI will be downloaded. Defaults to the extension's global storage directory.",
           "type": "string",
           "default": ""
+        },
+        "coder.headerCommand": {
+          "markdownDescription": "An external command that outputs additional HTTP headers added to all requests. The command must output each header as `key=value` on its own line. The following environment variables will be available to the process: `CODER_URL`.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -70,8 +70,10 @@ export class Commands {
                   severity: vscode.InputBoxValidationSeverity.Error,
                 }
               }
+              // This could be something like the header command erroring or an
+              // invalid session token.
               return {
-                message: "Invalid session token! (" + message + ")",
+                message: "Failed to authenticate: " + message,
                 severity: vscode.InputBoxValidationSeverity.Error,
               }
             })

--- a/src/error.ts
+++ b/src/error.ts
@@ -40,8 +40,8 @@ export class CertificateError extends Error {
 
   // maybeWrap returns a CertificateError if the code is a certificate error
   // otherwise it returns the original error.
-  static async maybeWrap<T>(err: T, address: string | undefined, logger: Logger): Promise<CertificateError | T> {
-    if (address && axios.isAxiosError(err)) {
+  static async maybeWrap<T>(err: T, address: string, logger: Logger): Promise<CertificateError | T> {
+    if (axios.isAxiosError(err)) {
       switch (err.code) {
         case X509_ERR_CODE.UNABLE_TO_VERIFY_LEAF_SIGNATURE:
           // "Unable to verify" can mean different things so we will attempt to

--- a/src/error.ts
+++ b/src/error.ts
@@ -40,8 +40,8 @@ export class CertificateError extends Error {
 
   // maybeWrap returns a CertificateError if the code is a certificate error
   // otherwise it returns the original error.
-  static async maybeWrap<T>(err: T, address: string, logger: Logger): Promise<CertificateError | T> {
-    if (axios.isAxiosError(err)) {
+  static async maybeWrap<T>(err: T, address: string | undefined, logger: Logger): Promise<CertificateError | T> {
+    if (address && axios.isAxiosError(err)) {
       switch (err.code) {
         case X509_ERR_CODE.UNABLE_TO_VERIFY_LEAF_SIGNATURE:
           // "Unable to verify" can mean different things so we will attempt to

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   axios.interceptors.response.use(
     (r) => r,
     async (err) => {
-      throw await CertificateError.maybeWrap(err, err?.config?.baseURL, storage)
+      throw await CertificateError.maybeWrap(err, axios.getUri(err.config), storage)
     },
   )
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
   // Add headers from the header command.
   axios.interceptors.request.use(async (config) => {
-    Object.entries(await storage.getHeaders()).forEach(([key, value]) => {
+    Object.entries(await storage.getHeaders(config.baseURL || axios.getUri(config))).forEach(([key, value]) => {
       config.headers[key] = value
     })
     return config

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,13 +61,10 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
   // Add headers from the header command.
   axios.interceptors.request.use(async (config) => {
-    return {
-      ...config,
-      headers: {
-        ...(await storage.getHeaders()),
-        ...creds.headers,
-      },
-    }
+    Object.entries(await storage.getHeaders()).forEach(([key, value]) => {
+      config.headers[key] = value
+    })
+    return config
   })
 
   const myWorkspacesProvider = new WorkspaceProvider(WorkspaceQuery.Mine, storage)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,7 +46,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   axios.interceptors.response.use(
     (r) => r,
     async (err) => {
-      throw await CertificateError.maybeWrap(err, err.config.baseURL, storage)
+      throw await CertificateError.maybeWrap(err, err?.config?.baseURL, storage)
     },
   )
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,23 +73,28 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   vscode.window.registerTreeDataProvider("myWorkspaces", myWorkspacesProvider)
   vscode.window.registerTreeDataProvider("allWorkspaces", allWorkspacesProvider)
 
-  getAuthenticatedUser()
-    .then(async (user) => {
-      if (user) {
-        vscode.commands.executeCommand("setContext", "coder.authenticated", true)
-        if (user.roles.find((role) => role.name === "owner")) {
-          await vscode.commands.executeCommand("setContext", "coder.isOwner", true)
+  const url = storage.getURL()
+  if (url) {
+    getAuthenticatedUser()
+      .then(async (user) => {
+        if (user) {
+          vscode.commands.executeCommand("setContext", "coder.authenticated", true)
+          if (user.roles.find((role) => role.name === "owner")) {
+            await vscode.commands.executeCommand("setContext", "coder.isOwner", true)
+          }
         }
-      }
-    })
-    .catch((error) => {
-      // This should be a failure to make the request, like the header command
-      // errored.
-      vscodeProposed.window.showErrorMessage("Failed to check user authentication: " + error.message)
-    })
-    .finally(() => {
-      vscode.commands.executeCommand("setContext", "coder.loaded", true)
-    })
+      })
+      .catch((error) => {
+        // This should be a failure to make the request, like the header command
+        // errored.
+        vscodeProposed.window.showErrorMessage("Failed to check user authentication: " + error.message)
+      })
+      .finally(() => {
+        vscode.commands.executeCommand("setContext", "coder.loaded", true)
+      })
+  } else {
+    vscode.commands.executeCommand("setContext", "coder.loaded", true)
+  }
 
   vscode.window.registerUriHandler({
     handleUri: async (uri) => {

--- a/src/headers.test.ts
+++ b/src/headers.test.ts
@@ -1,0 +1,57 @@
+import * as os from "os"
+import { it, expect } from "vitest"
+import { getHeaders } from "./headers"
+
+const logger = {
+  writeToCoderOutputChannel() {
+    // no-op
+  },
+}
+
+it("should return no headers", async () => {
+  await expect(getHeaders(undefined, undefined, logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("localhost", undefined, logger)).resolves.toStrictEqual({})
+  await expect(getHeaders(undefined, "command", logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("localhost", "", logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("", "command", logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("localhost", "  ", logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("  ", "command", logger)).resolves.toStrictEqual({})
+})
+
+it("should return headers", async () => {
+  await expect(getHeaders("localhost", "printf foo=bar'\n'baz=qux", logger)).resolves.toStrictEqual({
+    foo: "bar",
+    baz: "qux",
+  })
+  await expect(getHeaders("localhost", "printf foo=bar'\r\n'baz=qux", logger)).resolves.toStrictEqual({
+    foo: "bar",
+    baz: "qux",
+  })
+  await expect(getHeaders("localhost", "printf foo=bar'\r\n'", logger)).resolves.toStrictEqual({ foo: "bar" })
+  await expect(getHeaders("localhost", "printf foo=bar", logger)).resolves.toStrictEqual({ foo: "bar" })
+  await expect(getHeaders("localhost", "printf foo=bar=", logger)).resolves.toStrictEqual({ foo: "bar=" })
+  await expect(getHeaders("localhost", "printf foo=bar=baz", logger)).resolves.toStrictEqual({ foo: "bar=baz" })
+  await expect(getHeaders("localhost", "printf foo=", logger)).resolves.toStrictEqual({ foo: "" })
+})
+
+it("should error on malformed or empty lines", async () => {
+  await expect(getHeaders("localhost", "printf foo=bar'\r\n\r\n'", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf '\r\n'foo=bar", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf =foo", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf foo", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf '  =foo'", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf 'foo  =bar'", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf 'foo  foo=bar'", logger)).rejects.toMatch(/Malformed/)
+  await expect(getHeaders("localhost", "printf ''", logger)).rejects.toMatch(/Malformed/)
+})
+
+it("should have access to environment variables", async () => {
+  const coderUrl = "dev.coder.com"
+  await expect(
+    getHeaders(coderUrl, os.platform() === "win32" ? "printf url=%CODER_URL" : "printf url=$CODER_URL", logger),
+  ).resolves.toStrictEqual({ url: coderUrl })
+})
+
+it("should error on non-zero exit", async () => {
+  await expect(getHeaders("localhost", "exit 10", logger)).rejects.toMatch(/exited unexpectedly with code 10/)
+})

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,64 @@
+import * as cp from "child_process"
+import * as util from "util"
+
+export interface Logger {
+  writeToCoderOutputChannel(message: string): void
+}
+
+interface ExecException {
+  code?: number
+  stderr?: string
+  stdout?: string
+}
+
+function isExecException(err: unknown): err is ExecException {
+  return typeof (err as ExecException).code !== "undefined"
+}
+
+// TODO: getHeaders might make more sense to directly implement on Storage
+// but it is difficult to test Storage right now since we use vitest instead of
+// the standard extension testing framework which would give us access to vscode
+// APIs.  We should revert the testing framework then consider moving this.
+
+// getHeaders executes the header command and parses the headers from stdout.
+// Both stdout and stderr are logged on error but stderr is otherwise ignored.
+// Throws an error if the process exits with non-zero or the JSON is invalid.
+// Returns undefined if there is no header command set.  No effort is made to
+// validate the JSON other than making sure it can be parsed.
+export async function getHeaders(
+  url: string | undefined,
+  command: string | undefined,
+  logger: Logger,
+): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {}
+  if (typeof url === "string" && url.trim().length > 0 && typeof command === "string" && command.trim().length > 0) {
+    let result: { stdout: string; stderr: string }
+    try {
+      result = await util.promisify(cp.exec)(command, {
+        env: {
+          ...process.env,
+          CODER_URL: url,
+        },
+      })
+    } catch (error) {
+      if (isExecException(error)) {
+        logger.writeToCoderOutputChannel(`Header command exited unexpectedly with code ${error.code}`)
+        logger.writeToCoderOutputChannel(`stdout: ${error.stdout}`)
+        logger.writeToCoderOutputChannel(`stderr: ${error.stderr}`)
+        throw new Error(`Header command exited unexpectedly with code ${error.code}`)
+      }
+      throw new Error(`Header command exited unexpectedly: ${error}`)
+    }
+    const lines = result.stdout.replace(/\r?\n$/, "").split(/\r?\n/)
+    for (let i = 0; i < lines.length; ++i) {
+      const [key, value] = lines[i].split(/=(.*)/)
+      // Header names cannot be blank or contain whitespace and the Coder CLI
+      // requires that there be an equals sign (the value can be blank though).
+      if (key.length === 0 || key.indexOf(" ") !== -1 || typeof value === "undefined") {
+        throw new Error(`Malformed line from header command: [${lines[i]}] (out: ${result.stdout})`)
+      }
+      headers[key] = value
+    }
+  }
+  return headers
+}

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -508,9 +508,17 @@ export class Remote {
     }
 
     const escape = (str: string): string => `"${str.replace(/"/g, '\\"')}"`
+
+    // Add headers from the header command.
+    let headerArg = ""
+    const headerCommand = vscode.workspace.getConfiguration().get("coder.headerCommand")
+    if (typeof headerCommand === "string" && headerCommand.trim().length > 0) {
+      headerArg = ` --header-command "${escape(headerCommand)}"`
+    }
+
     const sshValues: SSHValues = {
       Host: `${Remote.Prefix}*`,
-      ProxyCommand: `${escape(binaryPath)} vscodessh --network-info-dir ${escape(
+      ProxyCommand: `${escape(binaryPath)}${headerArg} vscodessh --network-info-dir ${escape(
         this.storage.getNetworkInfoPath(),
       )} --session-token-file ${escape(this.storage.getSessionTokenPath())} --url-file ${escape(
         this.storage.getURLPath(),

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -513,7 +513,7 @@ export class Remote {
     let headerArg = ""
     const headerCommand = vscode.workspace.getConfiguration().get("coder.headerCommand")
     if (typeof headerCommand === "string" && headerCommand.trim().length > 0) {
-      headerArg = ` --header-command "${escape(headerCommand)}"`
+      headerArg = ` --header-command ${escape(headerCommand)}`
     }
 
     const sshValues: SSHValues = {

--- a/src/sshSupport.test.ts
+++ b/src/sshSupport.test.ts
@@ -29,6 +29,7 @@ it("computes the config for a host", () => {
 Host coder-vscode--*
   StrictHostKeyChecking no
   Another=true
+  ProxyCommand=/tmp/coder --header="X-FOO=bar" coder.dev
 # --- END CODER VSCODE ---
 `,
   )
@@ -36,5 +37,6 @@ Host coder-vscode--*
   expect(properties).toEqual({
     Another: "true",
     StrictHostKeyChecking: "yes",
+    ProxyCommand: '/tmp/coder --header="X-FOO=bar" coder.dev',
   })
 })

--- a/src/sshSupport.ts
+++ b/src/sshSupport.ts
@@ -52,7 +52,11 @@ export function computeSSHProperties(host: string, config: string): Record<strin
     if (line === "") {
       return
     }
-    const [key, ...valueParts] = line.split(/\s+|=/)
+    // The capture group here will include the captured portion in the array
+    // which we need to join them back up with their original values.  The first
+    // separate is ignored since it splits the key and value but is not part of
+    // the value itself.
+    const [key, _, ...valueParts] = line.split(/(\s+|=)/)
     if (key.startsWith("#")) {
       // Ignore comments!
       return
@@ -62,7 +66,7 @@ export function computeSSHProperties(host: string, config: string): Record<strin
         configs.push(currentConfig)
       }
       currentConfig = {
-        Host: valueParts.join(" "),
+        Host: valueParts.join(""),
         properties: {},
       }
       return
@@ -70,7 +74,7 @@ export function computeSSHProperties(host: string, config: string): Record<strin
     if (!currentConfig) {
       return
     }
-    currentConfig.properties[key] = valueParts.join(" ")
+    currentConfig.properties[key] = valueParts.join("")
   })
   if (currentConfig) {
     configs.push(currentConfig)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -393,7 +393,7 @@ export class Storage {
     }
   }
 
-  public async getHeaders(url = this.getURL()): Promise<Record<string, string> | undefined> {
+  public async getHeaders(url = this.getURL()): Promise<Record<string, string>> {
     return getHeaders(url, vscode.workspace.getConfiguration().get("coder.headerCommand"), this)
   }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -11,6 +11,7 @@ import os from "os"
 import path from "path"
 import prettyBytes from "pretty-bytes"
 import * as vscode from "vscode"
+import { getHeaders } from "./headers"
 
 export class Storage {
   public workspace?: Workspace
@@ -390,6 +391,10 @@ export class Storage {
       delete axios.defaults.headers.common["Coder-Session-Token"]
       await fs.rm(this.getSessionTokenPath(), { force: true })
     }
+  }
+
+  public async getHeaders(url = this.getURL()): Promise<Record<string, string> | undefined> {
+    return getHeaders(url, vscode.workspace.getConfiguration().get("coder.headerCommand"), this)
   }
 }
 


### PR DESCRIPTION
The command will be executed before requests and before configuring SSH to set custom headers.

Some notes:

1. When I use `--header` I seem to get the value set twice.  For example if I use `coder --header X-MY-CUSTOM-HEADER=hello-there` then on the server end I see `x-my-custom-header: hello-there, hello-there` so we should look into that.
2. I went with environment variables to pass data to the credentials process for now since I figured that would be easier than parsing command-line arguments but opinions are welcome here.  Only `CODER_URL` right now.  Are there others needed?
3. ~More importantly, I am not sure about the config SSH portion.  Since configuration might only happen on the first connect, the headers we hardcode into the SSH config could expire.~

~I have two main ideas for fixing the SSH config issue:~

1. ~Modify the CLI to call out to the same process to get the headers.  `--credentials-process` or something like that.  The CLI executes the process just as the extension does and sets the headers.  We set `--credentials-process` in the SSH config on the plugin side and are off to the races.~
2. ~Add a second VS Code setting for a proxy command wrapper which gets passed the path to the Coder binary and is responsible for adding the appropriate `--header` flags and passing through any other flags.  This way this credential process is called every time SSH is invoked.  Or instead of a separate setting it could be an environment variable/flag and we reuse the same process; it can switch behavior depending on what task it needs to do (output JSON or execute the Coder binary).~

~An example of the second option: `ProxyCommand my-wrapper --wrapper-flags -- --coder-flags` where `my-wrapper` is essentially `exec $CODER_BINARY --header my-custom-header "$@"` except everything after `--` should get passed through to the Coder binary and the rest can be flags to the wrapper itself in case we need them.~

~Thoughts?  I am inclined to go the first route since the second requires more complexity on the user side but the second does at least have the advantage (or danger) of allowing more control over how the Coder binary executes.~

~I also considered substitution in the proxy command (something similar to `coder $(/path/to/credentials-process) ssh dev.dev --stdio`) but I am not sure that is portable.~

Sorted the above, `--header-command` has been added to the CLI although we will need the next release before this can be used in the plugin.

Closes https://github.com/coder/vscode-coder/issues/76 and supersedes https://github.com/coder/vscode-coder/pull/81.
