### PR TITLE
ci: preview prerelease publish on main merges (#97)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,8 +70,5 @@ jobs:
           SHORT_SHA=${GITHUB_SHA::7}
           echo "value=${BASE_VERSION}-pre.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> $GITHUB_OUTPUT
 
-      - name: Update package.json version
-        run: npm version "${{ steps.version.outputs.value }}" --no-git-tag-version
-
       - name: Publish prerelease to VS Code Marketplace
-        run: npx vsce publish --pre-release
+        run: yarn vsce publish --pre-release ${{ steps.version.outputs.value }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
   preview:
     name: preview prerelease (marketplace)
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && env.VSCE_PAT != '' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VSCE_PAT != '' }}
     runs-on: ubuntu-22.04
     needs: [lint, test]
     concurrency:
@@ -70,5 +70,8 @@ jobs:
           SHORT_SHA=${GITHUB_SHA::7}
           echo "value=${BASE_VERSION}-pre.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> $GITHUB_OUTPUT
 
+      - name: Update package.json version
+        run: npm version "${{ steps.version.outputs.value }}" --no-git-tag-version
+
       - name: Publish prerelease to VS Code Marketplace
-        run: npx vsce publish --pre-release ${{ steps.version.outputs.value }}
+        run: npx vsce publish --pre-release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,11 +44,16 @@ jobs:
 
   preview:
     name: preview prerelease (marketplace)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VSCE_PAT != ''
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && env.VSCE_PAT != '' }}
     runs-on: ubuntu-22.04
     needs: [lint, test]
+    concurrency:
+      group: preview-marketplace
+      cancel-in-progress: true
     permissions:
       contents: read
+    env:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
       - uses: actions/checkout@v4
 
@@ -66,6 +71,4 @@ jobs:
           echo "value=${BASE_VERSION}-pre.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Publish prerelease to VS Code Marketplace
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx vsce publish --pre-release --no-git-tag-version ${{ steps.version.outputs.value }}
+        run: npx vsce publish --pre-release ${{ steps.version.outputs.value }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,3 +41,31 @@ jobs:
       - run: yarn
 
       - run: yarn test:ci
+
+  preview:
+    name: preview prerelease (marketplace)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && secrets.VSCE_PAT != ''
+    runs-on: ubuntu-22.04
+    needs: [lint, test]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - run: yarn
+
+      - name: Compute prerelease version
+        id: version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          SHORT_SHA=${GITHUB_SHA::7}
+          echo "value=${BASE_VERSION}-pre.${GITHUB_RUN_NUMBER}.${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Publish prerelease to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx vsce publish --pre-release --no-git-tag-version ${{ steps.version.outputs.value }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - run: yarn
 
-      - run: npx vsce package
+      - run: yarn vsce package
 
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"lint": "eslint . --ext ts,md,json",
 		"lint:fix": "yarn lint --fix",
 		"package": "webpack --mode production --devtool hidden-source-map",
-		"package:prerelease": "npx vsce package --pre-release",
+		"package:prerelease": "yarn vsce package --pre-release",
 		"pretest": "tsc -p . --outDir out && yarn run build && yarn run lint",
 		"test": "vitest",
 		"test:ci": "CI=true yarn test",


### PR DESCRIPTION
## Summary
- Consolidate release logic: keep stable release in `release.yaml`, add prerelease publish to `ci.yaml`.
- On pushes to `main`, after lint/test, package and publish a VS Code pre-release to the Marketplace when `VSCE_PAT` is set.

## Details
- Uses `vsce publish --pre-release --no-git-tag-version <computed-version>`.
- Version format: `<pkg.version>-pre.<run_number>.<short_sha>` to ensure monotonically increasing prereleases without tags.
- Does not affect stable releases triggered by `v*` tags in `release.yaml`.

## Notes
- Set `VSCE_PAT` secret in repo or org to enable publishing.

Refs: #97