### PR TITLE
fix(ci): remove archive: false from release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: extension-pr-${{ github.event.pull_request.number }}
           path: ${{ steps.setup.outputs.packageName }}
           if-no-files-found: error
           retention-days: 7
@@ -135,7 +134,6 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
-          name: extension-main-${{ github.sha }}
           path: ${{ steps.setup.outputs.packageName }}
           if-no-files-found: error
           archive: false

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -66,7 +66,6 @@ jobs:
           name: extension-${{ steps.version.outputs.version }}
           path: ${{ steps.setup.outputs.packageName }}
           if-no-files-found: error
-          archive: false
 
   publish:
     name: Publish Extension and Create Pre-Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,6 @@ jobs:
           name: extension-${{ steps.version.outputs.version }}
           path: ${{ steps.setup.outputs.packageName }}
           if-no-files-found: error
-          archive: false
 
   publish:
     name: Publish Extension and Create Release


### PR DESCRIPTION
## Summary
- With `archive: false`, the `name` parameter is ignored and the artifact name becomes the uploaded filename
- This broke the publish workflow which downloads artifacts by name
- Removes `archive: false` from release/pre-release workflows and removes the redundant `name` from CI uploads