### PR TITLE
Revert "chore: update Node.js version to 20"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - run: yarn
 
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - run: yarn
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
 
       - run: yarn
 


### PR DESCRIPTION
Reverts coder/vscode-coder#522

This causes `yarn build` to fail, probably due to some type-checking issues. 
```console
ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts
./src/workspacesProvider.ts 251:20-28
[tsl] ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts(251,21)
      TS2339: Property 'statuses' does not exist on type 'WorkspaceApp'.
 @ ./src/extension.ts 47:29-60

ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts
./src/workspacesProvider.ts 251:36-44
[tsl] ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts(251,37)
      TS2339: Property 'statuses' does not exist on type 'WorkspaceApp'.
 @ ./src/extension.ts 47:29-60

ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts
./src/workspacesProvider.ts 252:39-47
[tsl] ERROR in /Users/matifali/repos/coder/vscode-coder/src/workspacesProvider.ts(252,40)
      TS2339: Property 'statuses' does not exist on type 'WorkspaceApp'.
 @ ./src/extension.ts 47:29-60

3 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.98.0 compiled with 3 errors in 2030 ms
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```