### PR TITLE
feat: show if using coder connect in status indicator

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -705,7 +705,7 @@ export class Remote {
       // Coder Connect doesn't populate any other stats
       if (network.using_coder_connect) {
         networkStatus.text = statusText + "Coder Connect "
-        networkStatus.tooltip = "You're connected using Coder Connect!"
+        networkStatus.tooltip = "You're connected using Coder Connect."
         networkStatus.show()
         return
       }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -698,8 +698,18 @@ export class Remote {
       derp_latency: { [key: string]: number }
       upload_bytes_sec: number
       download_bytes_sec: number
+      using_coder_connect: boolean
     }) => {
       let statusText = "$(globe) "
+
+      // Coder Connect doesn't populate any other stats
+      if (network.using_coder_connect) {
+        networkStatus.text = statusText + "Coder Connect "
+        networkStatus.tooltip = "You're connected using Coder Connect!"
+        networkStatus.show()
+        return
+      }
+
       if (network.p2p) {
         statusText += "Direct "
         networkStatus.tooltip = "You're connected peer-to-peer ✨."


### PR DESCRIPTION
Relates to https://github.com/coder/vscode-coder/issues/447

Following on from https://github.com/coder/coder/pull/17572, this PR has the extension read the `using_coder_connect` bool from the network stats file, and change the status accordingly.

<img width="362" alt="image" src="https://github.com/user-attachments/assets/e5927c69-4a17-4c68-96db-77502fd6e045" />

