### PR TITLE
fix: escape variables in the header command

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -605,7 +605,7 @@ export class Remote {
       }
     }
 
-    const escape = (str: string): string => `"${str.replace(/"/g, '\\"')}"`
+    const escape = (str: string): string => `'${str.replace(/'/g, "'\\''")}'`
 
     // Add headers from the header command.
     let headerArg = ""


### PR DESCRIPTION
The documentation for the header command setting says:

> The following environment variables will be available to the process: `CODER_URL`.

However, if the command line itself references `$CODER_URL`, when connecting via the VSCode extension the variable will get substituted _before_ the `coder` CLI can set the variable when running the header command, which is contrary to the behaviour of the JetBrains plugin. This is because the VSCode extension is currently writing the header command into the SSH config's `ProxyCommand` with double quotes, allowing the shell spawned by `ssh` to substitute `$CODER_URL` (with the empty string).

This ensures environment variable references within the header command are not substituted before the `coder` binary can receive them, by using single quotes rather than double quotes in the `ProxyCommand`.

Tested on a macOS client.