### PR TITLE
fix: replace ssh config block in-place

### DIFF
--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -95,7 +95,10 @@ Host coder-vscode--*
   ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---`
+# --- END CODER VSCODE ---
+
+Host *
+  SetEnv TEST=1`
   mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
@@ -124,7 +127,10 @@ Host coder--updated--vscode--*
   ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---`
+# --- END CODER VSCODE ---
+
+Host *
+  SetEnv TEST=1`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
     encoding: "utf-8",


### PR DESCRIPTION
This PR introduces two changes:
1. Replace vscode block in-place in the SSH config
2. Adds an additional guard against replacing user-added blocks that _look_ like an old-form SSH config block (without block markings)

TBH, we could probably remove the old block detection entirely instead of this additional check, but didn't want to make that decision here.