### PR TITLE
Tweak certificate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Changes
+
+- Show certificate errors under the token input.
+
 ## [v0.1.36](https://github.com/coder/vscode-coder/releases/tag/v0.1.36) (2024-04-09)
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Coder",
   "description": "Open any workspace with a single click.",
   "repository": "https://github.com/coder/vscode-coder",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "engines": {
     "vscode": "^1.73.0"
   },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -113,7 +113,7 @@ export class Commands {
                 err.showNotification()
 
                 return {
-                  message: err.message,
+                  message: err.x509Err || err.message,
                   severity: vscode.InputBoxValidationSeverity.Error,
                 }
               }

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,7 +13,7 @@ export enum X509_ERR_CODE {
 
 // X509_ERR contains human-friendly versions of TLS errors.
 export enum X509_ERR {
-  PARTIAL_CHAIN = "Your Coder deployment's certificate cannot be verified because a certificate is missing from its chain. To fix this your deployment's administrator should bundle the missing certificates or you can add the missing certificates directly to this system's trust store.",
+  PARTIAL_CHAIN = "Your Coder deployment's certificate cannot be verified because a certificate is missing from its chain. To fix this your deployment's administrator should bundle the missing certificates.",
   // NON_SIGNING can be removed if BoringSSL is patched and the patch makes it
   // into the version of Electron used by VS Code.
   NON_SIGNING = "Your Coder deployment's certificate is not marked as being capable of signing. VS Code uses a version of Electron that does not support certificates like this even if they are self-issued. The certificate should be regenerated with the certificate signing capability.",

--- a/src/error.ts
+++ b/src/error.ts
@@ -31,7 +31,7 @@ interface KeyUsage {
 
 export class CertificateError extends Error {
   public static ActionAllowInsecure = "Allow Insecure"
-  public static ActionViewMoreDetails = "View More Details"
+  public static ActionOK = "OK"
   public static InsecureMessage =
     'The Coder extension will no longer verify TLS on HTTPS requests. You can change this at any time with the "coder.insecure" property in your VS Code settings.'
 
@@ -116,12 +116,6 @@ export class CertificateError extends Error {
     })
   }
 
-  viewMoreDetails(): Thenable<boolean> {
-    return vscode.env.openExternal(
-      vscode.Uri.parse("https://github.com/coder/vscode-coder/issues/115#issuecomment-1631512493"),
-    )
-  }
-
   // allowInsecure updates the value of the "coder.insecure" property.
   async allowInsecure(): Promise<void> {
     vscode.workspace.getConfiguration().update("coder.insecure", true, vscode.ConfigurationTarget.Global)
@@ -146,11 +140,10 @@ export class CertificateError extends Error {
       // inside VS Code.  Disabling the "Strict SSL" setting does not help
       // either.  For now avoid showing the button until this is sorted.
       // CertificateError.ActionAllowInsecure,
-      CertificateError.ActionViewMoreDetails,
+      CertificateError.ActionOK,
     )
     switch (val) {
-      case CertificateError.ActionViewMoreDetails:
-        await this.viewMoreDetails()
+      case CertificateError.ActionOK:
         return
       case CertificateError.ActionAllowInsecure:
         await this.allowInsecure()

--- a/src/error.ts
+++ b/src/error.ts
@@ -13,12 +13,12 @@ export enum X509_ERR_CODE {
 
 // X509_ERR contains human-friendly versions of TLS errors.
 export enum X509_ERR {
-  PARTIAL_CHAIN = "Your Coder deployment's certificate cannot be verified because a certificate is missing from its chain. To fix this your deployment's administrator should bundle the missing certificates.",
+  PARTIAL_CHAIN = "Your Coder deployment's certificate cannot be verified because a certificate is missing from its chain. To fix this your deployment's administrator must bundle the missing certificates.",
   // NON_SIGNING can be removed if BoringSSL is patched and the patch makes it
   // into the version of Electron used by VS Code.
-  NON_SIGNING = "Your Coder deployment's certificate is not marked as being capable of signing. VS Code uses a version of Electron that does not support certificates like this even if they are self-issued. The certificate should be regenerated with the certificate signing capability.",
-  UNTRUSTED_LEAF = "Your Coder deployment's certificate does not appear to be trusted by this system. The certificate should be added to this system's trust store.",
-  UNTRUSTED_CHAIN = "Your Coder deployment's certificate chain does not appear to be trusted by this system. The root of the certificate chain should be added to this system's trust store. ",
+  NON_SIGNING = "Your Coder deployment's certificate is not marked as being capable of signing. VS Code uses a version of Electron that does not support certificates like this even if they are self-issued. The certificate must be regenerated with the certificate signing capability.",
+  UNTRUSTED_LEAF = "Your Coder deployment's certificate does not appear to be trusted by this system. The certificate must be added to this system's trust store.",
+  UNTRUSTED_CHAIN = "Your Coder deployment's certificate chain does not appear to be trusted by this system. The root of the certificate chain must be added to this system's trust store. ",
 }
 
 export interface Logger {


### PR DESCRIPTION
Closes https://github.com/coder/customers/issues/442

If testing, can use URLs from https://badssl.com (like https://incomplete-chain.badssl.com/).

Tweak error wording and show the detailed error under the input, so it will display in two places now.

![screenshot](https://github.com/coder/vscode-coder/assets/45609798/225d37df-9b33-45aa-90aa-030e3ab31829)

Also remove the "view more details" button from the notification, for reasons detailed in the commit message.
