### PR TITLE
Use primary agent for the remote authority when opening a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   and configFile are provided.
 - Fix opening a workspace restores the VS Code session (files, tabs, context)
   of the selected agent.
+- Consistently use the same session for each agent. Previously,
+  depending on how you connected, it could be possible to get two
+  different sessions for an agent. Existing connections may still
+  have this problem, only new connections are fixed.
 
 ## [v1.9.2](https://github.com/coder/vscode-coder/releases/tag/v1.9.2) 2025-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update `/openDevContainer` to support all dev container features when hostPath
   and configFile are provided.
+- Fix opening a workspace restores the VS Code session (files, tabs, context)
+  of the selected agent.
 
 ## [v1.9.2](https://github.com/coder/vscode-coder/releases/tag/v1.9.2) 2025-06-25
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -436,6 +436,9 @@ export class Commands {
 			if (!baseUrl) {
 				throw new Error("You are not logged in");
 			}
+			if (treeItem.primaryAgentName === undefined) {
+				return;
+			}
 			await openWorkspace(
 				baseUrl,
 				treeItem.workspaceOwner,
@@ -524,6 +527,8 @@ export class Commands {
 		let folderPath: string | undefined;
 		let openRecent: boolean | undefined;
 
+		let workspace: Workspace | undefined;
+
 		const baseUrl = this.restClient.getAxiosInstance().defaults.baseURL;
 		if (!baseUrl) {
 			throw new Error("You are not logged in");
@@ -570,7 +575,7 @@ export class Commands {
 					});
 			});
 			quickPick.show();
-			const workspace = await new Promise<Workspace | undefined>((resolve) => {
+			workspace = await new Promise<Workspace | undefined>((resolve) => {
 				quickPick.onDidHide(() => {
 					resolve(undefined);
 				});
@@ -589,20 +594,31 @@ export class Commands {
 			}
 			workspaceOwner = workspace.owner_name;
 			workspaceName = workspace.name;
-
-			const agent = await this.maybeAskAgent(workspace);
-			if (!agent) {
-				// User declined to pick an agent.
-				return;
-			}
-			folderPath = agent.expanded_directory;
-			workspaceAgent = agent.name;
 		} else {
 			workspaceOwner = args[0] as string;
 			workspaceName = args[1] as string;
 			workspaceAgent = args[2] as string | undefined;
 			folderPath = args[3] as string | undefined;
 			openRecent = args[4] as boolean | undefined;
+		}
+
+		if (!workspaceAgent) {
+			if (workspace === undefined) {
+				workspace = await this.restClient.getWorkspaceByOwnerAndName(
+					workspaceOwner,
+					workspaceName,
+				);
+			}
+
+			const agent = await this.maybeAskAgent(workspace);
+			if (!agent) {
+				// User declined to pick an agent.
+				return;
+			}
+			if (!folderPath) {
+				folderPath = agent.expanded_directory;
+			}
+			workspaceAgent = agent.name;
 		}
 
 		await openWorkspace(
@@ -677,7 +693,7 @@ async function openWorkspace(
 	baseUrl: string,
 	workspaceOwner: string,
 	workspaceName: string,
-	workspaceAgent: string | undefined,
+	workspaceAgent: string,
 	folderPath: string | undefined,
 	openRecent: boolean | undefined,
 ) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -440,8 +440,8 @@ export class Commands {
 				baseUrl,
 				treeItem.workspaceOwner,
 				treeItem.workspaceName,
-				treeItem.workspaceAgent,
-				treeItem.workspaceFolderPath,
+				treeItem.primaryAgentName,
+				treeItem.primaryAgentFolderPath,
 				true,
 			);
 		} else {

--- a/src/workspacesProvider.ts
+++ b/src/workspacesProvider.ts
@@ -436,8 +436,8 @@ export class OpenableTreeItem extends vscode.TreeItem {
 
 		public readonly workspaceOwner: string,
 		public readonly workspaceName: string,
-		public readonly workspaceAgent: string | undefined,
-		public readonly workspaceFolderPath: string | undefined,
+		public readonly primaryAgentName: string | undefined,
+		public readonly primaryAgentFolderPath: string | undefined,
 
 		contextValue: CoderOpenableTreeItemType,
 	) {
@@ -476,7 +476,7 @@ class AgentTreeItem extends OpenableTreeItem {
 	}
 }
 
-export class WorkspaceTreeItem extends OpenableTreeItem {
+class WorkspaceTreeItem extends OpenableTreeItem {
 	public appStatus: {
 		name: string;
 		url?: string;
@@ -509,7 +509,7 @@ export class WorkspaceTreeItem extends OpenableTreeItem {
 				: vscode.TreeItemCollapsibleState.Expanded,
 			workspace.owner_name,
 			workspace.name,
-			undefined,
+			agents[0]?.name,
 			agents[0]?.expanded_directory,
 			agents.length > 1
 				? "coderWorkspaceMultipleAgents"


### PR DESCRIPTION
#121 

This change updates the behavior when opening a workspace from the sidebar: the first agent is now opened automatically using the same remote authority URI as when opening the agent directly.

If a workspace has multiple agents, we always open the first one, skipping the agent selection QuickPick when the folder is opened. I implemented it this way since we're already opening the `folderPath` of the first agent by default.

If this behavior should only apply when there's a single agent, it's easy to adjust. But in that case, should we also avoid passing the `folderPath` when multiple agents are present?