### PR TITLE
Add support for connections to multiple deployments

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,9 +5,8 @@ import * as vscode from "vscode"
 import { makeCoderSdk } from "./api"
 import { extractAgents } from "./api-helper"
 import { CertificateError } from "./error"
-import { Remote } from "./remote"
 import { Storage } from "./storage"
-import { toSafeHost } from "./util"
+import { AuthorityPrefix, toSafeHost } from "./util"
 import { OpenableTreeItem } from "./workspacesProvider"
 
 export class Commands {
@@ -475,7 +474,7 @@ async function openWorkspace(
 ) {
   // A workspace can have multiple agents, but that's handled
   // when opening a workspace unless explicitly specified.
-  let remoteAuthority = `ssh-remote+${Remote.Prefix}.${toSafeHost(baseUrl)}--${workspaceOwner}--${workspaceName}`
+  let remoteAuthority = `ssh-remote+${AuthorityPrefix}.${toSafeHost(baseUrl)}--${workspaceOwner}--${workspaceName}`
   if (workspaceAgent) {
     remoteAuthority += `--${workspaceAgent}`
   }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -610,7 +610,7 @@ export class Remote {
 
     let binaryPath: string | undefined
     if (this.mode === vscode.ExtensionMode.Production) {
-      binaryPath = await this.storage.fetchBinary(restClient)
+      binaryPath = await this.storage.fetchBinary(restClient, label)
     } else {
       try {
         // In development, try to use `/tmp/coder` as the binary path.
@@ -618,7 +618,7 @@ export class Remote {
         binaryPath = path.join(os.tmpdir(), "coder")
         await fs.stat(binaryPath)
       } catch (ex) {
-        binaryPath = await this.storage.fetchBinary(restClient)
+        binaryPath = await this.storage.fetchBinary(restClient, label)
       }
     }
 
@@ -647,8 +647,8 @@ export class Remote {
       Host: label ? `${Remote.Prefix}.${label}--*` : `${RemotePrefix}--*`,
       ProxyCommand: `${escape(binaryPath)}${headerArg} vscodessh --network-info-dir ${escape(
         this.storage.getNetworkInfoPath(),
-      )}${logArg} --session-token-file ${escape(this.storage.getSessionTokenPath())} --url-file ${escape(
-        this.storage.getURLPath(),
+      )}${logArg} --session-token-file ${escape(this.storage.getSessionTokenPath(label))} --url-file ${escape(
+        this.storage.getURLPath(label),
       )} %h`,
       ConnectTimeout: "0",
       StrictHostKeyChecking: "no",

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -14,12 +14,12 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-it("creates a new file and adds the config", async () => {
+it("creates a new file and adds config with empty label", async () => {
   mockFileSystem.readFile.mockRejectedValueOnce("No file found")
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
   await sshConfig.load()
-  await sshConfig.update({
+  await sshConfig.update("", {
     Host: "coder-vscode--*",
     ProxyCommand: "some-command-here",
     ConnectTimeout: "0",
@@ -41,6 +41,33 @@ Host coder-vscode--*
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())
 })
 
+it("creates a new file and adds the config", async () => {
+  mockFileSystem.readFile.mockRejectedValueOnce("No file found")
+
+  const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
+  await sshConfig.load()
+  await sshConfig.update("dev.coder.com", {
+    Host: "coder-vscode.dev.coder.com--*",
+    ProxyCommand: "some-command-here",
+    ConnectTimeout: "0",
+    StrictHostKeyChecking: "no",
+    UserKnownHostsFile: "/dev/null",
+    LogLevel: "ERROR",
+  })
+
+  const expectedOutput = `# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
+  ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+# --- END CODER VSCODE dev.coder.com ---`
+
+  expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
+  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())
+})
+
 it("adds a new coder config in an existent SSH configuration", async () => {
   const existentSSHConfig = `Host coder.something
   ConnectTimeout=0
@@ -53,8 +80,8 @@ it("adds a new coder config in an existent SSH configuration", async () => {
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
   await sshConfig.load()
-  await sshConfig.update({
-    Host: "coder-vscode--*",
+  await sshConfig.update("dev.coder.com", {
+    Host: "coder-vscode.dev.coder.com--*",
     ProxyCommand: "some-command-here",
     ConnectTimeout: "0",
     StrictHostKeyChecking: "no",
@@ -64,14 +91,14 @@ it("adds a new coder config in an existent SSH configuration", async () => {
 
   const expectedOutput = `${existentSSHConfig}
 
-# --- START CODER VSCODE ---
-Host coder-vscode--*
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
   ConnectTimeout 0
   LogLevel ERROR
   ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---`
+# --- END CODER VSCODE dev.coder.com ---`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
     encoding: "utf-8",
@@ -80,7 +107,7 @@ Host coder-vscode--*
 })
 
 it("updates an existent coder config", async () => {
-  const existentSSHConfig = `Host coder.something
+  const keepSSHConfig = `Host coder.something
   HostName coder.something
   ConnectTimeout=0
   StrictHostKeyChecking=no
@@ -88,14 +115,25 @@ it("updates an existent coder config", async () => {
   LogLevel ERROR
   ProxyCommand command
 
-# --- START CODER VSCODE ---
-Host coder-vscode--*
+# --- START CODER VSCODE dev2.coder.com ---
+Host coder-vscode.dev2.coder.com--*
   ConnectTimeout 0
   LogLevel ERROR
   ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---
+# --- END CODER VSCODE dev2.coder.com ---`
+
+  const existentSSHConfig = `${keepSSHConfig}
+
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
+  ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+# --- END CODER VSCODE dev.coder.com ---
 
 Host *
   SetEnv TEST=1`
@@ -103,8 +141,56 @@ Host *
 
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
   await sshConfig.load()
-  await sshConfig.update({
-    Host: "coder--updated--vscode--*",
+  await sshConfig.update("dev.coder.com", {
+    Host: "coder-vscode.dev-updated.coder.com--*",
+    ProxyCommand: "some-updated-command-here",
+    ConnectTimeout: "1",
+    StrictHostKeyChecking: "yes",
+    UserKnownHostsFile: "/dev/null",
+    LogLevel: "ERROR",
+  })
+
+  const expectedOutput = `${keepSSHConfig}
+
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev-updated.coder.com--*
+  ConnectTimeout 1
+  LogLevel ERROR
+  ProxyCommand some-updated-command-here
+  StrictHostKeyChecking yes
+  UserKnownHostsFile /dev/null
+# --- END CODER VSCODE dev.coder.com ---
+
+Host *
+  SetEnv TEST=1`
+
+  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+    encoding: "utf-8",
+    mode: 384,
+  })
+})
+
+it("does not remove deployment-unaware SSH config and adds the new one", async () => {
+  // Before the plugin supported multiple deployments, it would only write and
+  // overwrite this one block.  We need to leave it alone so existing
+  // connections keep working.  Only replace blocks specific to the deployment
+  // that we are targeting.  Going forward, all new connections will use the new
+  // deployment-specific block.
+  const existentSSHConfig = `# --- START CODER VSCODE ---
+Host coder-vscode--*
+  ConnectTimeout=0
+  HostName coder.something
+  LogLevel ERROR
+  ProxyCommand command
+  StrictHostKeyChecking=no
+  UserKnownHostsFile=/dev/null
+# --- END CODER VSCODE ---`
+  mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
+
+  const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
+  await sshConfig.load()
+  await sshConfig.update("dev.coder.com", {
+    Host: "coder-vscode.dev.coder.com--*",
     ProxyCommand: "some-command-here",
     ConnectTimeout: "0",
     StrictHostKeyChecking: "no",
@@ -112,25 +198,50 @@ Host *
     LogLevel: "ERROR",
   })
 
-  const expectedOutput = `Host coder.something
-  HostName coder.something
-  ConnectTimeout=0
-  StrictHostKeyChecking=no
-  UserKnownHostsFile=/dev/null
-  LogLevel ERROR
-  ProxyCommand command
+  const expectedOutput = `${existentSSHConfig}
 
-# --- START CODER VSCODE ---
-Host coder--updated--vscode--*
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
   ConnectTimeout 0
   LogLevel ERROR
   ProxyCommand some-command-here
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---
+# --- END CODER VSCODE dev.coder.com ---`
 
-Host *
-  SetEnv TEST=1`
+  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+    encoding: "utf-8",
+    mode: 384,
+  })
+})
+
+it("it does not remove a user-added block that only matches the host of an old coder SSH config", async () => {
+  const existentSSHConfig = `Host coder-vscode--*
+  ForwardAgent=yes`
+  mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig)
+
+  const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
+  await sshConfig.load()
+  await sshConfig.update("dev.coder.com", {
+    Host: "coder-vscode.dev.coder.com--*",
+    ProxyCommand: "some-command-here",
+    ConnectTimeout: "0",
+    StrictHostKeyChecking: "no",
+    UserKnownHostsFile: "/dev/null",
+    LogLevel: "ERROR",
+  })
+
+  const expectedOutput = `Host coder-vscode--*
+  ForwardAgent=yes
+
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
+  ConnectTimeout 0
+  LogLevel ERROR
+  ProxyCommand some-command-here
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+# --- END CODER VSCODE dev.coder.com ---`
 
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
     encoding: "utf-8",
@@ -143,8 +254,9 @@ it("override values", async () => {
   const sshConfig = new SSHConfig(sshFilePath, mockFileSystem)
   await sshConfig.load()
   await sshConfig.update(
+    "dev.coder.com",
     {
-      Host: "coder-vscode--*",
+      Host: "coder-vscode.dev.coder.com--*",
       ProxyCommand: "some-command-here",
       ConnectTimeout: "0",
       StrictHostKeyChecking: "no",
@@ -163,8 +275,8 @@ it("override values", async () => {
     },
   )
 
-  const expectedOutput = `# --- START CODER VSCODE ---
-Host coder-vscode--*
+  const expectedOutput = `# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
   Buzz baz
   ConnectTimeout 500
   ExtraKey ExtraValue
@@ -172,7 +284,7 @@ Host coder-vscode--*
   ProxyCommand some-command-here
   UserKnownHostsFile /dev/null
   loglevel DEBUG
-# --- END CODER VSCODE ---`
+# --- END CODER VSCODE dev.coder.com ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
   expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -31,8 +31,6 @@ const defaultFileSystem: FileSystem = {
   writeFile,
 }
 
-export const defaultSSHConfigResponse: Record<string, string> = {}
-
 // mergeSSHConfigValues will take a given ssh config and merge it with the overrides
 // provided. The merge handles key case insensitivity, so casing in the "key" does
 // not matter.
@@ -85,8 +83,13 @@ export class SSHConfig {
   private filePath: string
   private fileSystem: FileSystem
   private raw: string | undefined
-  private startBlockComment = "# --- START CODER VSCODE ---"
-  private endBlockComment = "# --- END CODER VSCODE ---"
+
+  private startBlockComment(label: string): string {
+    return label ? `# --- START CODER VSCODE ${label} ---` : `# --- START CODER VSCODE ---`
+  }
+  private endBlockComment(label: string): string {
+    return label ? `# --- END CODER VSCODE ${label} ---` : `# --- END CODER VSCODE ---`
+  }
 
   constructor(filePath: string, fileSystem: FileSystem = defaultFileSystem) {
     this.filePath = filePath
@@ -102,9 +105,12 @@ export class SSHConfig {
     }
   }
 
-  async update(values: SSHValues, overrides: Record<string, string> = defaultSSHConfigResponse) {
-    const block = this.getBlock()
-    const newBlock = this.buildBlock(values, overrides)
+  /**
+   * Update the block for the deployment with the provided label.
+   */
+  async update(label: string, values: SSHValues, overrides?: Record<string, string>) {
+    const block = this.getBlock(label)
+    const newBlock = this.buildBlock(label, values, overrides)
     if (block) {
       this.replaceBlock(block, newBlock)
     } else {
@@ -113,10 +119,13 @@ export class SSHConfig {
     await this.save()
   }
 
-  private getBlock(): Block | undefined {
+  /**
+   * Get the block for the deployment with the provided label.
+   */
+  private getBlock(label: string): Block | undefined {
     const raw = this.getRaw()
-    const startBlockIndex = raw.indexOf(this.startBlockComment)
-    const endBlockIndex = raw.indexOf(this.endBlockComment)
+    const startBlockIndex = raw.indexOf(this.startBlockComment(label))
+    const endBlockIndex = raw.indexOf(this.endBlockComment(label))
     const hasBlock = startBlockIndex > -1 && endBlockIndex > -1
 
     if (!hasBlock) {
@@ -136,25 +145,30 @@ export class SSHConfig {
     }
 
     return {
-      raw: raw.substring(startBlockIndex, endBlockIndex + this.endBlockComment.length),
+      raw: raw.substring(startBlockIndex, endBlockIndex + this.endBlockComment(label).length),
     }
   }
 
   /**
-   * buildBlock builds the ssh config block. The order of the keys is determinstic based on the input.
-   * Expected values are always in a consistent order followed by any additional overrides in sorted order.
+   * buildBlock builds the ssh config block for the provided URL. The order of
+   * the keys is determinstic based on the input.  Expected values are always in
+   * a consistent order followed by any additional overrides in sorted order.
    *
-   * @param param0 - SSHValues are the expected SSH values for using ssh with coder.
-   * @param overrides - Overrides typically come from the deployment api and are used to override the default values.
-   *                    The overrides are given as key:value pairs where the key is the ssh config file key.
-   *                    If the key matches an expected value, the expected value is overridden. If it does not
-   *                    match an expected value, it is appended to the end of the block.
+   * @param label     - The label for the deployment (like the encoded URL).
+   * @param values    - The expected SSH values for using ssh with Coder.
+   * @param overrides - Overrides typically come from the deployment api and are
+   *                    used to override the default values.  The overrides are
+   *                    given as key:value pairs where the key is the ssh config
+   *                    file key.  If the key matches an expected value, the
+   *                    expected value is overridden. If it does not match an
+   *                    expected value, it is appended to the end of the block.
    */
-  private buildBlock({ Host, ...otherValues }: SSHValues, overrides: Record<string, string>): Block {
-    const lines = [this.startBlockComment, `Host ${Host}`]
+  private buildBlock(label: string, values: SSHValues, overrides?: Record<string, string>) {
+    const { Host, ...otherValues } = values
+    const lines = [this.startBlockComment(label), `Host ${Host}`]
 
     // configValues is the merged values of the defaults and the overrides.
-    const configValues = mergeSSHConfigValues(otherValues, overrides)
+    const configValues = mergeSSHConfigValues(otherValues, overrides || {})
 
     // keys is the sorted keys of the merged values.
     const keys = (Object.keys(configValues) as Array<keyof typeof configValues>).sort()
@@ -165,7 +179,7 @@ export class SSHConfig {
       }
     })
 
-    lines.push(this.endBlockComment)
+    lines.push(this.endBlockComment(label))
     return {
       raw: lines.join("\n"),
     }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -115,7 +115,7 @@ export class Storage {
    * unable to download a working binary, whether because of network issues or
    * downloads being disabled.
    */
-  public async fetchBinary(restClient: Api, label: string | string): Promise<string> {
+  public async fetchBinary(restClient: Api, label: string): Promise<string> {
     const baseUrl = restClient.getAxiosInstance().defaults.baseURL
     this.output.appendLine(`Using deployment URL: ${baseUrl}`)
     this.output.appendLine(`Using deployment label: ${label || "n/a"}`)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,6 @@
 import { Api } from "coder/site/src/api/api"
 import { createWriteStream } from "fs"
 import fs from "fs/promises"
-import { ensureDir } from "fs-extra"
 import { IncomingMessage } from "http"
 import path from "path"
 import prettyBytes from "pretty-bytes"
@@ -24,14 +23,13 @@ export class Storage {
 
   /**
    * Add the URL to the list of recently accessed URLs in global storage, then
-   * set it as the last used URL and update it on disk for the cli.
+   * set it as the last used URL.
    *
-   * If the URL is falsey, then remove it as the currently accessed URL and do
-   * not touch the history.
+   * If the URL is falsey, then remove it as the last used URL and do not touch
+   * the history.
    */
   public async setURL(url?: string): Promise<void> {
     await this.memento.update("url", url)
-    this.updateUrl(url)
     if (url) {
       const history = this.withUrlHistory(url)
       await this.memento.update("urlHistory", history)
@@ -64,15 +62,13 @@ export class Storage {
   }
 
   /**
-   * Set or unset the last used token and update it on disk for the cli.
+   * Set or unset the last used token.
    */
   public async setSessionToken(sessionToken?: string): Promise<void> {
     if (!sessionToken) {
       await this.secrets.delete("sessionToken")
-      this.updateSessionToken(undefined)
     } else {
       await this.secrets.store("sessionToken", sessionToken)
-      this.updateSessionToken(sessionToken)
     }
   }
 
@@ -109,16 +105,20 @@ export class Storage {
   }
 
   /**
-   * Download and return the path to a working binary using the provided client.
+   * Download and return the path to a working binary for the deployment with
+   * the provided label using the provided client.  If the label is empty, use
+   * the old deployment-unaware path instead.
+   *
    * If there is already a working binary and it matches the server version,
    * return that, skipping the download.  If it does not match but downloads are
    * disabled, return whatever we have and log a warning.  Otherwise throw if
    * unable to download a working binary, whether because of network issues or
    * downloads being disabled.
    */
-  public async fetchBinary(restClient: Api): Promise<string> {
+  public async fetchBinary(restClient: Api, label: string | string): Promise<string> {
     const baseUrl = restClient.getAxiosInstance().defaults.baseURL
     this.output.appendLine(`Using deployment URL: ${baseUrl}`)
+    this.output.appendLine(`Using deployment label: ${label}`)
 
     // Settings can be undefined when set to their defaults (true in this case),
     // so explicitly check against false.
@@ -133,7 +133,7 @@ export class Storage {
     // Check if there is an existing binary and whether it looks valid.  If it
     // is valid and matches the server, or if it does not match the server but
     // downloads are disabled, we can return early.
-    const binPath = path.join(this.getBinaryCachePath(), cli.name())
+    const binPath = path.join(this.getBinaryCachePath(label), cli.name())
     this.output.appendLine(`Using binary path: ${binPath}`)
     const stat = await cli.stat(binPath)
     if (stat === undefined) {
@@ -351,13 +351,21 @@ export class Storage {
     }
   }
 
-  // getBinaryCachePath returns the path where binaries are cached.
-  // The caller must ensure it exists before use.
-  public getBinaryCachePath(): string {
+  /**
+   * Return the directory for a deployment with the provided label to where its
+   * binary is cached.
+   *
+   * If the label is empty, read the old deployment-unaware config instead.
+   *
+   * The caller must ensure this directory exists before use.
+   */
+  public getBinaryCachePath(label: string): string {
     const configPath = vscode.workspace.getConfiguration().get("coder.binaryDestination")
     return configPath && String(configPath).trim().length > 0
       ? path.resolve(String(configPath))
-      : path.join(this.globalStorageUri.fsPath, "bin")
+      : label
+        ? path.join(this.globalStorageUri.fsPath, label, "bin")
+        : path.join(this.globalStorageUri.fsPath, "bin")
   }
 
   // getNetworkInfoPath returns the path where network information
@@ -377,17 +385,31 @@ export class Storage {
   }
 
   /**
-   * Return the path to the session token file for the cli.
+   * Return the directory for the deployment with the provided label to where
+   * its session token is stored.
+   *
+   * If the label is empty, read the old deployment-unaware config instead.
+   *
+   * The caller must ensure this directory exists before use.
    */
-  public getSessionTokenPath(): string {
-    return path.join(this.globalStorageUri.fsPath, "session_token")
+  public getSessionTokenPath(label: string): string {
+    return label
+      ? path.join(this.globalStorageUri.fsPath, label, "session_token")
+      : path.join(this.globalStorageUri.fsPath, "session_token")
   }
 
   /**
-   * Return the path to the URL file for the cli.
+   * Return the directory for the deployment with the provided label to where
+   * its url is stored.
+   *
+   * If the label is empty, read the old deployment-unaware config instead.
+   *
+   * The caller must ensure this directory exists before use.
    */
-  public getURLPath(): string {
-    return path.join(this.globalStorageUri.fsPath, "url")
+  public getURLPath(label: string): string {
+    return label
+      ? path.join(this.globalStorageUri.fsPath, label, "url")
+      : path.join(this.globalStorageUri.fsPath, "url")
   }
 
   public writeToCoderOutputChannel(message: string) {
@@ -399,28 +421,41 @@ export class Storage {
   }
 
   /**
-   * Update or remove the URL on disk which can be used by the CLI via
-   * --url-file.
+   * Configure the CLI for the deployment with the provided label.
    */
-  private async updateUrl(url: string | undefined): Promise<void> {
+  public async configureCli(label: string, url: string | undefined, token: string | undefined | null) {
+    await Promise.all([this.updateUrlForCli(label, url), this.updateTokenForCli(label, token)])
+  }
+
+  /**
+   * Update or remove the URL for the deployment with the provided label on disk
+   * which can be used by the CLI via --url-file.
+   *
+   * If the label is empty, read the old deployment-unaware config instead.
+   */
+  private async updateUrlForCli(label: string, url: string | undefined): Promise<void> {
+    const urlPath = this.getURLPath(label)
     if (url) {
-      await ensureDir(this.globalStorageUri.fsPath)
-      await fs.writeFile(this.getURLPath(), url)
+      await fs.mkdir(path.dirname(urlPath), { recursive: true })
+      await fs.writeFile(urlPath, url)
     } else {
-      await fs.rm(this.getURLPath(), { force: true })
+      await fs.rm(urlPath, { force: true })
     }
   }
 
   /**
-   * Update or remove the session token on disk which can be used by the CLI
-   * via --session-token-file.
+   * Update or remove the session token for a deployment with the provided label
+   * on disk which can be used by the CLI via --session-token-file.
+   *
+   * If the label is empty, read the old deployment-unaware config instead.
    */
-  private async updateSessionToken(token: string | undefined) {
+  private async updateTokenForCli(label: string, token: string | undefined | null) {
+    const tokenPath = this.getSessionTokenPath(label)
     if (token) {
-      await ensureDir(this.globalStorageUri.fsPath)
-      await fs.writeFile(this.getSessionTokenPath(), token)
+      await fs.mkdir(path.dirname(tokenPath), { recursive: true })
+      await fs.writeFile(tokenPath, token)
     } else {
-      await fs.rm(this.getSessionTokenPath(), { force: true })
+      await fs.rm(tokenPath, { force: true })
     }
   }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -118,7 +118,7 @@ export class Storage {
   public async fetchBinary(restClient: Api, label: string | string): Promise<string> {
     const baseUrl = restClient.getAxiosInstance().defaults.baseURL
     this.output.appendLine(`Using deployment URL: ${baseUrl}`)
-    this.output.appendLine(`Using deployment label: ${label}`)
+    this.output.appendLine(`Using deployment label: ${label || "n/a"}`)
 
     // Settings can be undefined when set to their defaults (true in this case),
     // so explicitly check against false.
@@ -456,6 +456,23 @@ export class Storage {
       await fs.writeFile(tokenPath, token)
     } else {
       await fs.rm(tokenPath, { force: true })
+    }
+  }
+
+  /**
+   * Read the CLI config for a deployment with the provided label.
+   *
+   * IF a config file does not exist, return an empty string.
+   *
+   * If the label is empty, read the old deployment-unaware config.
+   */
+  public async readCliConfig(label: string): Promise<{ url: string; token: string }> {
+    const urlPath = this.getURLPath(label)
+    const tokenPath = this.getSessionTokenPath(label)
+    const [url, token] = await Promise.allSettled([fs.readFile(urlPath, "utf8"), fs.readFile(tokenPath, "utf8")])
+    return {
+      url: url.status === "fulfilled" ? url.value : "",
+      token: token.status === "fulfilled" ? token.value : "",
     }
   }
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,11 @@
+import { it, expect } from "vitest"
+import { toSafeHost } from "./util"
+
+it("escapes url host", async () => {
+  expect(toSafeHost("https://foobar:8080")).toBe("foobar")
+  expect(toSafeHost("https://ほげ")).toBe("xn--18j4d")
+  expect(toSafeHost("https://test.😉.invalid")).toBe("test.xn--n28h.invalid")
+  expect(toSafeHost("https://dev.😉-coder.com")).toBe("dev.xn---coder-vx74e.com")
+  expect(() => toSafeHost("invalid url")).toThrow("Invalid URL")
+  expect(toSafeHost("http://ignore-port.com:8080")).toBe("ignore-port.com")
+})

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,5 +1,62 @@
 import { it, expect } from "vitest"
-import { toSafeHost } from "./util"
+import { parseRemoteAuthority, toSafeHost } from "./util"
+
+it("ignore unrelated authorities", async () => {
+  const tests = [
+    "vscode://ssh-remote+some-unrelated-host.com",
+    "vscode://ssh-remote+coder-vscode",
+    "vscode://ssh-remote+coder-vscode-test",
+    "vscode://ssh-remote+coder-vscode-test--foo--bar",
+    "vscode://ssh-remote+coder-vscode-foo--bar",
+    "vscode://ssh-remote+coder--foo--bar",
+  ]
+  for (const test of tests) {
+    expect(parseRemoteAuthority(test)).toBe(null)
+  }
+})
+
+it("should error on invalid authorities", async () => {
+  const tests = [
+    "vscode://ssh-remote+coder-vscode--foo",
+    "vscode://ssh-remote+coder-vscode--",
+    "vscode://ssh-remote+coder-vscode--foo--",
+    "vscode://ssh-remote+coder-vscode--foo--bar--",
+  ]
+  for (const test of tests) {
+    expect(() => parseRemoteAuthority(test)).toThrow("Invalid")
+  }
+})
+
+it("should parse authority", async () => {
+  expect(parseRemoteAuthority("vscode://ssh-remote+coder-vscode--foo--bar")).toStrictEqual({
+    agent: "",
+    host: "coder-vscode--foo--bar",
+    label: "",
+    username: "foo",
+    workspace: "bar",
+  })
+  expect(parseRemoteAuthority("vscode://ssh-remote+coder-vscode--foo--bar--baz")).toStrictEqual({
+    agent: "baz",
+    host: "coder-vscode--foo--bar--baz",
+    label: "",
+    username: "foo",
+    workspace: "bar",
+  })
+  expect(parseRemoteAuthority("vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar")).toStrictEqual({
+    agent: "",
+    host: "coder-vscode.dev.coder.com--foo--bar",
+    label: "dev.coder.com",
+    username: "foo",
+    workspace: "bar",
+  })
+  expect(parseRemoteAuthority("vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar--baz")).toStrictEqual({
+    agent: "baz",
+    host: "coder-vscode.dev.coder.com--foo--bar--baz",
+    label: "dev.coder.com",
+    username: "foo",
+    workspace: "bar",
+  })
+})
 
 it("escapes url host", async () => {
   expect(toSafeHost("https://foobar:8080")).toBe("foobar")

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,11 @@
+import url from "url"
+
+/**
+ * Given a URL, return the host in a format that is safe to write.
+ */
+export function toSafeHost(rawUrl: string): string {
+  const u = new URL(rawUrl)
+  // If the host is invalid, an empty string is returned.  Although, `new URL`
+  // should already have thrown in that case.
+  return url.domainToASCII(u.hostname) || u.hostname
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,54 @@
 import url from "url"
 
+export interface AuthorityParts {
+  agent: string | undefined
+  host: string
+  label: string
+  username: string
+  workspace: string
+}
+
+// Prefix is a magic string that is prepended to SSH hosts to indicate that
+// they should be handled by this extension.
+export const AuthorityPrefix = "coder-vscode"
+
+/**
+ * Given an authority, parse into the expected parts.
+ *
+ * If this is not a Coder host, return null.
+ *
+ * Throw an error if the host is invalid.
+ */
+export function parseRemoteAuthority(authority: string): AuthorityParts | null {
+  // The authority looks like: vscode://ssh-remote+<ssh host name>
+  const authorityParts = authority.split("+")
+
+  // We create SSH host names in one of two formats:
+  // coder-vscode--<username>--<workspace>--<agent?> (old style)
+  // coder-vscode.<label>--<username>--<workspace>--<agent>
+  // The agent can be omitted; the user will be prompted for it instead.
+  // Anything else is unrelated to Coder and can be ignored.
+  const parts = authorityParts[1].split("--")
+  if (parts.length <= 1 || (parts[0] !== AuthorityPrefix && !parts[0].startsWith(`${AuthorityPrefix}.`))) {
+    return null
+  }
+
+  // It has the proper prefix, so this is probably a Coder host name.
+  // Validate the SSH host name.  Including the prefix, we expect at least
+  // three parts, or four if including the agent.
+  if ((parts.length !== 3 && parts.length !== 4) || parts.some((p) => !p)) {
+    throw new Error(`Invalid Coder SSH authority. Must be: <username>--<workspace>--<agent?>`)
+  }
+
+  return {
+    agent: parts[3] ?? "",
+    host: authorityParts[1],
+    label: parts[0].replace(/^coder-vscode\.?/, ""),
+    username: parts[1],
+    workspace: parts[2],
+  }
+}
+
 /**
  * Given a URL, return the host in a format that is safe to write.
  */


### PR DESCRIPTION
This is broadly three parts, as described by the commits, but the main gist is that the SSH blocks are now scoped (with the deployment URL in the host name), and the individual config files referenced in those config blocks are also scoped (with the deployment URL in the directory), and the connection process has been decoupled from the credentials in VS Code's memory and coupled to the credentials in the associated config directory instead.  More context in each commit message; it might even make sense to review by commit.

Existing hosts should not be affected, only new connections will be scoped by deployment.  Existing hosts (ones without the deployment in the host) will continue using the old config block and directories.  But it will not be possible to add new hosts using the old style; new connections will always be scoped. 

I should also clarify that this specifically is for supporting the "Recents" menu that may contain connections from multiple deployments and for reconnections (say you connect and then log into a different deployment while the other connection is still up).  It does not let you log into multiple deployments and see all the workspaces from all of them at once.

In other words it closes https://github.com/coder/vscode-coder/issues/173 but **not** https://github.com/coder/vscode-coder/issues/102.