### PR TITLE
Improve workspace update confirmation to clarify restart consequence

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -596,7 +596,7 @@ export class Commands {
 			{
 				useCustom: true,
 				modal: true,
-				detail: `Updating ${createWorkspaceIdentifier(this.workspace)} to the latest template version will restart your workspace. Running processes will be stopped and unsaved work may be lost.`,
+				detail: `Update ${createWorkspaceIdentifier(this.workspace)} to the latest version?\n\nUpdating will restart your workspace which stops any running processes and may result in the loss of unsaved work.`,
 			},
 			"Update and Restart",
 		);


### PR DESCRIPTION
## Summary
- Updated the confirmation dialog when updating a workspace to make it clear that the action will restart the workspace
- Renamed the "Update" button to "Update and Restart" so users understand the consequence before confirming

Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c1419072-20b7-4460-b5fd-2da7b66cf794" />

After:
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/ec1cba07-8d68-4c01-a3df-5044b4053400" />


Updates #784