### PR TITLE
fix: disable autostart on ssh command

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -627,7 +627,7 @@ export class Remote {
     const proxyCommand = featureSet.wildcardSSH
       ? `${escape(binaryPath)}${headerArg} --global-config ${escape(
           path.dirname(this.storage.getSessionTokenPath(label)),
-        )} ssh --stdio --usage-app=vscode --network-info-dir ${escape(this.storage.getNetworkInfoPath())}${await this.formatLogArg(logDir)} --ssh-host-prefix ${hostPrefix} %h`
+        )} ssh --stdio --usage-app=vscode --disable-autostart --network-info-dir ${escape(this.storage.getNetworkInfoPath())}${await this.formatLogArg(logDir)} --ssh-host-prefix ${hostPrefix} %h`
       : `${escape(binaryPath)}${headerArg} vscodessh --network-info-dir ${escape(
           this.storage.getNetworkInfoPath(),
         )}${await this.formatLogArg(logDir)} --session-token-file ${escape(this.storage.getSessionTokenPath(label))} --url-file ${escape(


### PR DESCRIPTION
Previously we used the `coder vscodessh` command for the proxy command in the ssh config, which does not have the autostart-on-connect capabilities. This restores the previous behavior.