### PR TITLE
Remove coder.openFromSidebar from command list

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,12 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+          {
+              "command": "coder.openFromSidebar",
+              "when": "false"
+          }
+      ],
       "view/title": [
         {
           "command": "coder.logout",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -351,6 +351,10 @@ export class Commands {
         treeItem.workspaceFolderPath,
         true,
       )
+    } else {
+      // If there is no tree item, then the user manually ran this command.
+      // Default to the regular open instead.
+      return this.open()
     }
   }
 


### PR DESCRIPTION
Two steps:

1. Hide the command
2. Make the command fall back to the regular open if it is somehow called

More details can be found in the commit messages.

Close https://github.com/coder/vscode-coder/issues/341