### PR TITLE
properly escape . in host -> ssh conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix bug where checking for overridden properties incorrectly converted host name pattern to regular expression.
+
 ## [v1.3.9](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2024-12-12)
 
 - Only show a login failure dialog for explicit logins (and not autologins).

--- a/src/sshSupport.test.ts
+++ b/src/sshSupport.test.ts
@@ -68,3 +68,39 @@ Host coder-v?code--*
     ProxyCommand: '/tmp/coder --header="X-BAR=foo" coder.dev',
   })
 })
+
+it("properly escapes meaningful regex characters", () => {
+  const properties = computeSSHProperties(
+    "coder-vscode.dev.coder.com--matalfi--dogfood",
+    `Host *
+  StrictHostKeyChecking yes
+
+# ------------START-CODER-----------
+# This section is managed by coder. DO NOT EDIT.
+#
+# You should not hand-edit this section unless you are removing it, all
+# changes will be lost when running "coder config-ssh".
+#
+Host coder.*
+        StrictHostKeyChecking=no
+        UserKnownHostsFile=/dev/null
+        ProxyCommand /usr/local/bin/coder --global-config "/Users/matifali/Library/Application Support/coderv2" ssh --stdio --ssh-host-prefix coder. %h
+# ------------END-CODER------------
+
+# --- START CODER VSCODE dev.coder.com ---
+Host coder-vscode.dev.coder.com--*
+  StrictHostKeyChecking no
+  UserKnownHostsFile=/dev/null
+  ProxyCommand "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/bin/coder-darwin-arm64" vscodessh --network-info-dir "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/net" --session-token-file "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/session" --url-file "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/url" %h
+# --- END CODER VSCODE dev.coder.com ---%
+
+`,
+  )
+
+  expect(properties).toEqual({
+    StrictHostKeyChecking: "yes",
+    ProxyCommand:
+      '"/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/bin/coder-darwin-arm64" vscodessh --network-info-dir "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/net" --session-token-file "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/session" --url-file "/Users/matifali/Library/Application Support/Code/User/globalStorage/coder.coder-remote/dev.coder.com/url" %h',
+    UserKnownHostsFile: "/dev/null",
+  })
+})

--- a/src/sshSupport.ts
+++ b/src/sshSupport.ts
@@ -47,9 +47,7 @@ export function computeSSHProperties(host: string, config: string): Record<strin
       }
     | undefined
   const configs: Array<typeof currentConfig> = []
-  // biome-ignore lint/complexity/noForEach: <explanation>
   config.split("\n").forEach((line) => {
-    // biome-ignore lint/style/noParameterAssign: <explanation>
     line = line.trim()
     if (line === "") {
       return

--- a/src/sshSupport.ts
+++ b/src/sshSupport.ts
@@ -47,7 +47,9 @@ export function computeSSHProperties(host: string, config: string): Record<strin
       }
     | undefined
   const configs: Array<typeof currentConfig> = []
+  // biome-ignore lint/complexity/noForEach: <explanation>
   config.split("\n").forEach((line) => {
+    // biome-ignore lint/style/noParameterAssign: <explanation>
     line = line.trim()
     if (line === "") {
       return
@@ -85,8 +87,11 @@ export function computeSSHProperties(host: string, config: string): Record<strin
     if (!config) {
       return
     }
+
     // In OpenSSH * matches any number of characters and ? matches exactly one.
-    if (!new RegExp("^" + config?.Host.replace(/\*/g, ".*").replace(/\?/g, ".") + "$").test(host)) {
+    if (
+      !new RegExp("^" + config?.Host.replace(/\./g, "\\.").replace(/\*/g, ".*").replace(/\?/g, ".") + "$").test(host)
+    ) {
       return
     }
     Object.assign(merged, config.properties)


### PR DESCRIPTION
When validating that our settings are not overridden by a user's ssh config, we were converting host names to regular expressions to use as matchers. In doing so, we were not correctly escaping `.` characters, which are special in regular expressions but not in host names.
This triggered a false flag when using the vscode extension alerting the user they were improperly overriding settings which they were not.
Note: this didn't come up before because we only now started using `coder.` has a host name in the ssh config as part of updating the vscode extension to simply use `coder ssh` as opposed to a dedicated `coder vscodessh` command.