### PR TITLE
fix: close sse connections

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -104,6 +104,7 @@ export function createStreamingFetchAdapter(axiosInstance: AxiosInstance) {
 
     const response = await axiosInstance.request({
       url: urlStr,
+      signal: init?.signal,
       headers: init?.headers as Record<string, string>,
       responseType: "stream",
       validateStatus: () => true, // Don't throw on any status code


### PR DESCRIPTION
We were not passing down the signal to the axios requests, causing them to be alive when they should be closed.

Related to https://github.com/coder/vscode-coder/issues/468