### PR TITLE
Recreate REST client after starting a workspace (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Recreate REST client in spots where confirmStart may have waited indefinitely.
+
 ## [v1.4.0](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2025-02-04)
 
 - Recreate REST client after starting a workspace to ensure fresh TLS certificates.


### PR DESCRIPTION
This is a followup to #431. It addresses the need to also recreate the REST client used inside `maybeWaitForRunning`, since it makes API calls before returning to `setup`.