### PR TITLE
Refactor REST client

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,61 @@
+import { Api } from "coder/site/src/api/api"
+import fs from "fs/promises"
+import * as https from "https"
+import * as os from "os"
+import * as vscode from "vscode"
+import { CertificateError } from "./error"
+import { Storage } from "./storage"
+
+// expandPath will expand ${userHome} in the input string.
+const expandPath = (input: string): string => {
+  const userHome = os.homedir()
+  return input.replace(/\${userHome}/g, userHome)
+}
+
+/**
+ * Create an sdk instance using the provided URL and token and hook it up to
+ * configuration.  The token may be undefined if some other form of
+ * authentication is being used.
+ */
+export async function makeCoderSdk(baseUrl: string, token: string | undefined, storage: Storage): Promise<Api> {
+  const restClient = new Api()
+  restClient.setHost(baseUrl)
+  if (token) {
+    restClient.setSessionToken(token)
+  }
+
+  restClient.getAxiosInstance().interceptors.request.use(async (config) => {
+    // Add headers from the header command.
+    Object.entries(await storage.getHeaders(baseUrl)).forEach(([key, value]) => {
+      config.headers[key] = value
+    })
+
+    // Configure TLS.
+    const cfg = vscode.workspace.getConfiguration()
+    const insecure = Boolean(cfg.get("coder.insecure"))
+    const certFile = expandPath(String(cfg.get("coder.tlsCertFile") ?? "").trim())
+    const keyFile = expandPath(String(cfg.get("coder.tlsKeyFile") ?? "").trim())
+    const caFile = expandPath(String(cfg.get("coder.tlsCaFile") ?? "").trim())
+
+    config.httpsAgent = new https.Agent({
+      cert: certFile === "" ? undefined : await fs.readFile(certFile),
+      key: keyFile === "" ? undefined : await fs.readFile(keyFile),
+      ca: caFile === "" ? undefined : await fs.readFile(caFile),
+      // rejectUnauthorized defaults to true, so we need to explicitly set it to false
+      // if we want to allow self-signed certificates.
+      rejectUnauthorized: !insecure,
+    })
+
+    return config
+  })
+
+  // Wrap certificate errors.
+  restClient.getAxiosInstance().interceptors.response.use(
+    (r) => r,
+    async (err) => {
+      throw await CertificateError.maybeWrap(err, baseUrl, storage)
+    },
+  )
+
+  return restClient
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,6 @@
-import axios from "axios"
-import { getAuthenticatedUser, getWorkspaces, updateWorkspaceVersion } from "coder/site/src/api/api"
-import { Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
+import { Api } from "coder/site/src/api/api"
+import { getErrorMessage } from "coder/site/src/api/errors"
+import { User, Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
 import * as vscode from "vscode"
 import { extractAgents } from "./api-helper"
 import { CertificateError } from "./error"
@@ -11,6 +11,7 @@ import { OpenableTreeItem } from "./workspacesProvider"
 export class Commands {
   public constructor(
     private readonly vscodeProposed: typeof vscode,
+    private readonly restClient: Api,
     private readonly storage: Storage,
   ) {}
 
@@ -82,7 +83,9 @@ export class Commands {
     if (!url) {
       return
     }
+    this.restClient.setHost(url)
 
+    let user: User | undefined
     let token: string | undefined = args.length >= 2 ? args[1] : undefined
     if (!token) {
       const opened = await vscode.env.openExternal(vscode.Uri.parse(`${url}/cli-auth`))
@@ -97,74 +100,72 @@ export class Commands {
         placeHolder: "Copy your API key from the opened browser page.",
         value: await this.storage.getSessionToken(),
         ignoreFocusOut: true,
-        validateInput: (value) => {
-          return axios
-            .get("/api/v2/users/me", {
-              baseURL: url,
-              headers: {
-                "Coder-Session-Token": value,
-              },
-            })
-            .then(() => {
-              return undefined
-            })
-            .catch((err) => {
-              if (err instanceof CertificateError) {
-                err.showNotification()
+        validateInput: async (value) => {
+          this.restClient.setSessionToken(value)
+          try {
+            user = await this.restClient.getAuthenticatedUser()
+            if (!user) {
+              throw new Error("Failed to get authenticated user")
+            }
+          } catch (err) {
+            // For certificate errors show both a notification and add to the
+            // text under the input box, since users sometimes miss the
+            // notification.
+            if (err instanceof CertificateError) {
+              err.showNotification()
 
-                return {
-                  message: err.x509Err || err.message,
-                  severity: vscode.InputBoxValidationSeverity.Error,
-                }
-              }
-              // This could be something like the header command erroring or an
-              // invalid session token.
-              const message =
-                err?.response?.data?.detail || err?.message || err?.response?.status || "no response from the server"
               return {
-                message: "Failed to authenticate: " + message,
+                message: err.x509Err || err.message,
                 severity: vscode.InputBoxValidationSeverity.Error,
               }
-            })
+            }
+            // This could be something like the header command erroring or an
+            // invalid session token.
+            const message = getErrorMessage(err, "no response from the server")
+            return {
+              message: "Failed to authenticate: " + message,
+              severity: vscode.InputBoxValidationSeverity.Error,
+            }
+          }
         },
       })
     }
-    if (!token) {
+    if (!token || !user) {
       return
     }
 
+    // Store these to be used in later sessions and in the cli.
     await this.storage.setURL(url)
     await this.storage.setSessionToken(token)
-    try {
-      const user = await getAuthenticatedUser()
-      if (!user) {
-        throw new Error("Failed to get authenticated user")
-      }
-      await vscode.commands.executeCommand("setContext", "coder.authenticated", true)
-      if (user.roles.find((role) => role.name === "owner")) {
-        await vscode.commands.executeCommand("setContext", "coder.isOwner", true)
-      }
-      vscode.window
-        .showInformationMessage(
-          `Welcome to Coder, ${user.username}!`,
-          {
-            detail: "You can now use the Coder extension to manage your Coder instance.",
-          },
-          "Open Workspace",
-        )
-        .then((action) => {
-          if (action === "Open Workspace") {
-            vscode.commands.executeCommand("coder.open")
-          }
-        })
-      vscode.commands.executeCommand("coder.refreshWorkspaces")
-    } catch (error) {
-      vscode.window.showErrorMessage("Failed to authenticate with Coder: " + error)
+
+    await vscode.commands.executeCommand("setContext", "coder.authenticated", true)
+    if (user.roles.find((role) => role.name === "owner")) {
+      await vscode.commands.executeCommand("setContext", "coder.isOwner", true)
     }
+
+    vscode.window
+      .showInformationMessage(
+        `Welcome to Coder, ${user.username}!`,
+        {
+          detail: "You can now use the Coder extension to manage your Coder instance.",
+        },
+        "Open Workspace",
+      )
+      .then((action) => {
+        if (action === "Open Workspace") {
+          vscode.commands.executeCommand("coder.open")
+        }
+      })
+
+    // Fetch workspaces for the new deployment.
+    vscode.commands.executeCommand("coder.refreshWorkspaces")
   }
 
-  // viewLogs opens the workspace logs.
+  /**
+   * View the logs for the currently logged-in deployment.
+   */
   public async viewLogs(): Promise<void> {
+    // TODO: This will need to be refactored for multi-deployment support.
     if (!this.storage.workspaceLogPath) {
       vscode.window.showInformationMessage("No logs available.", this.storage.workspaceLogPath || "<unset>")
       return
@@ -174,48 +175,81 @@ export class Commands {
     await vscode.window.showTextDocument(doc)
   }
 
+  /**
+   * Log out from the currently logged-in deployment.
+   */
   public async logout(): Promise<void> {
+    // Clear from the REST client.  An empty url will indicate to other parts of
+    // the code that we are logged out.
+    this.restClient.setHost("")
+    this.restClient.setSessionToken("")
+
+    // Clear from memory.
     await this.storage.setURL(undefined)
     await this.storage.setSessionToken(undefined)
+
     await vscode.commands.executeCommand("setContext", "coder.authenticated", false)
     vscode.window.showInformationMessage("You've been logged out of Coder!", "Login").then((action) => {
       if (action === "Login") {
         vscode.commands.executeCommand("coder.login")
       }
     })
+
+    // This will result in clearing the workspace list.
     vscode.commands.executeCommand("coder.refreshWorkspaces")
   }
 
+  /**
+   * Create a new workspace for the currently logged-in deployment.
+   *
+   * Must only be called if currently logged in.
+   */
   public async createWorkspace(): Promise<void> {
-    const uri = this.storage.getURL() + "/templates"
+    const uri = this.storage.getUrl() + "/templates"
     await vscode.commands.executeCommand("vscode.open", uri)
   }
 
+  /**
+   * Open a link to the workspace in the Coder dashboard.
+   *
+   * Must only be called if currently logged in.
+   */
   public async navigateToWorkspace(workspace: OpenableTreeItem) {
     if (workspace) {
-      const uri = this.storage.getURL() + `/@${workspace.workspaceOwner}/${workspace.workspaceName}`
+      const uri = this.storage.getUrl() + `/@${workspace.workspaceOwner}/${workspace.workspaceName}`
       await vscode.commands.executeCommand("vscode.open", uri)
     } else if (this.storage.workspace) {
-      const uri = this.storage.getURL() + `/@${this.storage.workspace.owner_name}/${this.storage.workspace.name}`
+      const uri = this.storage.getUrl() + `/@${this.storage.workspace.owner_name}/${this.storage.workspace.name}`
       await vscode.commands.executeCommand("vscode.open", uri)
     } else {
       vscode.window.showInformationMessage("No workspace found.")
     }
   }
 
+  /**
+   * Open a link to the workspace settings in the Coder dashboard.
+   *
+   * Must only be called if currently logged in.
+   */
   public async navigateToWorkspaceSettings(workspace: OpenableTreeItem) {
     if (workspace) {
-      const uri = this.storage.getURL() + `/@${workspace.workspaceOwner}/${workspace.workspaceName}/settings`
+      const uri = this.storage.getUrl() + `/@${workspace.workspaceOwner}/${workspace.workspaceName}/settings`
       await vscode.commands.executeCommand("vscode.open", uri)
     } else if (this.storage.workspace) {
       const uri =
-        this.storage.getURL() + `/@${this.storage.workspace.owner_name}/${this.storage.workspace.name}/settings`
+        this.storage.getUrl() + `/@${this.storage.workspace.owner_name}/${this.storage.workspace.name}/settings`
       await vscode.commands.executeCommand("vscode.open", uri)
     } else {
       vscode.window.showInformationMessage("No workspace found.")
     }
   }
 
+  /**
+   * Open a workspace or agent that is showing in the sidebar.
+   *
+   * This essentially just builds the host name and passes it to the VS Code
+   * Remote SSH extension.
+   */
   public async openFromSidebar(treeItem: OpenableTreeItem) {
     if (treeItem) {
       await openWorkspace(
@@ -228,6 +262,11 @@ export class Commands {
     }
   }
 
+  /**
+   * Open a workspace from the currently logged-in deployment.
+   *
+   * This must only be called if the REST client is logged in.
+   */
   public async open(...args: unknown[]): Promise<void> {
     let workspaceOwner: string
     let workspaceName: string
@@ -243,9 +282,10 @@ export class Commands {
       let lastWorkspaces: readonly Workspace[]
       quickPick.onDidChangeValue((value) => {
         quickPick.busy = true
-        getWorkspaces({
-          q: value,
-        })
+        this.restClient
+          .getWorkspaces({
+            q: value,
+          })
           .then((workspaces) => {
             lastWorkspaces = workspaces.workspaces
             const items: vscode.QuickPickItem[] = workspaces.workspaces.map((workspace) => {
@@ -348,8 +388,12 @@ export class Commands {
     await openWorkspace(workspaceOwner, workspaceName, workspaceAgent, folderPath, openRecent)
   }
 
+  /**
+   * Update the current workspace.  If there is no active workspace connection,
+   * this is a no-op.
+   */
   public async updateWorkspace(): Promise<void> {
-    if (!this.storage.workspace) {
+    if (!this.storage.workspace || !this.storage.restClient) {
       return
     }
     const action = await this.vscodeProposed.window.showInformationMessage(
@@ -362,11 +406,15 @@ export class Commands {
       "Update",
     )
     if (action === "Update") {
-      await updateWorkspaceVersion(this.storage.workspace)
+      await this.storage.restClient.updateWorkspaceVersion(this.storage.workspace)
     }
   }
 }
 
+/**
+ * Given a workspace, build the host name, find a directory to open, and pass
+ * both to the Remote SSH plugin.
+ */
 async function openWorkspace(
   workspaceOwner: string,
   workspaceName: string,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,7 +150,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   if (!vscodeProposed.env.remoteAuthority) {
     return
   }
-  const remote = new Remote(vscodeProposed, storage, ctx.extensionMode)
+  const remote = new Remote(vscodeProposed, storage, commands, ctx.extensionMode)
   try {
     await remote.setup(vscodeProposed.env.remoteAuthority)
   } catch (ex) {

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -43,10 +43,10 @@ export class Remote {
     const sshAuthority = authorityParts[1].substring(Remote.Prefix.length)
 
     // Authorities are in the format:
-    // coder-vscode--<username>--<workspace>--<agent> Agent can be omitted then
-    // will be prompted for instead.
+    // coder-vscode--<username>--<workspace>--<agent>
+    // The agent can be omitted; the user will be prompted for it instead.
     const parts = sshAuthority.split("--")
-    if (parts.length < 2 || parts.length > 3) {
+    if (parts.length !== 2 && parts.length !== 3) {
       throw new Error(`Invalid Coder SSH authority. Must be: <username>--<workspace>--<agent?>`)
     }
     const workspaceName = `${parts[0]}/${parts[1]}`

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,5 +1,4 @@
 import { Api } from "coder/site/src/api/api"
-import { Workspace } from "coder/site/src/api/typesGenerated"
 import { createWriteStream } from "fs"
 import fs from "fs/promises"
 import { ensureDir } from "fs-extra"
@@ -15,18 +14,6 @@ import { getHeaderCommand, getHeaders } from "./headers"
 const MAX_URLS = 10
 
 export class Storage {
-  // These will only be populated when actively connected to a workspace and are
-  // used in commands.  Because commands can be executed by the user, it is not
-  // possible to pass in arguments, so we have to store the current workspace
-  // and client somewhere, separately from the current login, since you can
-  // connect to workspaces not belonging to whatever you are logged into (for
-  // convenience; otherwise the recents menu can be a pain if you use multiple
-  // deployments).
-  // TODO: Should maybe store on the Commands class instead.
-  public workspace?: Workspace
-  public workspaceLogPath?: string
-  public restClient?: Api
-
   constructor(
     private readonly output: vscode.OutputChannel,
     private readonly memento: vscode.Memento,

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -78,15 +78,13 @@ export class Storage {
     return urls.size > MAX_URLS ? Array.from(urls).slice(urls.size - MAX_URLS, urls.size) : Array.from(urls)
   }
 
-  public setSessionToken(sessionToken?: string): Thenable<void> {
+  public async setSessionToken(sessionToken?: string): Promise<void> {
     if (!sessionToken) {
-      return this.secrets.delete("sessionToken").then(() => {
-        return this.updateSessionToken()
-      })
+      await this.secrets.delete("sessionToken")
+    } else {
+      await this.secrets.store("sessionToken", sessionToken)
     }
-    return this.secrets.store("sessionToken", sessionToken).then(() => {
-      return this.updateSessionToken()
-    })
+    return this.updateSessionToken()
   }
 
   public async getSessionToken(): Promise<string | undefined> {

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -26,6 +26,8 @@ type AgentWatcher = {
 /**
  * Polls workspaces using the provided REST client and renders them in a tree.
  *
+ * Polling does not start until fetchAndRefresh() is called at least once.
+ *
  * If the poll fails or the client has no URL configured, clear the tree and
  * abort polling until fetchAndRefresh() is called again.
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,8 +1611,7 @@ co@3.1.0:
 
 "coder@https://github.com/coder/coder#main":
   version "0.0.0"
-  uid "2e49fa94d4d89111de7a41dd810a8bf755574de6"
-  resolved "https://github.com/coder/coder#2e49fa94d4d89111de7a41dd810a8bf755574de6"
+  resolved "https://github.com/coder/coder#9eb797eb5a2bfb115db1fe8eccad78908a5f8ec1"
   dependencies:
     exec "^0.2.1"
 


### PR DESCRIPTION
We support connecting to previous workspaces, but sometimes this breaks because the previous workspace belongs to a different deployment, and the plugin always uses the credentials of the current deployment (https://github.com/coder/vscode-coder/issues/173).

This is a first step to fixing that: separating the client into two: one used by the plugin as a whole (mainly used to list workspaces of the current deployment in the sidebar) and one used to connect to a workspace which may belong to a different deployment (which is used to start the workspace, get the version, etc).  Thankfully this is pretty chill since @Parkreiner's changes to Coder core!

For now that second client does still use the global url and token so functionally it is still the same, but I will fix that in a follow up PR by looking at the host name and figuring out the right credentials to use for it.

As part of this, I try to remove usage of a few globals, in particular we had stuff like `storage.getSessionToken()` all over the place, now I only call that once when creating a client and we use it for the lifetime of the task.

## Alternatives

Instead of creating a separate client, we could log the entire plugin in to the right deployment.  So if you are connected to deployment A, then connect to a workspace belonging to deployment B, the plugin would now entirely be logged into deployment B.

That felt a little too unexpected to me, so I went with the multiple client route.

But maybe it would be better to do a full login, because then the workspaces you see in the sidebar belong to the same deployment.

Still, I think these changes are generally good anyway because they are getting rid of a bunch of global stuff.  We can do a full login if we want to with these changes as well.