### PR TITLE
Reuse agent metadata watchers

### DIFF
--- a/src/api-helper.ts
+++ b/src/api-helper.ts
@@ -1,12 +1,26 @@
 import { Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
 import { z } from "zod"
 
+export function errToStr(error: unknown, def: string) {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error
+  }
+  return def
+}
+
+export function extractAllAgents(workspaces: Workspace[]): WorkspaceAgent[] {
+  return workspaces.reduce((acc, workspace) => {
+    return acc.concat(extractAgents(workspace))
+  }, [] as WorkspaceAgent[])
+}
+
 export function extractAgents(workspace: Workspace): WorkspaceAgent[] {
-  const agents = workspace.latest_build.resources.reduce((acc, resource) => {
+  return workspace.latest_build.resources.reduce((acc, resource) => {
     return acc.concat(resource.agents || [])
   }, [] as WorkspaceAgent[])
-
-  return agents
 }
 
 export const AgentMetadataEventSchema = z.object({

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -128,6 +128,7 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
     oldWatcherIds.forEach((id) => {
       if (!reusedWatcherIds.includes(id)) {
         this.agentWatchers[id].dispose()
+        delete this.agentWatchers[id]
       }
     })
 


### PR DESCRIPTION
Followup PR to reuse watchers to make the automatic refresh less janky.

This has two effects:

1. Lower overhead from establishing the watchers over and over.
2. No more flashing in the tree as the watchers get recreated and we wait for the first update.

I renamed `CoderTreeItemType` to make clear it was for openable items only, not for the metadata items and not for the new error item.

Because I needed to refactor the watchers a little I added a line for when something with the metadata fails, rather than quietly disposing (tested by manually adding `throw new Error("hey")`).

![screenshot](https://github.com/coder/vscode-coder/assets/45609798/9cdf3d7a-b130-4a2a-a2b4-6e048100569b)
