### PR TITLE
fix: check for versions greater than 2.3.3 for the log-dir flag

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -24,6 +24,7 @@ import { getHeaderCommand } from "./headers"
 import { SSHConfig, SSHValues, defaultSSHConfigResponse, mergeSSHConfigValues } from "./sshConfig"
 import { computeSSHProperties, sshSupportsSetEnv } from "./sshSupport"
 import { Storage } from "./storage"
+import { supportsCoderAgentLogDirFlag } from "./version"
 import { WorkspaceAction } from "./workspaceAction"
 
 export class Remote {
@@ -76,10 +77,7 @@ export class Remote {
       await this.closeRemote()
       return
     }
-    // CLI versions before 2.3.3 don't support the --log-dir flag!
-    // If this check didn't exist, VS Code connections would fail on
-    // older versions because of an unknown CLI argument.
-    const hasCoderLogs = (parsedVersion?.compare("2.3.3") || 0) >= 0 || parsedVersion?.prerelease[0] === "devel"
+    const hasCoderLogs = supportsCoderAgentLogDirFlag(parsedVersion)
 
     // Find the workspace from the URI scheme provided!
     try {

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,13 @@
+import { parse } from "semver"
+import { describe, expect, it } from "vitest"
+import { supportsCoderAgentLogDirFlag } from "./version"
+
+describe("check version support", () => {
+  it("has logs", () => {
+    expect(supportsCoderAgentLogDirFlag(parse("v1.3.3+e491217"))).toBeFalsy()
+    expect(supportsCoderAgentLogDirFlag(parse("v2.3.3+e491217"))).toBeFalsy()
+    expect(supportsCoderAgentLogDirFlag(parse("v2.3.4+e491217"))).toBeTruthy()
+    expect(supportsCoderAgentLogDirFlag(parse("v5.3.4+e491217"))).toBeTruthy()
+    expect(supportsCoderAgentLogDirFlag(parse("v5.0.4+e491217"))).toBeTruthy()
+  })
+})

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,8 @@
+import { SemVer } from "semver"
+
+// CLI versions before 2.3.3 don't support the --log-dir flag!
+// If this check didn't exist, VS Code connections would fail on
+// older versions because of an unknown CLI argument.
+export const supportsCoderAgentLogDirFlag = (ver: SemVer | null): boolean => {
+  return (ver?.compare("2.3.3") || 0) > 0 || ver?.prerelease[0] === "devel"
+}


### PR DESCRIPTION
This was a dumb mistake!