### PR TITLE
feat: auto update workspace if required by template

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,4 +1,5 @@
 import { isAxiosError } from "axios"
+import { isApiError, isApiErrorResponse } from "coder/site/src/api/errors"
 import * as forge from "node-forge"
 import * as tls from "tls"
 import * as vscode from "vscode"
@@ -156,4 +157,15 @@ export class CertificateError extends Error {
         return
     }
   }
+}
+
+// getErrorDetail is copied from coder/site, but changes the default return.
+export const getErrorDetail = (error: unknown): string | undefined | null => {
+  if (isApiError(error)) {
+    return error.response.data.detail
+  }
+  if (isApiErrorResponse(error)) {
+    return error.detail
+  }
+  return null
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 "use strict"
 import axios, { isAxiosError } from "axios"
 import { getAuthenticatedUser } from "coder/site/src/api/api"
+import { getErrorMessage } from "coder/site/src/api/errors"
 import fs from "fs"
 import * as https from "https"
 import * as module from "module"
@@ -11,7 +12,6 @@ import { CertificateError, getErrorDetail } from "./error"
 import { Remote } from "./remote"
 import { Storage } from "./storage"
 import { WorkspaceQuery, WorkspaceProvider } from "./workspacesProvider"
-import { getErrorMessage } from "coder/site/src/api/errors"
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   // The Remote SSH extension's proposed APIs are used to override the SSH host

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 "use strict"
-import axios from "axios"
+import axios, { isAxiosError } from "axios"
 import { getAuthenticatedUser } from "coder/site/src/api/api"
 import fs from "fs"
 import * as https from "https"
@@ -7,10 +7,11 @@ import * as module from "module"
 import * as os from "os"
 import * as vscode from "vscode"
 import { Commands } from "./commands"
-import { CertificateError } from "./error"
+import { CertificateError, getErrorDetail } from "./error"
 import { Remote } from "./remote"
 import { Storage } from "./storage"
 import { WorkspaceQuery, WorkspaceProvider } from "./workspacesProvider"
+import { getErrorMessage } from "coder/site/src/api/errors"
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   // The Remote SSH extension's proposed APIs are used to override the SSH host
@@ -199,13 +200,38 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   try {
     await remote.setup(vscodeProposed.env.remoteAuthority)
   } catch (ex) {
-    if (ex instanceof CertificateError) {
-      return await ex.showModal("Failed to open workspace")
+    switch (true) {
+      case ex instanceof CertificateError:
+        await ex.showModal("Failed to open workspace")
+        break
+      case isAxiosError(ex):
+        {
+          const msg = getErrorMessage(ex, "")
+          const detail = getErrorDetail(ex)
+          const urlString = axios.getUri(ex.response?.config)
+          let path = urlString
+          try {
+            path = new URL(urlString).pathname
+          } catch (e) {
+            // ignore, default to full url
+          }
+
+          await vscodeProposed.window.showErrorMessage("Failed to open workspace", {
+            detail: `API ${ex.response?.config.method?.toUpperCase()} to '${path}' failed with code ${ex.response?.status}.\nMessage: ${msg}\nDetail: ${detail}`,
+            modal: true,
+            useCustom: true,
+          })
+        }
+        break
+      default:
+        await vscodeProposed.window.showErrorMessage("Failed to open workspace", {
+          detail: (ex as string).toString(),
+          modal: true,
+          useCustom: true,
+        })
     }
-    await vscodeProposed.window.showErrorMessage("Failed to open workspace", {
-      detail: (ex as string).toString(),
-      modal: true,
-      useCustom: true,
-    })
+
+    // Always close remote session when we fail to open a workspace.
+    await remote.closeRemote()
   }
 }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -9,7 +9,6 @@ import {
   getDeploymentSSHConfig,
   getTemplateVersion,
 } from "coder/site/src/api/api"
-import { getErrorMessage } from "coder/site/src/api/errors"
 import { ProvisionerJobLog, Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
 import EventSource from "eventsource"
 import find from "find-process"
@@ -21,7 +20,6 @@ import prettyBytes from "pretty-bytes"
 import * as semver from "semver"
 import * as vscode from "vscode"
 import * as ws from "ws"
-import { getErrorDetail } from "./error"
 import { getHeaderCommand } from "./headers"
 import { SSHConfig, SSHValues, defaultSSHConfigResponse, mergeSSHConfigValues } from "./sshConfig"
 import { computeSSHProperties, sshSupportsSetEnv } from "./sshSupport"


### PR DESCRIPTION
Closes: https://github.com/coder/customers/issues/543

# What this does

If the template has `require_active_version`, the extension will auto update the workspace on start.

If parameters change, an error like this gets raised:

![Screenshot from 2024-04-02 12-41-15](https://github.com/coder/vscode-coder/assets/5446298/07a790ea-9392-4efd-8e5d-ada1b47f96d9)

