### PR TITLE
Fix version comparison logic for checking wildcard support in "coder ssh"

### DIFF
--- a/src/featureSet.test.ts
+++ b/src/featureSet.test.ts
@@ -11,4 +11,12 @@ describe("check version support", () => {
       expect(featureSetForVersion(semver.parse(v)).proxyLogDirectory).toBeTruthy()
     })
   })
+  it("wildcard ssh", () => {
+    ;["v1.3.3+e491217", "v2.3.3+e491217"].forEach((v: string) => {
+      expect(featureSetForVersion(semver.parse(v)).wildcardSSH).toBeFalsy()
+    })
+    ;["v2.19.0", "v2.19.1", "v2.20.0+e491217", "v5.0.4+e491217"].forEach((v: string) => {
+      expect(featureSetForVersion(semver.parse(v)).wildcardSSH).toBeTruthy()
+    })
+  })
 })

--- a/src/featureSet.ts
+++ b/src/featureSet.ts
@@ -22,6 +22,6 @@ export function featureSetForVersion(version: semver.SemVer | null): FeatureSet 
     // If this check didn't exist, VS Code connections would fail on
     // older versions because of an unknown CLI argument.
     proxyLogDirectory: (version?.compare("2.3.3") || 0) > 0 || version?.prerelease[0] === "devel",
-    wildcardSSH: (version?.compare("2.19.0") || 0) > 0 || version?.prerelease[0] === "devel",
+    wildcardSSH: (version ? version.compare("2.19.0") : -1) >= 0 || version?.prerelease[0] === "devel",
   }
 }


### PR DESCRIPTION
This meant to check that the version was at least 2.19.0, but the logic was faulty.