### PR TITLE
Use VS Code's LogOutputChannel for logging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 		);
 	}
 
-	const output = vscode.window.createOutputChannel("Coder");
+	const output = vscode.window.createOutputChannel("Coder", { log: true });
 	const storage = new Storage(
 		output,
 		ctx.globalState,


### PR DESCRIPTION
#257

In this PR I create a `LogOutputChannel` instead of the old `OutputChannel`. By default, `appendLine` uses the `info` logging level so I used `info` to log most messages, except errors where the `error` level was used.

I think all of the info can be downgraded into `debug` level actually, and the errors could be downgraded into `warn` since they are handled or thrown right away. What do you think? 