### PR TITLE
Allow empty output from header command

### DIFF
--- a/src/headers.test.ts
+++ b/src/headers.test.ts
@@ -17,6 +17,7 @@ it("should return no headers", async () => {
   await expect(getHeaders("", "command", logger)).resolves.toStrictEqual({})
   await expect(getHeaders("localhost", "  ", logger)).resolves.toStrictEqual({})
   await expect(getHeaders("  ", "command", logger)).resolves.toStrictEqual({})
+  await expect(getHeaders("localhost", "printf ''", logger)).resolves.toStrictEqual({})
 })
 
 it("should return headers", async () => {
@@ -43,7 +44,6 @@ it("should error on malformed or empty lines", async () => {
   await expect(getHeaders("localhost", "printf '  =foo'", logger)).rejects.toMatch(/Malformed/)
   await expect(getHeaders("localhost", "printf 'foo  =bar'", logger)).rejects.toMatch(/Malformed/)
   await expect(getHeaders("localhost", "printf 'foo  foo=bar'", logger)).rejects.toMatch(/Malformed/)
-  await expect(getHeaders("localhost", "printf ''", logger)).rejects.toMatch(/Malformed/)
 })
 
 it("should have access to environment variables", async () => {

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -59,6 +59,10 @@ export async function getHeaders(
       }
       throw new Error(`Header command exited unexpectedly: ${error}`)
     }
+    if (!result.stdout) {
+      // Allow no output for parity with the Coder CLI.
+      return headers
+    }
     const lines = result.stdout.replace(/\r?\n$/, "").split(/\r?\n/)
     for (let i = 0; i < lines.length; ++i) {
       const [key, value] = lines[i].split(/=(.*)/)


### PR DESCRIPTION
Allow no output from the header command, for parity with the Coder CLI, similarly to the JetBrains plugin in https://github.com/coder/jetbrains-coder/issues/404