### PR TITLE
Automatically refresh workspaces

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,11 +90,18 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     return config
   })
 
-  const myWorkspacesProvider = new WorkspaceProvider(WorkspaceQuery.Mine, storage)
+  const myWorkspacesProvider = new WorkspaceProvider(WorkspaceQuery.Mine, storage, 5)
   const allWorkspacesProvider = new WorkspaceProvider(WorkspaceQuery.All, storage)
 
-  vscode.window.registerTreeDataProvider("myWorkspaces", myWorkspacesProvider)
+  // createTreeView, unlike registerTreeDataProvider, gives us the tree view API
+  // (so we can see when it is visible) but otherwise they have the same effect.
+  const wsTree = vscode.window.createTreeView("myWorkspaces", { treeDataProvider: myWorkspacesProvider })
   vscode.window.registerTreeDataProvider("allWorkspaces", allWorkspacesProvider)
+
+  myWorkspacesProvider.setVisibility(wsTree.visible)
+  wsTree.onDidChangeVisibility((event) => {
+    myWorkspacesProvider.setVisibility(event.visible)
+  })
 
   const url = storage.getURL()
   if (url) {

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -45,16 +45,22 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
     // needs to be cleared.
     this.cancelPendingRefresh()
 
+    let hadError = false
     try {
       this.workspaces = await this.fetch()
-      this.fetching = false
-      this.maybeScheduleRefresh()
     } catch (error) {
+      hadError = true
       this.workspaces = []
-      this.fetching = false
     }
 
+    this.fetching = false
+
     this.refresh()
+
+    // As long as there was no error we can schedule the next refresh.
+    if (hadError) {
+      this.maybeScheduleRefresh()
+    }
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/coder/vscode-coder/issues/184.

One existing issue with refreshing that is made more apparent with the auto refresh is that it reestablishes all the agent metadata watchers which both feels wasteful and causes the metadata to flash as it disappears for a moment then comes back when the watcher comes online.  In a followup PR I think I will refactor this to reuse existing watchers when possible.

Stacked on https://github.com/coder/vscode-coder/pull/202.