### PR TITLE
Handle ? in SSH config

### DIFF
--- a/src/sshSupport.test.ts
+++ b/src/sshSupport.test.ts
@@ -40,3 +40,31 @@ Host coder-vscode--*
     ProxyCommand: '/tmp/coder --header="X-FOO=bar" coder.dev',
   })
 })
+
+it("handles ? wildcards", () => {
+  const properties = computeSSHProperties(
+    "coder-vscode--testing",
+    `Host *
+  StrictHostKeyChecking yes
+
+Host i-???????? i-?????????????????
+  User test
+
+# --- START CODER VSCODE ---
+Host coder-v?ode--*
+  StrictHostKeyChecking yes
+  Another=false
+Host coder-v?code--*
+  StrictHostKeyChecking no
+  Another=true
+  ProxyCommand=/tmp/coder --header="X-BAR=foo" coder.dev
+# --- END CODER VSCODE ---
+`,
+  )
+
+  expect(properties).toEqual({
+    Another: "true",
+    StrictHostKeyChecking: "yes",
+    ProxyCommand: '/tmp/coder --header="X-BAR=foo" coder.dev',
+  })
+})

--- a/src/sshSupport.ts
+++ b/src/sshSupport.ts
@@ -85,7 +85,8 @@ export function computeSSHProperties(host: string, config: string): Record<strin
     if (!config) {
       return
     }
-    if (!new RegExp("^" + config?.Host.replace(/\*/g, ".*") + "$").test(host)) {
+    // In OpenSSH * matches any number of characters and ? matches exactly one.
+    if (!new RegExp("^" + config?.Host.replace(/\*/g, ".*").replace(/\?/g, ".") + "$").test(host)) {
       return
     }
     Object.assign(merged, config.properties)


### PR DESCRIPTION
Fixes https://github.com/coder/vscode-coder/issues/108

Still not sure why it reportedly worked before, as I think this code path has always been taken.  Maybe there are certain conditions where parsing the config is skipped but I have not dug deep enough to be sure.

This is still not complete because we are not handling `!`, other characters like `.` should be handled literally, and maybe some other things, but it should resolve the immediate issues.  We might also want to only parse hosts between the start/end block markers rather than the whole config, but I am not sure on that one.