### PR TITLE
fix: SSHConfig: atomically write ssh config

### DIFF
--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -8,6 +8,7 @@ const mockFileSystem = {
   readFile: vi.fn(),
   mkdir: vi.fn(),
   writeFile: vi.fn(),
+  rename: vi.fn(),
 }
 
 afterEach(() => {
@@ -38,7 +39,12 @@ Host coder-vscode--*
 # --- END CODER VSCODE ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())
+  expect(mockFileSystem.writeFile).toBeCalledWith(
+    expect.stringContaining(sshFilePath),
+    expectedOutput,
+    expect.anything(),
+  )
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("creates a new file and adds the config", async () => {
@@ -65,7 +71,12 @@ Host coder-vscode.dev.coder.com--*
 # --- END CODER VSCODE dev.coder.com ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())
+  expect(mockFileSystem.writeFile).toBeCalledWith(
+    expect.stringContaining(sshFilePath),
+    expectedOutput,
+    expect.anything(),
+  )
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("adds a new coder config in an existent SSH configuration", async () => {
@@ -100,10 +111,11 @@ Host coder-vscode.dev.coder.com--*
   UserKnownHostsFile /dev/null
 # --- END CODER VSCODE dev.coder.com ---`
 
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+  expect(mockFileSystem.writeFile).toBeCalledWith(expect.stringContaining(sshFilePath), expectedOutput, {
     encoding: "utf-8",
     mode: 384,
   })
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("updates an existent coder config", async () => {
@@ -164,10 +176,11 @@ Host coder-vscode.dev-updated.coder.com--*
 Host *
   SetEnv TEST=1`
 
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+  expect(mockFileSystem.writeFile).toBeCalledWith(expect.stringContaining(sshFilePath), expectedOutput, {
     encoding: "utf-8",
     mode: 384,
   })
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("does not remove deployment-unaware SSH config and adds the new one", async () => {
@@ -209,10 +222,11 @@ Host coder-vscode.dev.coder.com--*
   UserKnownHostsFile /dev/null
 # --- END CODER VSCODE dev.coder.com ---`
 
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+  expect(mockFileSystem.writeFile).toBeCalledWith(expect.stringContaining(sshFilePath), expectedOutput, {
     encoding: "utf-8",
     mode: 384,
   })
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("it does not remove a user-added block that only matches the host of an old coder SSH config", async () => {
@@ -243,10 +257,11 @@ Host coder-vscode.dev.coder.com--*
   UserKnownHostsFile /dev/null
 # --- END CODER VSCODE dev.coder.com ---`
 
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+  expect(mockFileSystem.writeFile).toBeCalledWith(expect.stringContaining(sshFilePath), expectedOutput, {
     encoding: "utf-8",
     mode: 384,
   })
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("throws an error if there is a missing end block", async () => {
@@ -517,10 +532,11 @@ Host afterconfig
     LogLevel: "ERROR",
   })
 
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, {
+  expect(mockFileSystem.writeFile).toBeCalledWith(expect.stringContaining(sshFilePath), expectedOutput, {
     encoding: "utf-8",
     mode: 384,
   })
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })
 
 it("override values", async () => {
@@ -561,5 +577,10 @@ Host coder-vscode.dev.coder.com--*
 # --- END CODER VSCODE dev.coder.com ---`
 
   expect(mockFileSystem.readFile).toBeCalledWith(sshFilePath, expect.anything())
-  expect(mockFileSystem.writeFile).toBeCalledWith(sshFilePath, expectedOutput, expect.anything())
+  expect(mockFileSystem.writeFile).toBeCalledWith(
+    expect.stringContaining(sshFilePath),
+    expectedOutput,
+    expect.anything(),
+  )
+  expect(mockFileSystem.rename).toBeCalledWith(expect.stringContaining(sshFilePath + "."), sshFilePath)
 })

--- a/src/sshConfig.test.ts
+++ b/src/sshConfig.test.ts
@@ -6,7 +6,7 @@ import { SSHConfig } from "./sshConfig"
 // setting it to a different path makes it easier to test
 // and makes mistakes abundantly clear.
 const sshFilePath = "/Path/To/UserHomeDir/.sshConfigDir/sshConfigFile"
-const sshTempFilePathExpr = `^/Path/To/UserHomeDir/.sshConfigDir/.sshConfigFile.vscode-coder-tmp.[a-z0-9]+$`
+const sshTempFilePathExpr = `^/Path/To/UserHomeDir/\\.sshConfigDir/\\.sshConfigFile\\.vscode-coder-tmp\\.[a-z0-9]+$`
 
 const mockFileSystem = {
   mkdir: vi.fn(),

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -239,7 +239,9 @@ export class SSHConfig {
       recursive: true,
     })
     const randSuffix = Math.random().toString(36).substring(8)
-    const tempFilePath = `${this.filePath}.${randSuffix}`
+    const fileName = path.basename(this.filePath)
+    const dirName = path.dirname(this.filePath)
+    const tempFilePath = `${dirName}/.${fileName}.vscode-coder-tmp.${randSuffix}`
     await this.fileSystem.writeFile(tempFilePath, this.getRaw(), {
       mode: existingMode,
       encoding: "utf-8",

--- a/src/sshConfig.ts
+++ b/src/sshConfig.ts
@@ -242,11 +242,27 @@ export class SSHConfig {
     const fileName = path.basename(this.filePath)
     const dirName = path.dirname(this.filePath)
     const tempFilePath = `${dirName}/.${fileName}.vscode-coder-tmp.${randSuffix}`
-    await this.fileSystem.writeFile(tempFilePath, this.getRaw(), {
-      mode: existingMode,
-      encoding: "utf-8",
-    })
-    await this.fileSystem.rename(tempFilePath, this.filePath)
+    try {
+      await this.fileSystem.writeFile(tempFilePath, this.getRaw(), {
+        mode: existingMode,
+        encoding: "utf-8",
+      })
+    } catch (err) {
+      throw new Error(
+        `Failed to write temporary SSH config file at ${tempFilePath}: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Please check your disk space, permissions, and that the directory exists.`,
+      )
+    }
+
+    try {
+      await this.fileSystem.rename(tempFilePath, this.filePath)
+    } catch (err) {
+      throw new Error(
+        `Failed to rename temporary SSH config file at ${tempFilePath} to ${this.filePath}: ${
+          err instanceof Error ? err.message : String(err)
+        }. Please check your disk space, permissions, and that the directory exists.`,
+      )
+    }
   }
 
   public getRaw() {


### PR DESCRIPTION
Relates to https://github.com/coder/vscode-coder/issues/504

To avoid race conditions, write to a tempfile and then rename.

Smoke-tested by:

- Setting immutable flag on `/Users/cian/.ssh/config` (`sudo chflags uchg $PATH`) and validating that the rename failed:
![Screenshot 2025-05-21 at 20 13 14](https://github.com/user-attachments/assets/c38e8588-c3f8-4bd0-8d6c-ef5a9f518f96)


- Setting immutable flag on `/Users/cian/.ssh` and validating that writing the temp file failed:
![Screenshot 2025-05-21 at 20 13 56](https://github.com/user-attachments/assets/51db5205-7e33-424c-9abb-3c6100911cfe)

- Once immutable flag removed (`sudo chflags nouchg $PATH`), connecting to workspace is successful.