### PR TITLE
Suppress login failure dialog on autologin

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,7 +221,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
     if (cfg.get("coder.autologin") === true) {
       const defaultUrl = cfg.get("coder.defaultUrl") || process.env.CODER_URL
       if (defaultUrl) {
-        vscode.commands.executeCommand("coder.login", defaultUrl)
+        vscode.commands.executeCommand("coder.login", defaultUrl, undefined, undefined, "true")
       }
     }
   }


### PR DESCRIPTION
This can be noisy and confusing if login attempts fail for users who don't have Coder accounts.