### PR TITLE
docs: document other editor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Support for VSCodium with Windsurf via the Windsurf Remote OpenSSH extension
+
 ## [v1.4.2](https://github.com/coder/vscode-coder/releases/tag/v1.4.2) (2025-03-07)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-### Added
+### Changed
 
-- Support for VSCodium with Windsurf via the Windsurf Remote OpenSSH extension
+- Make the MS Remote SSH extension part of an extension pack rather than a hard dependency, to enable
+  using the plugin in other VSCode likes (codium, windsurf, etc.)
 
 ## [v1.4.2](https://github.com/coder/vscode-coder/releases/tag/v1.4.2) (2025-03-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Make the MS Remote SSH extension part of an extension pack rather than a hard dependency, to enable
-  using the plugin in other VSCode likes (codium, windsurf, etc.)
+  using the plugin in other VSCode likes (cursor, windsurf, etc.)
 
 ## [v1.4.2](https://github.com/coder/vscode-coder/releases/tag/v1.4.2) (2025-03-07)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,4 +135,4 @@ to make sure we're using up to date versions of the client.
 3. Push a tag matching the new package.json version.
 4. Update the resulting draft release with the changelog contents.
 5. Publish the draft release.
-6. Download the `.vsix` file from the release and upload to the marketplace (both Microsoft and OpenVSX).
+6. Download the `.vsix` file from the release and upload to both the [official VS Code Extension Marketplace](https://code.visualstudio.com/api/working-with-extensions/publishing-extension), and the [open-source VSX Registry](https://open-vsx.org/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,4 +135,4 @@ to make sure we're using up to date versions of the client.
 3. Push a tag matching the new package.json version.
 4. Update the resulting draft release with the changelog contents.
 5. Publish the draft release.
-6. Download the `.vsix` file from the release and upload to the marketplace.
+6. Download the `.vsix` file from the release and upload to the marketplace (both Microsoft and OpenVSX).

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [!["Join us on
 Discord"](https://badgen.net/discord/online-members/coder)](https://coder.com/chat?utm_source=github.com/coder/vscode-coder&utm_medium=github&utm_campaign=readme.md)
 
-The Coder Remote VS Code extension lets you open
+The Coder Remote extension lets you open
 [Coder](https://github.com/coder/coder) workspaces with a single click.
 
 - Open workspaces from the dashboard in a single click.
 - Automatically start workspaces when opened.
-- No command-line or local dependencies required - just install VS Code!
+- No command-line or local dependencies required - just install your editor!
 - Works in air-gapped or restricted networks. Just connect to your Coder
   deployment!
+- Supports multiple editors: VS Code, Cursor, and Windsurf.
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The Coder Remote extension lets you open
 - Works in air-gapped or restricted networks. Just connect to your Coder
   deployment!
 - Supports multiple editors: VS Code, Cursor, and Windsurf.
+  > [!NOTE]  
+  > The extension builds on VSCode provided implementations of SSH. Make sure you have
+  > the correct ssh extension installed for your editor (ms-vscode-remote.remote-ssh or 
+  > codeium.windsurf-remote-openssh for windsurf)
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [!["Join us on
 Discord"](https://badgen.net/discord/online-members/coder)](https://coder.com/chat?utm_source=github.com/coder/vscode-coder&utm_medium=github&utm_campaign=readme.md)
 
-The Coder Remote extension lets you open
-[Coder](https://github.com/coder/coder) workspaces with a single click.
+The Coder Remote extension lets you open [Coder](https://github.com/coder/coder)
+workspaces with a single click.
 
 - Open workspaces from the dashboard in a single click.
 - Automatically start workspaces when opened.
@@ -14,9 +14,10 @@ The Coder Remote extension lets you open
   deployment!
 - Supports multiple editors: VS Code, Cursor, and Windsurf.
   > [!NOTE]  
-  > The extension builds on VSCode provided implementations of SSH. Make sure you have
-  > the correct ssh extension installed for your editor (ms-vscode-remote.remote-ssh or 
-  > codeium.windsurf-remote-openssh for windsurf)
+  > The extension builds on VSCode provided implementations of SSH. Make sure
+  > you have the correct ssh extension installed for your editor
+  > (ms-vscode-remote.remote-ssh or codeium.windsurf-remote-openssh for
+  > windsurf)
 
 ![Demo](https://github.com/coder/vscode-coder/raw/main/demo.gif?raw=true)
 


### PR DESCRIPTION
Document the addition of Windsurf support and clarify that the extension now works with multiple editors beyond VS Code.