### PR TITLE
fix: SSHConfig: check for multiple start/end blocks

### DIFF
--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -283,7 +283,7 @@ Host afterconfig
       LogLevel: "ERROR",
     }),
   ).rejects.toThrow(
-    `Malformed config: Unterminated START CODER VSCODE dev.coder.com block: Each START block must have an END block.`,
+    `Malformed config: ${sshFilePath} has an unterminated START CODER VSCODE dev.coder.com block. Each START block must have an END block.`,
   )
 })
 
@@ -338,7 +338,7 @@ Host afterconfig
       LogLevel: "ERROR",
     }),
   ).rejects.toThrow(
-    `Malformed config: Unterminated START CODER VSCODE dev.coder.com block: Each START block must have an END block.`,
+    `Malformed config: ${sshFilePath} has an unterminated START CODER VSCODE dev.coder.com block. Each START block must have an END block.`,
   )
 })
 
@@ -388,7 +388,9 @@ Host afterconfig
       UserKnownHostsFile: "/dev/null",
       LogLevel: "ERROR",
     }),
-  ).rejects.toThrow(`Malformed config: Unterminated START CODER VSCODE block: Each START block must have an END block.`)
+  ).rejects.toThrow(
+    `Malformed config: ${sshFilePath} has an unterminated START CODER VSCODE block. Each START block must have an END block.`,
+  )
 })
 
 it("throws an error if there are more than one sections with the same label", async () => {
@@ -437,7 +439,7 @@ Host afterconfig
       LogLevel: "ERROR",
     }),
   ).rejects.toThrow(
-    `Malformed config: ssh config has 2 START CODER VSCODE dev.coder.com sections, please remove all but one.`,
+    `Malformed config: ${sshFilePath} has 2 START CODER VSCODE dev.coder.com sections. Please remove all but one.`,
   )
 })
 

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -126,25 +126,26 @@ export class SSHConfig {
     const raw = this.getRaw()
     const startBlock = this.startBlockComment(label)
     const endBlock = this.endBlockComment(label)
+
     const startBlockCount = countSubstring(startBlock, raw)
     const endBlockCount = countSubstring(endBlock, raw)
-    const startBlockIndex = raw.indexOf(startBlock)
-    const endBlockIndex = raw.indexOf(endBlock)
-    const hasBlock = startBlockIndex > -1 && endBlockIndex > -1
-
-    if (!hasBlock) {
-      return
-    }
-
     if (startBlockCount !== endBlockCount) {
       throw new SSHConfigBadFormat(
         `Malformed config: Unterminated START CODER VSCODE ${label ? label + " " : ""}block: Each START block must have an END block.`,
       )
     }
+
     if (startBlockCount > 1 || endBlockCount > 1) {
       throw new SSHConfigBadFormat(
         `Malformed config: ssh config has ${startBlockCount} START CODER VSCODE ${label ? label + " " : ""}sections, please remove all but one.`,
       )
+    }
+
+    const startBlockIndex = raw.indexOf(startBlock)
+    const endBlockIndex = raw.indexOf(endBlock)
+    const hasBlock = startBlockIndex > -1 && endBlockIndex > -1
+    if (!hasBlock) {
+      return
     }
 
     if (startBlockIndex === -1) {

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -138,12 +138,12 @@ export class SSHConfig {
 
     if (startBlockCount !== endBlockCount) {
       throw new SSHConfigBadFormat(
-        `Malformed config: ssh config has ${startBlockCount} ${label} START comments but ${endBlockCount} ${label} END comments. Each START must have a matching END.`,
+        `Malformed config: Unterminated START CODER VSCODE ${label ? label + " " : ""}block: Each START block must have an END block.`,
       )
     }
     if (startBlockCount > 1 || endBlockCount > 1) {
       throw new SSHConfigBadFormat(
-        `Malformed config: ssh config has ${startBlockCount} ${label} sections, please remove all but one.`,
+        `Malformed config: ssh config has ${startBlockCount} START CODER VSCODE ${label ? label + " " : ""}sections, please remove all but one.`,
       )
     }
 

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -131,13 +131,13 @@ export class SSHConfig {
     const endBlockCount = countSubstring(endBlock, raw)
     if (startBlockCount !== endBlockCount) {
       throw new SSHConfigBadFormat(
-        `Malformed config: Unterminated START CODER VSCODE ${label ? label + " " : ""}block: Each START block must have an END block.`,
+        `Malformed config: ${this.filePath} has an unterminated START CODER VSCODE ${label ? label + " " : ""}block. Each START block must have an END block.`,
       )
     }
 
     if (startBlockCount > 1 || endBlockCount > 1) {
       throw new SSHConfigBadFormat(
-        `Malformed config: ssh config has ${startBlockCount} START CODER VSCODE ${label ? label + " " : ""}sections, please remove all but one.`,
+        `Malformed config: ${this.filePath} has ${startBlockCount} START CODER VSCODE ${label ? label + " " : ""}sections. Please remove all but one.`,
       )
     }
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,5 +1,5 @@
-import { it, expect } from "vitest"
-import { parseRemoteAuthority, toSafeHost } from "./util"
+import { describe, it, expect } from "vitest"
+import { countSubstring, parseRemoteAuthority, toSafeHost } from "./util"
 
 it("ignore unrelated authorities", async () => {
   const tests = [
@@ -72,4 +72,36 @@ it("escapes url host", async () => {
   expect(toSafeHost("https://dev.😉-coder.com")).toBe("dev.xn---coder-vx74e.com")
   expect(() => toSafeHost("invalid url")).toThrow("Invalid URL")
   expect(toSafeHost("http://ignore-port.com:8080")).toBe("ignore-port.com")
+})
+
+describe("countSubstring", () => {
+  it("handles empty strings", () => {
+    expect(countSubstring("", "")).toBe(0)
+    expect(countSubstring("foo", "")).toBe(0)
+    expect(countSubstring("", "foo")).toBe(0)
+  })
+
+  it("handles single character", () => {
+    expect(countSubstring("a", "a")).toBe(1)
+    expect(countSubstring("a", "b")).toBe(0)
+    expect(countSubstring("a", "aa")).toBe(2)
+    expect(countSubstring("a", "aaa")).toBe(3)
+    expect(countSubstring("a", "baaa")).toBe(3)
+  })
+
+  it("handles multiple characters", () => {
+    expect(countSubstring("foo", "foo")).toBe(1)
+    expect(countSubstring("foo", "bar")).toBe(0)
+    expect(countSubstring("foo", "foobar")).toBe(1)
+    expect(countSubstring("foo", "foobarbaz")).toBe(1)
+    expect(countSubstring("foo", "foobarbazfoo")).toBe(2)
+    expect(countSubstring("foo", "foobarbazfoof")).toBe(2)
+  })
+
+  it("does not handle overlapping substrings", () => {
+    expect(countSubstring("aa", "aaa")).toBe(1)
+    expect(countSubstring("aa", "aaaa")).toBe(2)
+    expect(countSubstring("aa", "aaaaa")).toBe(2)
+    expect(countSubstring("aa", "aaaaaa")).toBe(3)
+  })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -123,9 +123,6 @@ export function expandPath(input: string): string {
 
 /**
  * Return the number of times a substring appears in a string.
- * @param needle string
- * @param haystack string
- * @returns number
  */
 export function countSubstring(needle: string, haystack: string): number {
   if (needle.length < 1 || haystack.length < 1) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -120,3 +120,22 @@ export function expandPath(input: string): string {
   const userHome = os.homedir()
   return input.replace(/\${userHome}/g, userHome)
 }
+
+/**
+ * Return the number of times a substring appears in a string.
+ * @param needle string
+ * @param haystack string
+ * @returns number
+ */
+export function countSubstring(needle: string, haystack: string): number {
+  if (needle.length < 1 || haystack.length < 1) {
+    return 0
+  }
+  let count = 0
+  let pos = haystack.indexOf(needle)
+  while (pos !== -1) {
+    count++
+    pos = haystack.indexOf(needle, pos + needle.length)
+  }
+  return count
+}


### PR DESCRIPTION
Relates to https://github.com/coder/vscode-coder/issues/504

# What this does:

Ports over the existing checks in `coder config-ssh` to handle malformed blocks.

Now, if your SSH config is malformed, you will see an error similar to the below upon attempting to connect:


* If one of the automatically generated blocks is missing a start or end comment, you will see the below error:
  ![Screenshot 2025-05-21 at 17 15 04](https://github.com/user-attachments/assets/7eea1736-500f-4642-9eef-b3eed63bdad5)

* If there is more than one block with a given label, you will see the below error:
![Screenshot 2025-05-21 at 17 14 39](https://github.com/user-attachments/assets/edfb0b6c-12bc-4730-ac90-d893bb725f96)

In both cases, it will unfortunately be necessary to edit the SSH config and fix the issue manually.