### PR TITLE
fix: add connection status indicator to vscode windows, windsurf, `open-remote-ssh`

### DIFF
--- a/src/remote.ts
+++ b/src/remote.ts
@@ -19,7 +19,7 @@ import { Inbox } from "./inbox"
 import { SSHConfig, SSHValues, mergeSSHConfigValues } from "./sshConfig"
 import { computeSSHProperties, sshSupportsSetEnv } from "./sshSupport"
 import { Storage } from "./storage"
-import { AuthorityPrefix, expandPath, parseRemoteAuthority } from "./util"
+import { AuthorityPrefix, expandPath, findPort, parseRemoteAuthority } from "./util"
 import { WorkspaceMonitor } from "./workspaceMonitor"
 
 export interface RemoteDetails extends vscode.Disposable {
@@ -793,14 +793,7 @@ export class Remote {
       // this to find the SSH process that is powering this connection. That SSH
       // process will be logging network information periodically to a file.
       const text = await fs.readFile(logPath, "utf8")
-      const matches = text.match(/-> socksPort (\d+) ->/)
-      if (!matches) {
-        return
-      }
-      if (matches.length < 2) {
-        return
-      }
-      const port = Number.parseInt(matches[1])
+      const port = await findPort(text)
       if (!port) {
         return
       }

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,7 @@ export interface AuthorityParts {
 export const AuthorityPrefix = "coder-vscode"
 
 // `ms-vscode-remote.remote-ssh`: `-> socksPort <port> ->`
-// `codeium.windsurf-remote-openssh`: `=> <port>(socks) =>`
+// `codeium.windsurf-remote-openssh`, `jeanp413.open-remote-ssh`: `=> <port>(socks) =>`
 // Windows `ms-vscode-remote.remote-ssh`: `between local port <port>`
 export const RemoteSSHLogPortRegex = /(?:-> socksPort (\d+) ->|=> (\d+)\(socks\) =>|between local port (\d+))/
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,6 +13,34 @@ export interface AuthorityParts {
 // they should be handled by this extension.
 export const AuthorityPrefix = "coder-vscode"
 
+// `ms-vscode-remote.remote-ssh`: `-> socksPort <port> ->`
+// `codeium.windsurf-remote-openssh`: `=> <port>(socks) =>`
+// Windows `ms-vscode-remote.remote-ssh`: `between local port <port>`
+export const RemoteSSHLogPortRegex = /(?:-> socksPort (\d+) ->|=> (\d+)\(socks\) =>|between local port (\d+))/;
+
+
+/**
+ * Given the contents of a Remote - SSH log file, find a port number used by the
+ * SSH process. This is typically the socks port, but the local port works too.
+ *
+ * Returns null if no port is found.
+ */
+export async function findPort(text: string): Promise<number | null> {
+  const matches = text.match(RemoteSSHLogPortRegex)
+  if (!matches) {
+    return null
+  }
+  if (matches.length < 2) {
+    return null
+  }
+  const portStr = matches[1] || matches[2] || matches[3];
+  if (!portStr) {
+    return null
+  }
+
+  return Number.parseInt(portStr);
+}
+
 /**
  * Given an authority, parse into the expected parts.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,8 +16,7 @@ export const AuthorityPrefix = "coder-vscode"
 // `ms-vscode-remote.remote-ssh`: `-> socksPort <port> ->`
 // `codeium.windsurf-remote-openssh`: `=> <port>(socks) =>`
 // Windows `ms-vscode-remote.remote-ssh`: `between local port <port>`
-export const RemoteSSHLogPortRegex = /(?:-> socksPort (\d+) ->|=> (\d+)\(socks\) =>|between local port (\d+))/;
-
+export const RemoteSSHLogPortRegex = /(?:-> socksPort (\d+) ->|=> (\d+)\(socks\) =>|between local port (\d+))/
 
 /**
  * Given the contents of a Remote - SSH log file, find a port number used by the
@@ -33,12 +32,12 @@ export async function findPort(text: string): Promise<number | null> {
   if (matches.length < 2) {
     return null
   }
-  const portStr = matches[1] || matches[2] || matches[3];
+  const portStr = matches[1] || matches[2] || matches[3]
   if (!portStr) {
     return null
   }
 
-  return Number.parseInt(portStr);
+  return Number.parseInt(portStr)
 }
 
 /**


### PR DESCRIPTION
Relates to #361.

With the previous PR (Coder Connect integration), it's important that users always see this indicator, so I've added support in some extra scenarios. It already works in Cursor.

Windsurf (macOS):
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/ab9b3ef4-5d70-436e-9503-f28734e446f6" />

VS Code (Windows):
![image](https://github.com/user-attachments/assets/6a322a1f-fa0f-4b75-b339-67a861550016)
I've been told Windows used to have the indicator, but they must have changed the format of this one log line to not have parity with the other platforms.

Windsurf (Windows):
![image](https://github.com/user-attachments/assets/195ff78a-2bab-402a-90a6-66d3d752ff09)

VSCodium - `jeanp413.open-remote-ssh` (Windows):
![image](https://github.com/user-attachments/assets/62efee16-a7d4-4419-ab89-e42163cc0e6d)

VSCodium - `jeanp413.open-remote-ssh` (macOS):
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/a0da8eda-367b-42dd-99e9-861e580fee3b" />




