### PR TITLE
Use find-process npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
 		"axios": "1.12.2",
 		"date-fns": "^3.6.0",
 		"eventsource": "^3.0.6",
-		"find-process": "https://github.com/coder/find-process#fix/sequoia-compat",
+		"find-process": "^2.0.0",
 		"jsonc-parser": "^3.3.1",
 		"openpgp": "^6.2.2",
 		"pretty-bytes": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4135,9 +4135,10 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-"find-process@https://github.com/coder/find-process#fix/sequoia-compat":
-  version "1.4.10"
-  resolved "https://github.com/coder/find-process#58804f57e5bdedad72c4319109d3ce2eae09a1ad"
+find-process@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-process/-/find-process-2.0.0.tgz#0708037e538762835773fe9f3423c4cc5669f8a3"
+  integrity sha512-YUBQnteWGASJoEVVsOXy6XtKAY2O1FCsWnnvQ8y0YwgY1rZiKeVptnFvMu6RSELZAJOGklqseTnUGGs5D0bKmg==
   dependencies:
     chalk "~4.1.2"
     commander "^12.1.0"


### PR DESCRIPTION
Now that the support for Mac OS Sequoia has been fixed, we can go back to the original npm package to get regular updates when they come.