### PR TITLE
feat: use environment variables for CLI auth instead of file flags

### DIFF
--- a/src/core/cliManager.ts
+++ b/src/core/cliManager.ts
@@ -710,10 +710,10 @@ export class CliManager {
 	}
 
 	/**
-	 * Update the URL for the deployment with the provided label on disk which can
-	 * be used by the CLI via --url-file.  If the URL is falsey, do nothing.
+	 * Update the URL for the deployment with the provided label on disk for
+	 * persistence.  If the URL is falsey, do nothing.
 	 *
-	 * If the label is empty, read the old deployment-unaware config instead.
+	 * If the label is empty, use the old deployment-unaware path instead.
 	 */
 	private async updateUrlForCli(
 		label: string,
@@ -728,10 +728,9 @@ export class CliManager {
 
 	/**
 	 * Update the session token for a deployment with the provided label on disk
-	 * which can be used by the CLI via --session-token-file.  If the token is
-	 * null, do nothing.
+	 * for persistence.  If the token is null, do nothing.
 	 *
-	 * If the label is empty, read the old deployment-unaware config instead.
+	 * If the label is empty, use the old deployment-unaware path instead.
 	 */
 	private async updateTokenForCli(
 		label: string,


### PR DESCRIPTION
## Summary

Pass `CODER_URL` and `CODER_SESSION_TOKEN` via SSH `SetEnv` directive instead of using `--session-token-file` and `--url-file` CLI flags. This simplifies the auth flow by using environment variables that the CLI natively supports.

## Changes

- Remove `--session-token-file` and `--url-file` from `vscodessh` ProxyCommand
- Add `CODER_URL` and `CODER_SESSION_TOKEN` to SSH `SetEnv` directive
- Update doc comments to reflect persistence-only purpose of file storage
- Keep file-based storage for extension's own credential persistence across sessions

## How it works

Previously:
```
ProxyCommand coder vscodessh --session-token-file /path/to/session --url-file /path/to/url %h
```

Now:
```
ProxyCommand coder vscodessh %h
SetEnv CODER_URL=https://example.coder.com CODER_SESSION_TOKEN=xxx CODER_SSH_SESSION_TYPE=vscode
```

The CLI reads credentials from environment variables, which SSH passes via `SetEnv`.