### PR TITLE
Start workspaces by shelling out to CLI

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcessWithoutNullStreams } from "child_process"
+import { spawn } from "child_process"
 import { Api } from "coder/site/src/api/api"
 import { ProvisionerJobLog, Workspace } from "coder/site/src/api/typesGenerated"
 import fs from "fs/promises"
@@ -137,11 +137,7 @@ export async function startWorkspaceIfStoppedOrFailed(
   }
 
   return new Promise((resolve, reject) => {
-    const startProcess: ChildProcessWithoutNullStreams = spawn(binPath, [
-      "start",
-      "--yes",
-      workspace.owner_name + "/" + workspace.name,
-    ])
+    const startProcess = spawn(binPath, ["start", "--yes", workspace.owner_name + "/" + workspace.name])
 
     startProcess.stdout.on("data", (data: Buffer) => {
       data

--- a/src/api.ts
+++ b/src/api.ts
@@ -125,6 +125,7 @@ export async function makeCoderSdk(baseUrl: string, token: string | undefined, s
  */
 export async function startWorkspaceIfStoppedOrFailed(
   restClient: Api,
+  globalConfigDir: string,
   binPath: string,
   workspace: Workspace,
   writeEmitter: vscode.EventEmitter<string>,
@@ -137,7 +138,13 @@ export async function startWorkspaceIfStoppedOrFailed(
   }
 
   return new Promise((resolve, reject) => {
-    const startArgs = ["start", "--yes", workspace.owner_name + "/" + workspace.name]
+    const startArgs = [
+      "--global-config",
+      globalConfigDir,
+      "start",
+      "--yes",
+      workspace.owner_name + "/" + workspace.name,
+    ]
     const startProcess = spawn(binPath, startArgs)
 
     startProcess.stdout.on("data", (data: Buffer) => {

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -182,7 +182,7 @@ export class Remote {
     const workspaceName = `${parts.username}/${parts.workspace}`
 
     // Migrate "session_token" file to "session", if needed.
-    this.storage.migrateSessionToken(parts.label)
+    await this.storage.migrateSessionToken(parts.label)
 
     // Get the URL and token belonging to this host.
     const { url: baseUrlRaw, token } = await this.storage.readCliConfig(parts.label)

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -50,7 +50,11 @@ export class Remote {
   /**
    * Try to get the workspace running.  Return undefined if the user canceled.
    */
-  private async maybeWaitForRunning(restClient: Api, workspace: Workspace): Promise<Workspace | undefined> {
+  private async maybeWaitForRunning(
+    restClient: Api,
+    workspace: Workspace,
+    binPath: string,
+  ): Promise<Workspace | undefined> {
     // Maybe already running?
     if (workspace.latest_build.status === "running") {
       return workspace
@@ -62,6 +66,28 @@ export class Remote {
     let writeEmitter: undefined | vscode.EventEmitter<string>
     let terminal: undefined | vscode.Terminal
     let attempts = 0
+
+    function initWriteEmitterAndTerminal(): vscode.EventEmitter<string> {
+      if (!writeEmitter) {
+        writeEmitter = new vscode.EventEmitter<string>()
+      }
+      if (!terminal) {
+        terminal = vscode.window.createTerminal({
+          name: "Build Log",
+          location: vscode.TerminalLocation.Panel,
+          // Spin makes this gear icon spin!
+          iconPath: new vscode.ThemeIcon("gear~spin"),
+          pty: {
+            onDidWrite: writeEmitter.event,
+            close: () => undefined,
+            open: () => undefined,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as Partial<vscode.Pseudoterminal> as any,
+        })
+        terminal.show(true)
+      }
+      return writeEmitter
+    }
 
     try {
       // Show a notification while we wait.
@@ -78,24 +104,7 @@ export class Remote {
               case "pending":
               case "starting":
               case "stopping":
-                if (!writeEmitter) {
-                  writeEmitter = new vscode.EventEmitter<string>()
-                }
-                if (!terminal) {
-                  terminal = vscode.window.createTerminal({
-                    name: "Build Log",
-                    location: vscode.TerminalLocation.Panel,
-                    // Spin makes this gear icon spin!
-                    iconPath: new vscode.ThemeIcon("gear~spin"),
-                    pty: {
-                      onDidWrite: writeEmitter.event,
-                      close: () => undefined,
-                      open: () => undefined,
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    } as Partial<vscode.Pseudoterminal> as any,
-                  })
-                  terminal.show(true)
-                }
+                writeEmitter = initWriteEmitterAndTerminal()
                 this.storage.writeToCoderOutputChannel(`Waiting for ${workspaceName}...`)
                 workspace = await waitForBuild(restClient, writeEmitter, workspace)
                 break
@@ -103,8 +112,9 @@ export class Remote {
                 if (!(await this.confirmStart(workspaceName))) {
                   return undefined
                 }
+                writeEmitter = initWriteEmitterAndTerminal()
                 this.storage.writeToCoderOutputChannel(`Starting ${workspaceName}...`)
-                workspace = await startWorkspaceIfStoppedOrFailed(restClient, workspace)
+                workspace = await startWorkspaceIfStoppedOrFailed(restClient, binPath, workspace, writeEmitter)
                 break
               case "failed":
                 // On a first attempt, we will try starting a failed workspace
@@ -113,8 +123,9 @@ export class Remote {
                   if (!(await this.confirmStart(workspaceName))) {
                     return undefined
                   }
+                  writeEmitter = initWriteEmitterAndTerminal()
                   this.storage.writeToCoderOutputChannel(`Starting ${workspaceName}...`)
-                  workspace = await startWorkspaceIfStoppedOrFailed(restClient, workspace)
+                  workspace = await startWorkspaceIfStoppedOrFailed(restClient, binPath, workspace, writeEmitter)
                   break
                 }
               // Otherwise fall through and error.
@@ -292,7 +303,7 @@ export class Remote {
     disposables.push(this.registerLabelFormatter(remoteAuthority, workspace.owner_name, workspace.name))
 
     // If the workspace is not in a running state, try to get it running.
-    const updatedWorkspace = await this.maybeWaitForRunning(workspaceRestClient, workspace)
+    const updatedWorkspace = await this.maybeWaitForRunning(workspaceRestClient, workspace, binaryPath)
     if (!updatedWorkspace) {
       // User declined to start the workspace.
       await this.closeRemote()

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -507,11 +507,9 @@ export class Storage {
    */
   public async migrateSessionToken(label: string) {
     const oldTokenPath = this.getLegacySessionTokenPath(label)
+    const newTokenPath = this.getSessionTokenPath(label)
     try {
-      await fs.stat(oldTokenPath)
-      const newTokenPath = this.getSessionTokenPath(label)
       await fs.rename(oldTokenPath, newTokenPath)
-      return
     } catch (error) {
       if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
         return


### PR DESCRIPTION
Replace the REST-API-based start flow with one that shells out to the coder CLI.