### PR TITLE
fix: specify `--header-command` when running `coder start`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Multiple open instances of the extension could potentially clobber writes to
   `~/.ssh/config`. Updates to this file are now atomic.
 - Add support for `anysphere.remote-ssh` Remote SSH extension.
+- Use `--header-command` properly when starting a workspace.
 
 ## [v1.9.0](https://github.com/coder/vscode-coder/releases/tag/v1.9.0) 2025-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Use `--header-command` properly when starting a workspace.
+
 ## [v1.9.1](https://github.com/coder/vscode-coder/releases/tag/v1.9.1) 2025-05-27
 
 ### Fixed
@@ -12,7 +16,6 @@
 - Multiple open instances of the extension could potentially clobber writes to
   `~/.ssh/config`. Updates to this file are now atomic.
 - Add support for `anysphere.remote-ssh` Remote SSH extension.
-- Use `--header-command` properly when starting a workspace.
 
 ## [v1.9.0](https://github.com/coder/vscode-coder/releases/tag/v1.9.0) 2025-05-15
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -9,6 +9,7 @@ import * as vscode from "vscode"
 import * as ws from "ws"
 import { errToStr } from "./api-helper"
 import { CertificateError } from "./error"
+import { getHeaderArgs } from "./headers"
 import { getProxyForUrl } from "./proxy"
 import { Storage } from "./storage"
 import { expandPath } from "./util"
@@ -168,6 +169,7 @@ export async function startWorkspaceIfStoppedOrFailed(
     const startArgs = [
       "--global-config",
       globalConfigDir,
+      ...getHeaderArgs(vscode.workspace.getConfiguration()),
       "start",
       "--yes",
       workspace.owner_name + "/" + workspace.name,

--- a/src/util.ts
+++ b/src/util.ts
@@ -93,3 +93,7 @@ export function expandPath(input: string): string {
   const userHome = os.homedir()
   return input.replace(/\${userHome}/g, userHome)
 }
+
+export function escapeCommandArg(arg: string): string {
+  return `"${arg.replace(/"/g, '\\"')}"`
+}


### PR DESCRIPTION
Closes #499

The `coder start` command can't always work properly without specifying these args (eg., getting past proxies). This refactors the code a little to make it easier to get the right argument values, and passes them to `coder start`.