### PR TITLE
Use coder ssh in place of coder vscodessh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ contains the `coder-vscode` prefix, and if so we delay activation to:
 
 ```text
 Host coder-vscode.dev.coder.com--*
-	ProxyCommand "/tmp/coder" vscodessh --network-info-dir "/home/kyle/.config/Code/User/globalStorage/coder.coder-remote/net" --session-token-file "/home/kyle/.config/Code/User/globalStorage/coder.coder-remote/dev.coder.com/session_token" --url-file "/home/kyle/.config/Code/User/globalStorage/coder.coder-remote/dev.coder.com/url" %h
+	ProxyCommand "/tmp/coder" --global-config "/home/kyle/.config/Code/User/globalStorage/coder.coder-remote/dev.coder.com" ssh --stdio --network-info-dir "/home/kyle/.config/Code/User/globalStorage/coder.coder-remote/net" --ssh-host-prefix coder-vscode.dev.coder.com-- %h
 	ConnectTimeout 0
 	StrictHostKeyChecking no
 	UserKnownHostsFile /dev/null
@@ -50,8 +50,8 @@ specified port. This port is printed to the `Remote - SSH` log file in the VS
 Code Output panel in the format `-> socksPort <port> ->`. We use this port to
 find the SSH process ID that is being used by the remote session.
 
-The `vscodessh` subcommand on the `coder` binary periodically flushes its
-network information to `network-info-dir + "/" + process.ppid`. SSH executes
+The `ssh` subcommand on the `coder` binary periodically flushes its network
+information to `network-info-dir + "/" + process.ppid`. SSH executes
 `ProxyCommand`, which means the `process.ppid` will always be the matching SSH
 command.
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -538,7 +538,7 @@ async function openWorkspace(
   // when opening a workspace unless explicitly specified.
   let remoteAuthority = `ssh-remote+${AuthorityPrefix}.${toSafeHost(baseUrl)}--${workspaceOwner}--${workspaceName}`
   if (workspaceAgent) {
-    remoteAuthority += `--${workspaceAgent}`
+    remoteAuthority += `.${workspaceAgent}`
   }
 
   let newWindow = true

--- a/src/featureSet.ts
+++ b/src/featureSet.ts
@@ -3,6 +3,7 @@ import * as semver from "semver"
 export type FeatureSet = {
   vscodessh: boolean
   proxyLogDirectory: boolean
+  wildcardSSH: boolean
 }
 
 /**
@@ -21,5 +22,6 @@ export function featureSetForVersion(version: semver.SemVer | null): FeatureSet 
     // If this check didn't exist, VS Code connections would fail on
     // older versions because of an unknown CLI argument.
     proxyLogDirectory: (version?.compare("2.3.3") || 0) > 0 || version?.prerelease[0] === "devel",
+    wildcardSSH: (version?.compare("2.19.0") || 0) > 0 || version?.prerelease[0] === "devel",
   }
 }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -56,6 +56,13 @@ it("should parse authority", async () => {
     username: "foo",
     workspace: "bar",
   })
+  expect(parseRemoteAuthority("vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar.baz")).toStrictEqual({
+    agent: "baz",
+    host: "coder-vscode.dev.coder.com--foo--bar.baz",
+    label: "dev.coder.com",
+    username: "foo",
+    workspace: "bar",
+  })
 })
 
 it("escapes url host", async () => {


### PR DESCRIPTION
Build on top of recent coder PRs to make `coder ssh` provide equivalent functionality to `vscodessh`, avoiding the need for a VSCode-specific ssh subcommand.

This aligns the VS Code extension with the proposed change to the JetBrains extension in https://github.com/coder/jetbrains-coder/pull/521.

Depends on https://github.com/coder/coder/pull/16078, https://github.com/coder/coder/pull/16080, https://github.com/coder/coder/pull/16088