### PR TITLE
Recreate REST client after starting a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recreate REST client after starting a workspace to ensure fresh TLS certificates.
+
 ## [v1.3.10](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2025-01-17)
 
 - Fix bug where checking for overridden properties incorrectly converted host name pattern to regular expression.


### PR DESCRIPTION
`maybeWaitForRunning` can take indefinitely long because it prompts for confirmation, and in that time, client certificates can expire. Start setup fresh after this call to make sure the REST client uses the latest certificates.