### PR TITLE
Reconnect WebSockets when configuration settings change

### DIFF
--- a/src/configWatcher.ts
+++ b/src/configWatcher.ts
@@ -1,0 +1,39 @@
+import { isDeepStrictEqual } from "node:util";
+import * as vscode from "vscode";
+
+export interface WatchedSetting {
+	setting: string;
+	getValue: () => unknown;
+}
+
+/**
+ * Watch for configuration changes and invoke a callback when values change.
+ * Only fires when actual values change, not just when settings are touched.
+ */
+export function watchConfigurationChanges(
+	settings: WatchedSetting[],
+	onChange: (changedSettings: string[]) => void,
+): vscode.Disposable {
+	const appliedValues = new Map(settings.map((s) => [s.setting, s.getValue()]));
+
+	return vscode.workspace.onDidChangeConfiguration((e) => {
+		const changedSettings: string[] = [];
+
+		for (const { setting, getValue } of settings) {
+			if (!e.affectsConfiguration(setting)) {
+				continue;
+			}
+
+			const newValue = getValue();
+
+			if (!isDeepStrictEqual(newValue, appliedValues.get(setting))) {
+				changedSettings.push(setting);
+				appliedValues.set(setting, newValue);
+			}
+		}
+
+		if (changedSettings.length > 0) {
+			onChange(changedSettings);
+		}
+	});
+}

--- a/test/mocks/vscode.runtime.ts
+++ b/test/mocks/vscode.runtime.ts
@@ -120,8 +120,10 @@ export const workspace = {
 	onDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.event,
 
 	// test-only triggers:
-	__fireDidChangeConfiguration: onDidChangeConfiguration.fire,
-	__fireDidChangeWorkspaceFolders: onDidChangeWorkspaceFolders.fire,
+	__fireDidChangeConfiguration: (e: unknown) =>
+		onDidChangeConfiguration.fire(e),
+	__fireDidChangeWorkspaceFolders: (e: unknown) =>
+		onDidChangeWorkspaceFolders.fire(e),
 };
 
 export const env = {

--- a/test/unit/configWatcher.test.ts
+++ b/test/unit/configWatcher.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import * as vscode from "vscode";
+
+import {
+	watchConfigurationChanges,
+	type WatchedSetting,
+} from "@/configWatcher";
+
+import { MockConfigurationProvider } from "../mocks/testHelpers";
+
+describe("watchConfigurationChanges", () => {
+	const createWatcher = (...keys: string[]) => {
+		const changes: string[][] = [];
+		const settings: WatchedSetting[] = keys.map((key) => ({
+			setting: key,
+			getValue: () => vscode.workspace.getConfiguration().get(key),
+		}));
+		const watcher = watchConfigurationChanges(settings, (changed) =>
+			changes.push(changed),
+		);
+		return { changes, dispose: () => watcher.dispose() };
+	};
+
+	it("fires callback when watched setting value changes", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", "initial");
+		const { changes, dispose } = createWatcher("test.setting");
+
+		config.set("test.setting", "changed");
+
+		expect(changes).toEqual([["test.setting"]]);
+		dispose();
+	});
+
+	it("does not fire callback when value is unchanged", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", "value");
+		const { changes, dispose } = createWatcher("test.setting");
+
+		config.set("test.setting", "value");
+
+		expect(changes).toEqual([]);
+		dispose();
+	});
+
+	it("does not fire callback for unrelated settings", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", "initial");
+		const { changes, dispose } = createWatcher("test.setting");
+
+		config.set("other.setting", "some-value");
+
+		expect(changes).toEqual([]);
+		dispose();
+	});
+
+	it("tracks value changes across multiple events", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", "initial");
+		const { changes, dispose } = createWatcher("test.setting");
+
+		config.set("test.setting", "changed1");
+		config.set("test.setting", "changed2");
+		config.set("test.setting", "changed2"); // same value - no callback
+		config.set("test.setting", "changed1"); // back to changed1 - should fire
+
+		expect(changes).toEqual([
+			["test.setting"],
+			["test.setting"],
+			["test.setting"],
+		]);
+		dispose();
+	});
+
+	it("stops watching after dispose", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", "initial");
+		const { changes, dispose } = createWatcher("test.setting");
+		dispose();
+
+		config.set("test.setting", "changed");
+
+		expect(changes).toEqual([]);
+	});
+
+	it("uses deep equality for object values", () => {
+		const config = new MockConfigurationProvider();
+		config.set("test.setting", { key: "value" });
+		const { changes, dispose } = createWatcher("test.setting");
+
+		config.set("test.setting", { key: "value" }); // deep equal - no callback
+		config.set("test.setting", { key: "different" });
+
+		expect(changes).toEqual([["test.setting"]]);
+		dispose();
+	});
+});


### PR DESCRIPTION
## Summary
- WebSockets now automatically reconnect when proxy, TLS, or header settings change
- Previously users had to reload the window for these changes to take effect (or trigger a WS reconnect)
- Extracted reusable `watchConfigurationChanges` utility from `remote.ts`

## Settings that trigger reconnection
- `coder.headerCommand`
- `coder.insecure`
- `coder.tlsCertFile`, `coder.tlsKeyFile`, `coder.tlsCaFile`, `coder.tlsAltHost`
- `http.proxy`, `coder.proxyBypass`

Closes #691