### PR TITLE
Enhancing SSH Connection Compatibility with Cursor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   const openRemoteSSHExtension = vscode.extensions.getExtension("anysphere.open-remote-ssh")
   // If the "anysphere.open-remote-ssh" extension is available, it is used with priority
   // If it is not found, then the extension "ms-vscode-remote.remote-ssh" is sought as a fallback.
+  // This is specifically for non-official VS Code distributions, such as Cursor.
   const useRemoteSSHExtension = openRemoteSSHExtension
     ? openRemoteSSHExtension
     : vscode.extensions.getExtension("ms-vscode-remote.remote-ssh")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,13 +19,15 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   //
   // This is janky, but that's alright since it provides such minimal
   // functionality to the extension.
-  const msRemoteSSHExtension = vscode.extensions.getExtension("ms-vscode-remote.remote-ssh")
   const openRemoteSSHExtension = vscode.extensions.getExtension("anysphere.open-remote-ssh")
-  if (!msRemoteSSHExtension && !openRemoteSSHExtension) {
+  // If the "anysphere.open-remote-ssh" extension is available, it is used with priority
+  // If it is not found, then the extension "ms-vscode-remote.remote-ssh" is sought as a fallback.
+  const useRemoteSSHExtension = openRemoteSSHExtension
+    ? openRemoteSSHExtension
+    : vscode.extensions.getExtension("ms-vscode-remote.remote-ssh")
+  if (!useRemoteSSHExtension) {
     throw new Error("Remote SSH extension not found")
   }
-  // Use "anysphere.open-remote-ssh" if it exists as the cursor is using it
-  const useRemoteSSHExtension = openRemoteSSHExtension ? openRemoteSSHExtension : msRemoteSSHExtension
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const vscodeProposed: typeof vscode = (module as any)._load(
     "vscode",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,15 +19,18 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   //
   // This is janky, but that's alright since it provides such minimal
   // functionality to the extension.
-  const remoteSSHExtension = vscode.extensions.getExtension("ms-vscode-remote.remote-ssh")
-  if (!remoteSSHExtension) {
+  const msRemoteSSHExtension = vscode.extensions.getExtension("ms-vscode-remote.remote-ssh")
+  const openRemoteSSHExtension = vscode.extensions.getExtension("anysphere.open-remote-ssh")
+  if (!msRemoteSSHExtension && !openRemoteSSHExtension) {
     throw new Error("Remote SSH extension not found")
   }
+  // Use "anysphere.open-remote-ssh" if it exists as the cursor is using it
+  const useRemoteSSHExtension = openRemoteSSHExtension ? openRemoteSSHExtension : msRemoteSSHExtension
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const vscodeProposed: typeof vscode = (module as any)._load(
     "vscode",
     {
-      filename: remoteSSHExtension?.extensionPath,
+      filename: useRemoteSSHExtension?.extensionPath,
     },
     false,
   )


### PR DESCRIPTION
Previous MR https://github.com/coder/vscode-coder/pull/221

## Overview

I have been a dedicated user of both Coder and Cursor. However, I've encountered persistent issues when attempting to connect to the Coder workspace via Cursor ([Cursor](https://cursor.sh/)). These issues range from receiving 404 errors to SSH connection failures, preventing any access to the workspace. The root cause of these problems lies in the necessity to use Cursor's built-in Open Remote - SSH extension, `anysphere.open-remote-ssh`, for successful SSH connections.

### Changes Made

I've confirmed that users utilizing Cursor can simply specify `anysphere.open-remote-ssh` explicitly within the Coder plugin without any issues coexisting with `ms-vscode-remote.remote-ssh`. Therefore, I've made a straightforward update to check for the existence of `anysphere.open-remote-ssh` and use it preferentially if available. This eliminates the need to remove any dependencies.

With this MR, I'm hopeful for a seamless integration between Cursor and Coder, which I personally believe is the best combination.