### PR TITLE
Use Axios client for EventSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,42 @@
 
 ## Unreleased
 
+### Fixed
+
 - Remove agent singleton so that client TLS certificates are reloaded on every API request.
 - Use Axios client to receive event stream so TLS settings are properly applied.
 
-### Fixed
-
 ## [v1.4.1](https://github.com/coder/vscode-coder/releases/tag/v1.4.1) (2025-02-19)
+
+### Fixed
 
 - Recreate REST client in spots where confirmStart may have waited indefinitely.
 
 ## [v1.4.0](https://github.com/coder/vscode-coder/releases/tag/v1.4.0) (2025-02-04)
 
+### Fixed
+
 - Recreate REST client after starting a workspace to ensure fresh TLS certificates.
+
+### Changed
+
 - Use `coder ssh` subcommand in place of `coder vscodessh`.
 
 ## [v1.3.10](https://github.com/coder/vscode-coder/releases/tag/v1.3.10) (2025-01-17)
+
+### Fixed
 
 - Fix bug where checking for overridden properties incorrectly converted host name pattern to regular expression.
 
 ## [v1.3.9](https://github.com/coder/vscode-coder/releases/tag/v1.3.9) (2024-12-12)
 
+### Fixed
+
 - Only show a login failure dialog for explicit logins (and not autologins).
 
 ## [v1.3.8](https://github.com/coder/vscode-coder/releases/tag/v1.3.8) (2024-12-06)
+
+### Changed
 
 - When starting a workspace, shell out to the Coder binary instead of making an
   API call. This reduces drift between what the plugin does and the CLI does. As

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove agent singleton so that client TLS certificates are reloaded on every API request.
+- Use Axios client to receive event stream so TLS settings are properly applied.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -208,10 +208,10 @@
     ],
     "menus": {
       "commandPalette": [
-          {
-              "command": "coder.openFromSidebar",
-              "when": "false"
-          }
+        {
+          "command": "coder.openFromSidebar",
+          "when": "false"
+        }
       ],
       "view/title": [
         {
@@ -275,7 +275,7 @@
     "test:ci": "CI=true yarn test"
   },
   "devDependencies": {
-    "@types/eventsource": "^1.1.15",
+    "@types/eventsource": "^3.0.0",
     "@types/glob": "^7.1.3",
     "@types/node": "^18.0.0",
     "@types/node-forge": "^1.3.11",
@@ -309,7 +309,7 @@
   "dependencies": {
     "axios": "1.7.7",
     "date-fns": "^3.6.0",
-    "eventsource": "^2.0.2",
+    "eventsource": "^3.0.5",
     "find-process": "^1.4.7",
     "jsonc-parser": "^3.3.1",
     "memfs": "^4.9.3",

--- a/src/api-helper.ts
+++ b/src/api-helper.ts
@@ -1,5 +1,6 @@
 import { isApiError, isApiErrorResponse } from "coder/site/src/api/errors"
 import { Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
+import { ErrorEvent } from "eventsource"
 import { z } from "zod"
 
 export function errToStr(error: unknown, def: string) {
@@ -9,6 +10,8 @@ export function errToStr(error: unknown, def: string) {
     return error.response.data.message
   } else if (isApiErrorResponse(error)) {
     return error.message
+  } else if (error instanceof ErrorEvent) {
+    return error.code ? `${error.code}: ${error.message}` : error.message?.toString() || def
   } else if (typeof error === "string" && error.trim().length > 0) {
     return error
   }

--- a/src/api-helper.ts
+++ b/src/api-helper.ts
@@ -11,7 +11,7 @@ export function errToStr(error: unknown, def: string) {
   } else if (isApiErrorResponse(error)) {
     return error.message
   } else if (error instanceof ErrorEvent) {
-    return error.code ? `${error.code}: ${error.message}` : error.message?.toString() || def
+    return error.code ? `${error.code}: ${error.message || def}` : error.message || def
   } else if (typeof error === "string" && error.trim().length > 0) {
     return error
   }

--- a/src/api.ts
+++ b/src/api.ts
@@ -127,11 +127,9 @@ export function createStreamingFetchAdapter(axiosInstance: AxiosInstance) {
       },
     })
 
-    const createReader = () => stream.getReader()
-
     return {
       body: {
-        getReader: () => createReader(),
+        getReader: () => stream.getReader(),
       },
       url: urlStr,
       status: response.status,

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -1,8 +1,9 @@
 import { Api } from "coder/site/src/api/api"
 import { Workspace, WorkspaceAgent } from "coder/site/src/api/typesGenerated"
-import EventSource from "eventsource"
+import { EventSource } from "eventsource"
 import * as path from "path"
 import * as vscode from "vscode"
+import { createStreamingFetchAdapter } from "./api"
 import {
   AgentMetadataEvent,
   AgentMetadataEventSchemaArray,
@@ -228,12 +229,9 @@ export class WorkspaceProvider implements vscode.TreeDataProvider<vscode.TreeIte
 function monitorMetadata(agentId: WorkspaceAgent["id"], restClient: Api): AgentWatcher {
   // TODO: Is there a better way to grab the url and token?
   const url = restClient.getAxiosInstance().defaults.baseURL
-  const token = restClient.getAxiosInstance().defaults.headers.common["Coder-Session-Token"] as string | undefined
   const metadataUrl = new URL(`${url}/api/v2/workspaceagents/${agentId}/watch-metadata`)
   const eventSource = new EventSource(metadataUrl.toString(), {
-    headers: {
-      "Coder-Session-Token": token,
-    },
+    fetch: createStreamingFetchAdapter(restClient.getAxiosInstance()),
   })
 
   let disposed = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,12 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
-"@types/eventsource@^1.1.15":
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.15.tgz#949383d3482e20557cbecbf3b038368d94b6be27"
-  integrity sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==
+"@types/eventsource@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-3.0.0.tgz#6b1b50c677032fd3be0b5c322e8ae819b3df62eb"
+  integrity sha512-yEhFj31FTD29DtNeqePu+A+lD6loRef6YOM5XfN1kUwBHyy2DySGlA3jJU+FbQSkrfmlBVluf2Dub/OyReFGKA==
+  dependencies:
+    eventsource "*"
 
 "@types/glob@^7.1.3":
   version "7.2.0"
@@ -2529,10 +2531,17 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
-  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+eventsource-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.0.0.tgz#9303e303ef807d279ee210a17ce80f16300d9f57"
+  integrity sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==
+
+eventsource@*, eventsource@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.5.tgz#0cae1eee2d2c75894de8b02a91d84e5c57f0cc5a"
+  integrity sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==
+  dependencies:
+    eventsource-parser "^3.0.0"
 
 exec@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
This allows client TLS certificates to be used for event monitoring. Upgrade to a newer `eventsource` package that supports a custom `fetch` function, and provide a custom `fetch` function which wraps Axios.