### PR TITLE
Fix GPG verification with reformatted keys

### DIFF
--- a/src/pgp.ts
+++ b/src/pgp.ts
@@ -69,6 +69,7 @@ export async function verifySignature(
 			signature,
 			verificationKeys: publicKeys,
 			config: {
+				// Rational https://github.com/coder/vscode-coder/pull/748#issuecomment-3789538490
 				allowInsecureVerificationWithReformattedKeys: true,
 			},
 		});


### PR DESCRIPTION
Allow signature verification to succeed when public keys have been reformatted by enabling allowInsecureVerificationWithReformattedKeys in the OpenPGP config.