### PR TITLE
Do not require token auth with mTLS

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,17 +74,17 @@
           "default": ""
         },
         "coder.tlsCertFile": {
-          "markdownDescription": "Path to file for TLS client cert",
+          "markdownDescription": "Path to file for TLS client cert. When specified, token authorization will be skipped.",
           "type": "string",
           "default": ""
         },
         "coder.tlsKeyFile": {
-          "markdownDescription": "Path to file for TLS client key",
+          "markdownDescription": "Path to file for TLS client key. When specified, token authorization will be skipped.",
           "type": "string",
           "default": ""
         },
         "coder.tlsCaFile": {
-          "markdownDescription": "Path to file for TLS certificate authority",
+          "markdownDescription": "Path to file for TLS certificate authority.",
           "type": "string",
           "default": ""
         },

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -136,7 +136,12 @@ export class Commands {
    * Log into the provided deployment.  If the deployment URL is not specified,
    * ask for it first with a menu showing recent URLs and CODER_URL, if set.
    */
-  public async login([inputUrl, inputLabel, inputToken]: string[]): Promise<void> {
+  public async login(...args: string[]): Promise<void> {
+    // Destructure would be nice but VS Code can pass undefined which errors.
+    const inputUrl = args[0]
+    const inputToken = args[1]
+    const inputLabel = args[2]
+
     const url = await this.maybeAskUrl(inputUrl)
     if (!url) {
       return

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -136,8 +136,8 @@ export class Commands {
    * Log into the provided deployment.  If the deployment URL is not specified,
    * ask for it first with a menu showing recent URLs and CODER_URL, if set.
    */
-  public async login(...args: string[]): Promise<void> {
-    const url = await this.maybeAskUrl(args[0])
+  public async login([inputUrl, inputLabel, inputToken]: string[]): Promise<void> {
+    const url = await this.maybeAskUrl(inputUrl)
     if (!url) {
       return
     }
@@ -145,10 +145,10 @@ export class Commands {
     // It is possible that we are trying to log into an old-style host, in which
     // case we want to write with the provided blank label instead of generating
     // a host label.
-    const label = typeof args[2] === "undefined" ? toSafeHost(url) : args[2]
+    const label = typeof inputLabel === "undefined" ? toSafeHost(url) : inputLabel
 
     // Try to get a token from the user, if we need one, and their user.
-    const res = await this.maybeAskToken(url, args[1])
+    const res = await this.maybeAskToken(url, inputToken)
     if (!res) {
       return // The user aborted.
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import axios, { isAxiosError } from "axios"
 import { getErrorMessage } from "coder/site/src/api/errors"
 import * as module from "module"
 import * as vscode from "vscode"
-import { makeCoderSdk } from "./api"
+import { makeCoderSdk, needToken } from "./api"
 import { errToStr } from "./api-helper"
 import { Commands } from "./commands"
 import { CertificateError, getErrorDetail } from "./error"
@@ -92,8 +92,12 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         }
 
         // If the token is missing we will get a 401 later and the user will be
-        // prompted to sign in again, so we do not need to ensure it is set.
-        const token = params.get("token")
+        // prompted to sign in again, so we do not need to ensure it is set now.
+        // For non-token auth, we write a blank token since the `vscodessh`
+        // command currently always requires a token file.  However, if there is
+        // a query parameter for non-token auth go ahead and use it anyway; all
+        // that really matters is the file is created.
+        const token = needToken() ? params.get("token") : (params.get("token") ?? "")
         if (token) {
           restClient.setSessionToken(token)
           await storage.setSessionToken(token)

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -435,8 +435,8 @@ export class Storage {
   /**
    * Configure the CLI for the deployment with the provided label.
    *
-   * Falsey values are a no-op; we avoid unconfiguring the CLI to avoid breaking
-   * existing connections.
+   * Falsey URLs and null tokens are a no-op; we avoid unconfiguring the CLI to
+   * avoid breaking existing connections.
    */
   public async configureCli(label: string, url: string | undefined, token: string | undefined | null) {
     await Promise.all([this.updateUrlForCli(label, url), this.updateTokenForCli(label, token)])
@@ -459,15 +459,15 @@ export class Storage {
   /**
    * Update the session token for a deployment with the provided label on disk
    * which can be used by the CLI via --session-token-file.  If the token is
-   * falsey, do nothing.
+   * null, do nothing.
    *
    * If the label is empty, read the old deployment-unaware config instead.
    */
   private async updateTokenForCli(label: string, token: string | undefined | null) {
-    if (token) {
+    if (token !== null) {
       const tokenPath = this.getSessionTokenPath(label)
       await fs.mkdir(path.dirname(tokenPath), { recursive: true })
-      await fs.writeFile(tokenPath, token)
+      await fs.writeFile(tokenPath, token ?? "")
     }
   }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -438,7 +438,7 @@ export class Storage {
    * Falsey URLs and null tokens are a no-op; we avoid unconfiguring the CLI to
    * avoid breaking existing connections.
    */
-  public async configureCli(label: string, url: string | undefined, token: string | undefined | null) {
+  public async configureCli(label: string, url: string | undefined, token: string | null) {
     await Promise.all([this.updateUrlForCli(label, url), this.updateTokenForCli(label, token)])
   }
 


### PR DESCRIPTION
The strategy: when configuring the cli, write blank token files, since currently the `vscodessh` always expects a file.  Still need to validate if this works; if not we may need to write something like `unused` or modify the cli itself.

We configure in two places: login via command palette and dashboard link, so both those code paths are changed to write `""` when not using token auth.  Additionally, the login route is changed to not prompt for the token (failure to auth will be a hard error instead).