### PR TITLE
feat: add ability to attach to devcontainers

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -111,6 +111,61 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
         await storage.configureCli(toSafeHost(url), url, token)
 
         vscode.commands.executeCommand("coder.open", owner, workspace, agent, folder, openRecent)
+      } else if (uri.path === "/openDevContainer") {
+        const workspaceOwner = params.get("owner")
+        const workspaceName = params.get("workspace")
+        const workspaceAgent = params.get("agent")
+        const devContainerName = params.get("devContainerName")
+        const devContainerFolder = params.get("devContainerFolder")
+
+        if (!workspaceOwner) {
+          throw new Error("workspace owner must be specified as a query parameter")
+        }
+
+        if (!workspaceName) {
+          throw new Error("workspace name must be specified as a query parameter")
+        }
+
+        if (!devContainerName) {
+          throw new Error("dev container name must be specified as a query parameter")
+        }
+
+        if (!devContainerFolder) {
+          throw new Error("dev container folder must be specified as a query parameter")
+        }
+
+        // We are not guaranteed that the URL we currently have is for the URL
+        // this workspace belongs to, or that we even have a URL at all (the
+        // queries will default to localhost) so ask for it if missing.
+        // Pre-populate in case we do have the right URL so the user can just
+        // hit enter and move on.
+        const url = await commands.maybeAskUrl(params.get("url"), storage.getUrl())
+        if (url) {
+          restClient.setHost(url)
+          await storage.setUrl(url)
+        } else {
+          throw new Error("url must be provided or specified as a query parameter")
+        }
+
+        // If the token is missing we will get a 401 later and the user will be
+        // prompted to sign in again, so we do not need to ensure it is set now.
+        // For non-token auth, we write a blank token since the `vscodessh`
+        // command currently always requires a token file.  However, if there is
+        // a query parameter for non-token auth go ahead and use it anyway; all
+        // that really matters is the file is created.
+        const token = needToken() ? params.get("token") : (params.get("token") ?? "")
+
+        // Store on disk to be used by the cli.
+        await storage.configureCli(toSafeHost(url), url, token)
+
+        vscode.commands.executeCommand(
+          "coder.openDevContainer",
+          workspaceOwner,
+          workspaceName,
+          workspaceAgent,
+          devContainerName,
+          devContainerFolder,
+        )
       } else {
         throw new Error(`Unknown path ${uri.path}`)
       }
@@ -123,6 +178,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   vscode.commands.registerCommand("coder.login", commands.login.bind(commands))
   vscode.commands.registerCommand("coder.logout", commands.logout.bind(commands))
   vscode.commands.registerCommand("coder.open", commands.open.bind(commands))
+  vscode.commands.registerCommand("coder.openDevContainer", commands.openDevContainer.bind(commands))
   vscode.commands.registerCommand("coder.openFromSidebar", commands.openFromSidebar.bind(commands))
   vscode.commands.registerCommand("coder.workspace.update", commands.updateWorkspace.bind(commands))
   vscode.commands.registerCommand("coder.createWorkspace", commands.createWorkspace.bind(commands))

--- a/src/util.ts
+++ b/src/util.ts
@@ -61,6 +61,19 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
   }
 }
 
+export function toRemoteAuthority(
+  baseUrl: string,
+  workspaceOwner: string,
+  workspaceName: string,
+  workspaceAgent: string | undefined,
+): string {
+  let remoteAuthority = `ssh-remote+${AuthorityPrefix}.${toSafeHost(baseUrl)}--${workspaceOwner}--${workspaceName}`
+  if (workspaceAgent) {
+    remoteAuthority += `.${workspaceAgent}`
+  }
+  return remoteAuthority
+}
+
 /**
  * Given a URL, return the host in a format that is safe to write.
  */


### PR DESCRIPTION
Relates to https://github.com/coder/coder/issues/16426

Adds the ability to connect to a running devcontainer inside a Coder Workspace.

We add a new handler to handle the URI 
```
vscode://coder.coder-remote/openDevContainer
```

With the following query params:
- `url`: The URL of the deployment
- `token`: The API key
- `owner`: The workspace owner
- `workspace`: The workspace name
- `devContainerName`: The name of the dev container
- `devContainerFolder`: The folder inside the dev container
