### PR TITLE
Remove agent singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,20 @@
 
 ## Unreleased
 
-## [v1.4.1](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2025-02-19)
+- Remove agent singleton so that client TLS certificates are reloaded on every API request.
 
 ### Fixed
 
+## [v1.4.1](https://github.com/coder/vscode-coder/releases/tag/v1.4.1) (2025-02-19)
+
 - Recreate REST client in spots where confirmStart may have waited indefinitely.
 
-## [v1.4.0](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2025-02-04)
+## [v1.4.0](https://github.com/coder/vscode-coder/releases/tag/v1.4.0) (2025-02-04)
 
 - Recreate REST client after starting a workspace to ensure fresh TLS certificates.
 - Use `coder ssh` subcommand in place of `coder vscodessh`.
 
-## [v1.3.10](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2025-01-17)
+## [v1.3.10](https://github.com/coder/vscode-coder/releases/tag/v1.3.10) (2025-01-17)
 
 - Fix bug where checking for overridden properties incorrectly converted host name pattern to regular expression.
 


### PR DESCRIPTION
This causes TLS certificates to be reread on every API request, so if they are refreshed on disk, the extension will pick up the new ones. It also avoids the need to recreating the REST client (which was an ultimately unsuccessful effort to make the extension pick up new certificates).