### PR TITLE
Add CLAUDE.md with development guidelines and commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Coder Extension Development Guidelines
+
+## Build and Test Commands
+- Build: `yarn build`
+- Watch mode: `yarn watch`
+- Package: `yarn package`
+- Lint: `yarn lint`
+- Lint with auto-fix: `yarn lint:fix`
+- Run all tests: `yarn test`
+- Run specific test: `vitest ./src/filename.test.ts`
+- CI test mode: `yarn test:ci`
+
+## Code Style Guidelines
+- TypeScript with strict typing
+- No semicolons (see `.prettierrc`)
+- Trailing commas for all multi-line lists
+- 120 character line width
+- Use ES6 features (arrow functions, destructuring, etc.)
+- Use `const` by default; `let` only when necessary
+- Prefix unused variables with underscore (e.g., `_unused`)
+- Sort imports alphabetically in groups: external → parent → sibling
+- Error handling: wrap and type errors appropriately
+- Use async/await for promises, avoid explicit Promise construction where possible
+- Test files must be named `*.test.ts` and use Vitest


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>

Following Ben's instructions and initializing a Claude.md file for this repo. @aaronlehmann you mentioned Claude writing a chunk of TypeScript for you the other day so you may find this interesting: we've been asked to preview [`claude-code`](https://docs.anthropic.com/en/docs/agents-and-tools/claude-code/overview). 