### PR TITLE
Mark untrusted workspaces as supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
   "extensionKind": [
     "ui"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "categories": [
     "Other"
   ],


### PR DESCRIPTION
It seems that if you do not use any files in the workspace then you can set this as true.

This fixes an issue where you get "no view is registered with id" because the extension seems to be in a half-activated state where the activate function runs but the view does not exist.  If you check the extension list you see that the extension is disabled due to workspace trust.  It might be a bug in VS Code that only presents when an extension is using the  `onResolveRemoteAuthority:ssh-remote` activation event.

Fixes https://github.com/coder/vscode-coder/issues/134