### PR TITLE
fix: improve `openDevContainer` support with local workspace folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update `/openDevContainer` to support all dev container features when hostPath
+  and configFile are provided.
+
 ## [v1.9.2](https://github.com/coder/vscode-coder/releases/tag/v1.9.2) 2025-06-25
 
 ### Fixed

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -620,19 +620,19 @@ export class Commands {
 	 *
 	 * Throw if not logged into a deployment.
 	 */
-	public async openDevContainer(...args: string[]): Promise<void> {
+	public async openDevContainer(
+		workspaceOwner: string,
+		workspaceName: string,
+		workspaceAgent: string,
+		devContainerName: string,
+		devContainerFolder: string,
+		localWorkspaceFolder: string = "",
+		localConfigFile: string = "",
+	): Promise<void> {
 		const baseUrl = this.restClient.getAxiosInstance().defaults.baseURL;
 		if (!baseUrl) {
 			throw new Error("You are not logged in");
 		}
-
-		const workspaceOwner = args[0] as string;
-		const workspaceName = args[1] as string;
-		const workspaceAgent = args[2] as string;
-		const devContainerName = args[3] as string;
-		const devContainerFolder = args[4] as string;
-		const localWorkspaceFolder = args[5] as string | undefined;
-		const localConfigFile = args[6] as string | undefined;
 
 		await openDevContainer(
 			baseUrl,
@@ -755,8 +755,8 @@ async function openDevContainer(
 	workspaceAgent: string,
 	devContainerName: string,
 	devContainerFolder: string,
-	localWorkspaceFolder: string | undefined,
-	localConfigFile: string | undefined,
+	localWorkspaceFolder: string = "",
+	localConfigFile: string = "",
 ) {
 	const remoteAuthority = toRemoteAuthority(
 		baseUrl,
@@ -765,20 +765,18 @@ async function openDevContainer(
 		workspaceAgent,
 	);
 
-	if (!localWorkspaceFolder) {
-		localConfigFile = undefined;
-	}
-	let configFile;
-	if (localConfigFile) {
-		configFile = {
-			path: localConfigFile,
-			scheme: "vscode-fileHost",
-		};
-	}
+	const hostPath = localWorkspaceFolder ? localWorkspaceFolder : undefined;
+	const configFile =
+		hostPath && localConfigFile
+			? {
+					path: localConfigFile,
+					scheme: "vscode-fileHost",
+				}
+			: undefined;
 	const devContainer = Buffer.from(
 		JSON.stringify({
 			containerName: devContainerName,
-			hostPath: localWorkspaceFolder,
+			hostPath,
 			configFile,
 			localDocker: false,
 		}),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -165,6 +165,8 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 				const workspaceAgent = params.get("agent");
 				const devContainerName = params.get("devContainerName");
 				const devContainerFolder = params.get("devContainerFolder");
+				const localWorkspaceFolder = params.get("localWorkspaceFolder");
+				const localConfigFile = params.get("localConfigFile");
 
 				if (!workspaceOwner) {
 					throw new Error(
@@ -187,6 +189,12 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 				if (!devContainerFolder) {
 					throw new Error(
 						"dev container folder must be specified as a query parameter",
+					);
+				}
+
+				if (localConfigFile && !localWorkspaceFolder) {
+					throw new Error(
+						"local workspace folder must be specified as a query parameter if local config file is provided",
 					);
 				}
 
@@ -228,6 +236,8 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 					workspaceAgent,
 					devContainerName,
 					devContainerFolder,
+					localWorkspaceFolder,
+					localConfigFile,
 				);
 			} else {
 				throw new Error(`Unknown path ${uri.path}`);


### PR DESCRIPTION
This change allows `localWorkspaceFolder` and `localConfigFile` to be
provided which allows us to use `dev-container` rather than
`attached-container` to enter enabling all dev container features like
file change detection and rebuilding.

Example open URL:

```
vscode://coder.coder-remote/openDevContainer?owner=mafredri&workspace=magenta-rat-8&agent=dev&devContainerName=boring_shaw&devContainerFolder=/workspaces/coder&localWorkspaceFolder=/home/coder/coder&localConfigFile=/home/coder/coder/.devcontainer/devcontainer.json
```