### PR TITLE
chore: downgrade ua-parser-js version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "@types/vscode"
+      # These versions must match the versions specified in coder/coder exactly.
+      - dependency-name: "@types/ua-parser-js"
+      - dependency-name: "ua-parser-js"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - run: yarn
 
       - run: yarn lint
+
+      - run: yarn build
 
   test:
     runs-on: ubuntu-22.04
@@ -32,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: "18"
 
       - run: yarn
 

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
     "@types/glob": "^7.1.3",
     "@types/node": "^22.14.1",
     "@types/node-forge": "^1.3.11",
-    "@types/ua-parser-js": "^0.7.39",
+    "@types/ua-parser-js": "0.7.36",
     "@types/vscode": "^1.73.0",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
@@ -323,7 +323,7 @@
     "pretty-bytes": "^6.1.1",
     "proxy-agent": "^6.4.0",
     "semver": "^7.7.1",
-    "ua-parser-js": "^2.0.3",
+    "ua-parser-js": "1.0.40",
     "ws": "^8.18.2",
     "zod": "^3.25.1"
   },


### PR DESCRIPTION
This version must match the version in coder/coder. @aqandrew and dependabot mistakenly upgraded this version. (not mad, just letting you know)

I've updated dependabot's config to avoid it updating it to begin with, and added a build check to CI so that we can have better confidence in the build-ability of the main branch.