### PR TITLE
feat: add coder.tlsAltHost option

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,11 @@
           "type": "string",
           "default": ""
         },
+        "coder.tlsAltHost": {
+          "markdownDescription": "Alternative hostname to use for TLS verification. This is useful when the hostname in the certificate does not match the hostname used to connect.",
+          "type": "string",
+          "default": ""
+        },
         "coder.proxyLogDirectory": {
           "markdownDescription": "If set, the Coder CLI will output extra SSH information into this directory, which can be helpful for debugging connectivity issues.",
           "type": "string",

--- a/src/api.ts
+++ b/src/api.ts
@@ -31,6 +31,7 @@ async function createHttpAgent(): Promise<ProxyAgent> {
   const certFile = expandPath(String(cfg.get("coder.tlsCertFile") ?? "").trim())
   const keyFile = expandPath(String(cfg.get("coder.tlsKeyFile") ?? "").trim())
   const caFile = expandPath(String(cfg.get("coder.tlsCaFile") ?? "").trim())
+  const altHost = expandPath(String(cfg.get("coder.tlsAltHost") ?? "").trim())
 
   return new ProxyAgent({
     // Called each time a request is made.
@@ -41,6 +42,7 @@ async function createHttpAgent(): Promise<ProxyAgent> {
     cert: certFile === "" ? undefined : await fs.readFile(certFile),
     key: keyFile === "" ? undefined : await fs.readFile(keyFile),
     ca: caFile === "" ? undefined : await fs.readFile(caFile),
+    servername: altHost === "" ? undefined : altHost,
     // rejectUnauthorized defaults to true, so we need to explicitly set it to
     // false if we want to allow self-signed certificates.
     rejectUnauthorized: !insecure,
@@ -66,7 +68,8 @@ async function getHttpAgent(): Promise<ProxyAgent> {
         e.affectsConfiguration("coder.insecure") ||
         e.affectsConfiguration("coder.tlsCertFile") ||
         e.affectsConfiguration("coder.tlsKeyFile") ||
-        e.affectsConfiguration("coder.tlsCaFile")
+        e.affectsConfiguration("coder.tlsCaFile") ||
+        e.affectsConfiguration("coder.tlsAltHost")
       ) {
         agent = createHttpAgent()
       }


### PR DESCRIPTION
This allows using a specific hostname for the TLS connection, this is useful when the tls cert does not match the hostname of the server which can be used for testing.

Not sure how we test this....