### PR TITLE
feat: add network slowness detection with configurable threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,16 +172,6 @@
 					"type": "number",
 					"default": 200
 				},
-				"coder.networkThreshold.downloadMbps": {
-					"markdownDescription": "Download speed threshold in Mbps. A warning indicator appears in the status bar when download speed drops below this value. Set to `0` to disable.",
-					"type": "number",
-					"default": 5
-				},
-				"coder.networkThreshold.uploadMbps": {
-					"markdownDescription": "Upload speed threshold in Mbps. A warning indicator appears in the status bar when upload speed drops below this value. Set to `0` to disable.",
-					"type": "number",
-					"default": 0
-				},
 				"coder.httpClientLogLevel": {
 					"markdownDescription": "Controls the verbosity of HTTP client logging. This affects what details are logged for each HTTP request and response.",
 					"type": "string",

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
 				"coder.networkThreshold.latencyMs": {
 					"markdownDescription": "Latency threshold in milliseconds. A warning indicator appears in the status bar when latency exceeds this value. Set to `0` to disable.",
 					"type": "number",
+					"minimum": 0,
 					"default": 250
 				},
 				"coder.httpClientLogLevel": {

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 				"coder.networkThreshold.latencyMs": {
 					"markdownDescription": "Latency threshold in milliseconds. A warning indicator appears in the status bar when latency exceeds this value. Set to `0` to disable.",
 					"type": "number",
-					"default": 200
+					"default": 250
 				},
 				"coder.httpClientLogLevel": {
 					"markdownDescription": "Controls the verbosity of HTTP client logging. This affects what details are logged for each HTTP request and response.",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,21 @@
 					"type": "boolean",
 					"default": false
 				},
+				"coder.networkThreshold.latencyMs": {
+					"markdownDescription": "Latency threshold in milliseconds. A warning indicator appears in the status bar when latency exceeds this value. Set to `0` to disable.",
+					"type": "number",
+					"default": 200
+				},
+				"coder.networkThreshold.downloadMbps": {
+					"markdownDescription": "Download speed threshold in Mbps. A warning indicator appears in the status bar when download speed drops below this value. Set to `0` to disable.",
+					"type": "number",
+					"default": 5
+				},
+				"coder.networkThreshold.uploadMbps": {
+					"markdownDescription": "Upload speed threshold in Mbps. A warning indicator appears in the status bar when upload speed drops below this value. Set to `0` to disable.",
+					"type": "number",
+					"default": 0
+				},
 				"coder.httpClientLogLevel": {
 					"markdownDescription": "Controls the verbosity of HTTP client logging. This affects what details are logged for each HTTP request and response.",
 					"type": "string",

--- a/src/remote/networkStatus.ts
+++ b/src/remote/networkStatus.ts
@@ -4,81 +4,52 @@ import * as vscode from "vscode";
 import type { NetworkInfo } from "./sshProcess";
 
 /** Number of consecutive polls required to trigger or clear a warning */
-const WARNING_DEBOUNCE_THRESHOLD = 3;
+const WARNING_DEBOUNCE_THRESHOLD = 2;
 
 const WARNING_BACKGROUND = new vscode.ThemeColor(
 	"statusBarItem.warningBackground",
 );
 
-export interface NetworkThresholds {
+interface NetworkThresholds {
 	latencyMs: number;
 }
 
-function getThresholdConfig(): NetworkThresholds {
-	const cfg = vscode.workspace.getConfiguration("coder");
-	return {
-		latencyMs: cfg.get<number>("networkThreshold.latencyMs", 200),
-	};
-}
-
-export function isLatencySlow(
-	network: NetworkInfo,
-	thresholds: NetworkThresholds,
-): boolean {
-	return thresholds.latencyMs > 0 && network.latency > thresholds.latencyMs;
-}
-
-export function buildNetworkTooltip(
-	network: NetworkInfo,
-	latencySlow: boolean,
-	thresholds: NetworkThresholds,
-): vscode.MarkdownString {
-	const fmt = (bytesPerSec: number) =>
-		prettyBytes(bytesPerSec * 8, { bits: true }) + "/s";
-
-	const sections: string[] = [];
-
-	if (latencySlow) {
-		sections.push("$(warning) **Slow connection detected**");
-	}
-
-	const metrics: string[] = [];
-	metrics.push(
-		latencySlow
-			? `Latency: ${network.latency.toFixed(2)}ms (threshold: ${thresholds.latencyMs}ms)`
-			: `Latency: ${network.latency.toFixed(2)}ms`,
-	);
-	metrics.push(`Download: ${fmt(network.download_bytes_sec)}`);
-	metrics.push(`Upload: ${fmt(network.upload_bytes_sec)}`);
-
+function connectionLabel(network: NetworkInfo): string {
 	if (network.using_coder_connect) {
-		metrics.push("Connection: Coder Connect");
-	} else if (network.p2p) {
-		metrics.push("Connection: Direct (P2P)");
-	} else {
-		metrics.push(`Connection: ${network.preferred_derp} (relay)`);
+		return "Coder Connect";
 	}
-
-	// Two trailing spaces + \n = hard line break (tight rows within a section).
-	sections.push(metrics.join("  \n"));
-
-	if (latencySlow) {
-		sections.push(
-			"[$(pulse) Ping workspace](command:coder.pingWorkspace) · " +
-				"[$(gear) Configure threshold](command:workbench.action.openSettings?%22coder.networkThreshold%22)",
-		);
+	if (network.p2p) {
+		return "Direct";
 	}
+	return network.preferred_derp;
+}
 
-	// Blank line between sections = paragraph break.
-	const md = new vscode.MarkdownString(sections.join("\n\n"));
-	md.isTrusted = true;
-	md.supportThemeIcons = true;
-	return md;
+function connectionSummary(network: NetworkInfo): string {
+	if (network.p2p) {
+		return "$(zap) Directly connected peer-to-peer.";
+	}
+	return `$(broadcast) Connected via ${network.preferred_derp} relay. Will switch to peer-to-peer when available.`;
+}
+
+function formatLatency(latency: number, isStale: boolean): string | undefined {
+	if (latency <= 0) {
+		return undefined;
+	}
+	return isStale ? `(~${latency.toFixed(2)}ms)` : `(${latency.toFixed(2)}ms)`;
+}
+
+function buildStatusText(network: NetworkInfo, isStale: boolean): string {
+	const parts = ["$(globe)", connectionLabel(network)];
+	const latency = formatLatency(network.latency, isStale);
+	if (latency) {
+		parts.push(latency);
+	}
+	return parts.join(" ");
 }
 
 /**
- * Manages network status bar presentation and slowness warning state.
- * Owns the warning debounce logic and status bar updates.
+ * Manages network status bar presentation.
+ * Warning state is debounced over consecutive polls to avoid flicker.
  */
 export class NetworkStatusReporter {
 	private warningCounter = 0;
@@ -87,55 +58,34 @@ export class NetworkStatusReporter {
 	constructor(private readonly statusBarItem: vscode.StatusBarItem) {}
 
 	update(network: NetworkInfo, isStale: boolean): void {
-		let statusText = "$(globe) ";
+		const thresholds: NetworkThresholds = {
+			latencyMs: vscode.workspace
+				.getConfiguration("coder")
+				.get<number>("networkThreshold.latencyMs", 250),
+		};
+		const isSlow =
+			!network.using_coder_connect &&
+			thresholds.latencyMs > 0 &&
+			network.latency > thresholds.latencyMs;
+		this.updateWarningState(isSlow);
 
-		// Coder Connect doesn't populate any other stats
-		if (network.using_coder_connect) {
-			this.warningCounter = 0;
-			this.isWarningActive = false;
-			this.statusBarItem.text = statusText + "Coder Connect ";
-			this.statusBarItem.tooltip = "You're connected using Coder Connect.";
-			this.statusBarItem.backgroundColor = undefined;
-			this.statusBarItem.command = undefined;
-			this.statusBarItem.show();
-			return;
-		}
-
-		const thresholds = getThresholdConfig();
-		const latencySlow = isLatencySlow(network, thresholds);
-		this.updateWarningState(latencySlow);
-
-		if (network.p2p) {
-			statusText += "Direct ";
-		} else {
-			statusText += network.preferred_derp + " ";
-		}
-
-		const latencyText = isStale
-			? `(~${network.latency.toFixed(2)}ms)`
-			: `(${network.latency.toFixed(2)}ms)`;
-		statusText += latencyText;
-		this.statusBarItem.text = statusText;
-
-		if (this.isWarningActive) {
-			this.statusBarItem.backgroundColor = WARNING_BACKGROUND;
-			this.statusBarItem.command = "coder.pingWorkspace";
-		} else {
-			this.statusBarItem.backgroundColor = undefined;
-			this.statusBarItem.command = undefined;
-		}
-
-		this.statusBarItem.tooltip = buildNetworkTooltip(
+		this.statusBarItem.text = buildStatusText(network, isStale);
+		this.statusBarItem.tooltip = this.buildTooltip(
 			network,
-			this.isWarningActive,
 			thresholds,
+			isStale,
 		);
-
+		this.statusBarItem.backgroundColor = this.isWarningActive
+			? WARNING_BACKGROUND
+			: undefined;
+		this.statusBarItem.command = this.isWarningActive
+			? "coder.pingWorkspace"
+			: undefined;
 		this.statusBarItem.show();
 	}
 
-	private updateWarningState(latencySlow: boolean): void {
-		if (latencySlow) {
+	private updateWarningState(isSlow: boolean): void {
+		if (isSlow) {
 			this.warningCounter = Math.min(
 				this.warningCounter + 1,
 				WARNING_DEBOUNCE_THRESHOLD,
@@ -150,4 +100,64 @@ export class NetworkStatusReporter {
 			this.isWarningActive = false;
 		}
 	}
+
+	private buildTooltip(
+		network: NetworkInfo,
+		thresholds: NetworkThresholds,
+		isStale: boolean,
+	): vscode.MarkdownString {
+		// The Coder CLI only populates `using_coder_connect: true` for this path
+		// and leaves latency/throughput at zero, so we show a dedicated message
+		// instead of rendering empty metric lines.
+		if (network.using_coder_connect) {
+			return markdown(
+				"$(cloud) Connected using Coder Connect. Detailed network stats aren't collected for this connection type.",
+			);
+		}
+
+		const fmt = (bytesPerSec: number) =>
+			prettyBytes(bytesPerSec * 8, { bits: true }) + "/s";
+
+		const sections: string[] = [];
+		if (this.isWarningActive) {
+			sections.push("$(warning) **Slow connection detected**");
+		}
+		sections.push(connectionSummary(network));
+
+		const metrics: string[] = [];
+		if (network.latency > 0) {
+			metrics.push(
+				thresholds.latencyMs > 0
+					? `Latency: ${network.latency.toFixed(2)}ms (threshold: ${thresholds.latencyMs}ms)`
+					: `Latency: ${network.latency.toFixed(2)}ms`,
+			);
+		}
+		metrics.push(`Download: ${fmt(network.download_bytes_sec)}`);
+		metrics.push(`Upload: ${fmt(network.upload_bytes_sec)}`);
+		// Two trailing spaces + \n = hard line break (tight rows within a section).
+		sections.push(metrics.join("  \n"));
+
+		if (this.isWarningActive) {
+			sections.push(
+				"[$(pulse) Run latency test](command:coder.pingWorkspace) · " +
+					"[$(gear) Configure threshold](command:workbench.action.openSettings?%22coder.networkThreshold%22)",
+			);
+		}
+
+		if (isStale) {
+			sections.push(
+				"$(history) Readings are stale; waiting for a fresh sample.",
+			);
+		}
+
+		// Blank line between sections = paragraph break.
+		return markdown(sections.join("\n\n"));
+	}
+}
+
+function markdown(value: string): vscode.MarkdownString {
+	const md = new vscode.MarkdownString(value);
+	md.isTrusted = true;
+	md.supportThemeIcons = true;
+	return md;
 }

--- a/src/remote/networkStatus.ts
+++ b/src/remote/networkStatus.ts
@@ -10,18 +10,13 @@ const WARNING_BACKGROUND = new vscode.ThemeColor(
 	"statusBarItem.warningBackground",
 );
 
+const CODER_CONNECT_TEXT = "$(globe) Coder Connect";
+const CODER_CONNECT_TOOLTIP = markdown(
+	"$(cloud) Connected using Coder Connect. Detailed network stats aren't collected for this connection type.",
+);
+
 interface NetworkThresholds {
 	latencyMs: number;
-}
-
-function connectionLabel(network: NetworkInfo): string {
-	if (network.using_coder_connect) {
-		return "Coder Connect";
-	}
-	if (network.p2p) {
-		return "Direct";
-	}
-	return network.preferred_derp;
 }
 
 function connectionSummary(network: NetworkInfo): string {
@@ -31,20 +26,10 @@ function connectionSummary(network: NetworkInfo): string {
 	return `$(broadcast) Connected via ${network.preferred_derp} relay. Will switch to peer-to-peer when available.`;
 }
 
-function formatLatency(latency: number, isStale: boolean): string | undefined {
-	if (latency <= 0) {
-		return undefined;
-	}
-	return isStale ? `(~${latency.toFixed(2)}ms)` : `(${latency.toFixed(2)}ms)`;
-}
-
 function buildStatusText(network: NetworkInfo, isStale: boolean): string {
-	const parts = ["$(globe)", connectionLabel(network)];
-	const latency = formatLatency(network.latency, isStale);
-	if (latency) {
-		parts.push(latency);
-	}
-	return parts.join(" ");
+	const label = network.p2p ? "Direct" : network.preferred_derp;
+	const staleMarker = isStale ? "~" : "";
+	return `$(globe) ${label} (${staleMarker}${network.latency.toFixed(2)}ms)`;
 }
 
 /**
@@ -58,15 +43,26 @@ export class NetworkStatusReporter {
 	constructor(private readonly statusBarItem: vscode.StatusBarItem) {}
 
 	update(network: NetworkInfo, isStale: boolean): void {
+		// Coder Connect doesn't populate latency/throughput, so we show a dedicated
+		// message and skip the slowness machinery entirely.
+		if (network.using_coder_connect) {
+			this.warningCounter = 0;
+			this.isWarningActive = false;
+			this.statusBarItem.text = CODER_CONNECT_TEXT;
+			this.statusBarItem.tooltip = CODER_CONNECT_TOOLTIP;
+			this.statusBarItem.backgroundColor = undefined;
+			this.statusBarItem.command = undefined;
+			this.statusBarItem.show();
+			return;
+		}
+
 		const thresholds: NetworkThresholds = {
 			latencyMs: vscode.workspace
 				.getConfiguration("coder")
 				.get<number>("networkThreshold.latencyMs", 250),
 		};
 		const isSlow =
-			!network.using_coder_connect &&
-			thresholds.latencyMs > 0 &&
-			network.latency > thresholds.latencyMs;
+			thresholds.latencyMs > 0 && network.latency > thresholds.latencyMs;
 		this.updateWarningState(isSlow);
 
 		this.statusBarItem.text = buildStatusText(network, isStale);
@@ -106,15 +102,6 @@ export class NetworkStatusReporter {
 		thresholds: NetworkThresholds,
 		isStale: boolean,
 	): vscode.MarkdownString {
-		// The Coder CLI only populates `using_coder_connect: true` for this path
-		// and leaves latency/throughput at zero, so we show a dedicated message
-		// instead of rendering empty metric lines.
-		if (network.using_coder_connect) {
-			return markdown(
-				"$(cloud) Connected using Coder Connect. Detailed network stats aren't collected for this connection type.",
-			);
-		}
-
 		const fmt = (bytesPerSec: number) =>
 			prettyBytes(bytesPerSec * 8, { bits: true }) + "/s";
 
@@ -124,16 +111,13 @@ export class NetworkStatusReporter {
 		}
 		sections.push(connectionSummary(network));
 
-		const metrics: string[] = [];
-		if (network.latency > 0) {
-			metrics.push(
-				thresholds.latencyMs > 0
-					? `Latency: ${network.latency.toFixed(2)}ms (threshold: ${thresholds.latencyMs}ms)`
-					: `Latency: ${network.latency.toFixed(2)}ms`,
-			);
-		}
-		metrics.push(`Download: ${fmt(network.download_bytes_sec)}`);
-		metrics.push(`Upload: ${fmt(network.upload_bytes_sec)}`);
+		const thresholdSuffix =
+			thresholds.latencyMs > 0 ? ` (threshold: ${thresholds.latencyMs}ms)` : "";
+		const metrics = [
+			`Latency: ${network.latency.toFixed(2)}ms${thresholdSuffix}`,
+			`Download: ${fmt(network.download_bytes_sec)}`,
+			`Upload: ${fmt(network.upload_bytes_sec)}`,
+		];
 		// Two trailing spaces + \n = hard line break (tight rows within a section).
 		sections.push(metrics.join("  \n"));
 

--- a/src/remote/networkStatus.ts
+++ b/src/remote/networkStatus.ts
@@ -3,116 +3,74 @@ import * as vscode from "vscode";
 
 import type { NetworkInfo } from "./sshProcess";
 
-/** Bytes per second in 1 Mbps */
-const BYTES_PER_MBPS = 125_000;
-
 /** Number of consecutive polls required to trigger or clear a warning */
 const WARNING_DEBOUNCE_THRESHOLD = 3;
 
-export interface ThresholdViolations {
-	latency: boolean;
-	download: boolean;
-	upload: boolean;
+const WARNING_BACKGROUND = new vscode.ThemeColor(
+	"statusBarItem.warningBackground",
+);
+
+export interface NetworkThresholds {
+	latencyMs: number;
 }
 
-const NO_VIOLATIONS: ThresholdViolations = {
-	latency: false,
-	download: false,
-	upload: false,
-};
-
-export function getThresholdConfig(): {
-	latencyMs: number;
-	downloadMbps: number;
-	uploadMbps: number;
-} {
+function getThresholdConfig(): NetworkThresholds {
 	const cfg = vscode.workspace.getConfiguration("coder");
 	return {
 		latencyMs: cfg.get<number>("networkThreshold.latencyMs", 200),
-		downloadMbps: cfg.get<number>("networkThreshold.downloadMbps", 5),
-		uploadMbps: cfg.get<number>("networkThreshold.uploadMbps", 0),
 	};
 }
 
-export function checkThresholdViolations(
+export function isLatencySlow(
 	network: NetworkInfo,
-	thresholds: { latencyMs: number; downloadMbps: number; uploadMbps: number },
-): ThresholdViolations {
-	return {
-		latency: thresholds.latencyMs > 0 && network.latency > thresholds.latencyMs,
-		download:
-			thresholds.downloadMbps > 0 &&
-			network.download_bytes_sec / BYTES_PER_MBPS < thresholds.downloadMbps,
-		upload:
-			thresholds.uploadMbps > 0 &&
-			network.upload_bytes_sec / BYTES_PER_MBPS < thresholds.uploadMbps,
-	};
-}
-
-export function hasAnyViolation(violations: ThresholdViolations): boolean {
-	return violations.latency || violations.download || violations.upload;
-}
-
-export function getWarningCommand(violations: ThresholdViolations): string {
-	const latencyOnly =
-		violations.latency && !violations.download && !violations.upload;
-	const throughputOnly =
-		!violations.latency && (violations.download || violations.upload);
-
-	if (latencyOnly) {
-		return "coder.pingWorkspace";
-	}
-	if (throughputOnly) {
-		return "coder.speedTest";
-	}
-	// Multiple types of violations — let the user choose
-	return "coder.showNetworkDiagnostics";
+	thresholds: NetworkThresholds,
+): boolean {
+	return thresholds.latencyMs > 0 && network.latency > thresholds.latencyMs;
 }
 
 export function buildNetworkTooltip(
 	network: NetworkInfo,
-	violations: ThresholdViolations,
-	thresholds: { latencyMs: number; downloadMbps: number; uploadMbps: number },
+	latencySlow: boolean,
+	thresholds: NetworkThresholds,
 ): vscode.MarkdownString {
 	const fmt = (bytesPerSec: number) =>
 		prettyBytes(bytesPerSec * 8, { bits: true }) + "/s";
 
-	const lines: string[] = [];
+	const sections: string[] = [];
 
-	let latencyLine = `Latency: ${network.latency.toFixed(2)}ms`;
-	if (violations.latency) {
-		latencyLine += ` $(warning) (threshold: ${thresholds.latencyMs}ms)`;
+	if (latencySlow) {
+		sections.push("$(warning) **Slow connection detected**");
 	}
-	lines.push(latencyLine);
 
-	let downloadLine = `Download: ${fmt(network.download_bytes_sec)}`;
-	if (violations.download) {
-		downloadLine += ` $(warning) (threshold: ${thresholds.downloadMbps} Mbit/s)`;
-	}
-	lines.push(downloadLine);
-
-	let uploadLine = `Upload: ${fmt(network.upload_bytes_sec)}`;
-	if (violations.upload) {
-		uploadLine += ` $(warning) (threshold: ${thresholds.uploadMbps} Mbit/s)`;
-	}
-	lines.push(uploadLine);
+	const metrics: string[] = [];
+	metrics.push(
+		latencySlow
+			? `Latency: ${network.latency.toFixed(2)}ms (threshold: ${thresholds.latencyMs}ms)`
+			: `Latency: ${network.latency.toFixed(2)}ms`,
+	);
+	metrics.push(`Download: ${fmt(network.download_bytes_sec)}`);
+	metrics.push(`Upload: ${fmt(network.upload_bytes_sec)}`);
 
 	if (network.using_coder_connect) {
-		lines.push("Connection: Coder Connect");
+		metrics.push("Connection: Coder Connect");
 	} else if (network.p2p) {
-		lines.push("Connection: Direct (P2P)");
+		metrics.push("Connection: Direct (P2P)");
 	} else {
-		lines.push(`Connection: ${network.preferred_derp} (relay)`);
+		metrics.push(`Connection: ${network.preferred_derp} (relay)`);
 	}
 
-	if (hasAnyViolation(violations)) {
-		lines.push("");
-		lines.push(
-			"_Click for diagnostics_ | [Configure thresholds](command:workbench.action.openSettings?%22coder.networkThreshold%22)",
+	// Two trailing spaces + \n = hard line break (tight rows within a section).
+	sections.push(metrics.join("  \n"));
+
+	if (latencySlow) {
+		sections.push(
+			"[$(pulse) Ping workspace](command:coder.pingWorkspace) · " +
+				"[$(gear) Configure threshold](command:workbench.action.openSettings?%22coder.networkThreshold%22)",
 		);
 	}
 
-	const md = new vscode.MarkdownString(lines.join("\n\n"));
+	// Blank line between sections = paragraph break.
+	const md = new vscode.MarkdownString(sections.join("\n\n"));
 	md.isTrusted = true;
 	md.supportThemeIcons = true;
 	return md;
@@ -120,35 +78,13 @@ export function buildNetworkTooltip(
 
 /**
  * Manages network status bar presentation and slowness warning state.
- * Owns the warning debounce logic, status bar updates, and the
- * diagnostics command registration.
+ * Owns the warning debounce logic and status bar updates.
  */
-export class NetworkStatusReporter implements vscode.Disposable {
+export class NetworkStatusReporter {
 	private warningCounter = 0;
 	private isWarningActive = false;
-	private readonly diagnosticsCommand: vscode.Disposable;
 
-	constructor(private readonly statusBarItem: vscode.StatusBarItem) {
-		this.diagnosticsCommand = vscode.commands.registerCommand(
-			"coder.showNetworkDiagnostics",
-			async () => {
-				const pick = await vscode.window.showQuickPick(
-					[
-						{ label: "Run Ping", commandId: "coder.pingWorkspace" },
-						{ label: "Run Speed Test", commandId: "coder.speedTest" },
-						{
-							label: "Create Support Bundle",
-							commandId: "coder.supportBundle",
-						},
-					],
-					{ placeHolder: "Select a diagnostic to run" },
-				);
-				if (pick) {
-					await vscode.commands.executeCommand(pick.commandId);
-				}
-			},
-		);
-	}
+	constructor(private readonly statusBarItem: vscode.StatusBarItem) {}
 
 	update(network: NetworkInfo, isStale: boolean): void {
 		let statusText = "$(globe) ";
@@ -166,8 +102,8 @@ export class NetworkStatusReporter implements vscode.Disposable {
 		}
 
 		const thresholds = getThresholdConfig();
-		const violations = checkThresholdViolations(network, thresholds);
-		const activeViolations = this.updateWarningState(violations);
+		const latencySlow = isLatencySlow(network, thresholds);
+		this.updateWarningState(latencySlow);
 
 		if (network.p2p) {
 			statusText += "Direct ";
@@ -182,10 +118,8 @@ export class NetworkStatusReporter implements vscode.Disposable {
 		this.statusBarItem.text = statusText;
 
 		if (this.isWarningActive) {
-			this.statusBarItem.backgroundColor = new vscode.ThemeColor(
-				"statusBarItem.warningBackground",
-			);
-			this.statusBarItem.command = getWarningCommand(activeViolations);
+			this.statusBarItem.backgroundColor = WARNING_BACKGROUND;
+			this.statusBarItem.command = "coder.pingWorkspace";
 		} else {
 			this.statusBarItem.backgroundColor = undefined;
 			this.statusBarItem.command = undefined;
@@ -193,21 +127,15 @@ export class NetworkStatusReporter implements vscode.Disposable {
 
 		this.statusBarItem.tooltip = buildNetworkTooltip(
 			network,
-			activeViolations,
+			this.isWarningActive,
 			thresholds,
 		);
 
 		this.statusBarItem.show();
 	}
 
-	/**
-	 * Updates the debounce counter and returns the effective violations
-	 * (current violations when warning is active, all-clear otherwise).
-	 */
-	private updateWarningState(
-		violations: ThresholdViolations,
-	): ThresholdViolations {
-		if (hasAnyViolation(violations)) {
+	private updateWarningState(latencySlow: boolean): void {
+		if (latencySlow) {
 			this.warningCounter = Math.min(
 				this.warningCounter + 1,
 				WARNING_DEBOUNCE_THRESHOLD,
@@ -221,11 +149,5 @@ export class NetworkStatusReporter implements vscode.Disposable {
 		} else if (this.warningCounter === 0) {
 			this.isWarningActive = false;
 		}
-
-		return this.isWarningActive ? violations : NO_VIOLATIONS;
-	}
-
-	dispose(): void {
-		this.diagnosticsCommand.dispose();
 	}
 }

--- a/src/remote/networkStatus.ts
+++ b/src/remote/networkStatus.ts
@@ -1,0 +1,231 @@
+import prettyBytes from "pretty-bytes";
+import * as vscode from "vscode";
+
+import type { NetworkInfo } from "./sshProcess";
+
+/** Bytes per second in 1 Mbps */
+const BYTES_PER_MBPS = 125_000;
+
+/** Number of consecutive polls required to trigger or clear a warning */
+const WARNING_DEBOUNCE_THRESHOLD = 3;
+
+export interface ThresholdViolations {
+	latency: boolean;
+	download: boolean;
+	upload: boolean;
+}
+
+const NO_VIOLATIONS: ThresholdViolations = {
+	latency: false,
+	download: false,
+	upload: false,
+};
+
+export function getThresholdConfig(): {
+	latencyMs: number;
+	downloadMbps: number;
+	uploadMbps: number;
+} {
+	const cfg = vscode.workspace.getConfiguration("coder");
+	return {
+		latencyMs: cfg.get<number>("networkThreshold.latencyMs", 200),
+		downloadMbps: cfg.get<number>("networkThreshold.downloadMbps", 5),
+		uploadMbps: cfg.get<number>("networkThreshold.uploadMbps", 0),
+	};
+}
+
+export function checkThresholdViolations(
+	network: NetworkInfo,
+	thresholds: { latencyMs: number; downloadMbps: number; uploadMbps: number },
+): ThresholdViolations {
+	return {
+		latency: thresholds.latencyMs > 0 && network.latency > thresholds.latencyMs,
+		download:
+			thresholds.downloadMbps > 0 &&
+			network.download_bytes_sec / BYTES_PER_MBPS < thresholds.downloadMbps,
+		upload:
+			thresholds.uploadMbps > 0 &&
+			network.upload_bytes_sec / BYTES_PER_MBPS < thresholds.uploadMbps,
+	};
+}
+
+export function hasAnyViolation(violations: ThresholdViolations): boolean {
+	return violations.latency || violations.download || violations.upload;
+}
+
+export function getWarningCommand(violations: ThresholdViolations): string {
+	const latencyOnly =
+		violations.latency && !violations.download && !violations.upload;
+	const throughputOnly =
+		!violations.latency && (violations.download || violations.upload);
+
+	if (latencyOnly) {
+		return "coder.pingWorkspace";
+	}
+	if (throughputOnly) {
+		return "coder.speedTest";
+	}
+	// Multiple types of violations — let the user choose
+	return "coder.showNetworkDiagnostics";
+}
+
+export function buildNetworkTooltip(
+	network: NetworkInfo,
+	violations: ThresholdViolations,
+	thresholds: { latencyMs: number; downloadMbps: number; uploadMbps: number },
+): vscode.MarkdownString {
+	const fmt = (bytesPerSec: number) =>
+		prettyBytes(bytesPerSec * 8, { bits: true }) + "/s";
+
+	const lines: string[] = [];
+
+	let latencyLine = `Latency: ${network.latency.toFixed(2)}ms`;
+	if (violations.latency) {
+		latencyLine += ` $(warning) (threshold: ${thresholds.latencyMs}ms)`;
+	}
+	lines.push(latencyLine);
+
+	let downloadLine = `Download: ${fmt(network.download_bytes_sec)}`;
+	if (violations.download) {
+		downloadLine += ` $(warning) (threshold: ${thresholds.downloadMbps} Mbit/s)`;
+	}
+	lines.push(downloadLine);
+
+	let uploadLine = `Upload: ${fmt(network.upload_bytes_sec)}`;
+	if (violations.upload) {
+		uploadLine += ` $(warning) (threshold: ${thresholds.uploadMbps} Mbit/s)`;
+	}
+	lines.push(uploadLine);
+
+	if (network.using_coder_connect) {
+		lines.push("Connection: Coder Connect");
+	} else if (network.p2p) {
+		lines.push("Connection: Direct (P2P)");
+	} else {
+		lines.push(`Connection: ${network.preferred_derp} (relay)`);
+	}
+
+	if (hasAnyViolation(violations)) {
+		lines.push("");
+		lines.push(
+			"_Click for diagnostics_ | [Configure thresholds](command:workbench.action.openSettings?%22coder.networkThreshold%22)",
+		);
+	}
+
+	const md = new vscode.MarkdownString(lines.join("\n\n"));
+	md.isTrusted = true;
+	md.supportThemeIcons = true;
+	return md;
+}
+
+/**
+ * Manages network status bar presentation and slowness warning state.
+ * Owns the warning debounce logic, status bar updates, and the
+ * diagnostics command registration.
+ */
+export class NetworkStatusReporter implements vscode.Disposable {
+	private warningCounter = 0;
+	private isWarningActive = false;
+	private readonly diagnosticsCommand: vscode.Disposable;
+
+	constructor(private readonly statusBarItem: vscode.StatusBarItem) {
+		this.diagnosticsCommand = vscode.commands.registerCommand(
+			"coder.showNetworkDiagnostics",
+			async () => {
+				const pick = await vscode.window.showQuickPick(
+					[
+						{ label: "Run Ping", commandId: "coder.pingWorkspace" },
+						{ label: "Run Speed Test", commandId: "coder.speedTest" },
+						{
+							label: "Create Support Bundle",
+							commandId: "coder.supportBundle",
+						},
+					],
+					{ placeHolder: "Select a diagnostic to run" },
+				);
+				if (pick) {
+					await vscode.commands.executeCommand(pick.commandId);
+				}
+			},
+		);
+	}
+
+	update(network: NetworkInfo, isStale: boolean): void {
+		let statusText = "$(globe) ";
+
+		// Coder Connect doesn't populate any other stats
+		if (network.using_coder_connect) {
+			this.warningCounter = 0;
+			this.isWarningActive = false;
+			this.statusBarItem.text = statusText + "Coder Connect ";
+			this.statusBarItem.tooltip = "You're connected using Coder Connect.";
+			this.statusBarItem.backgroundColor = undefined;
+			this.statusBarItem.command = undefined;
+			this.statusBarItem.show();
+			return;
+		}
+
+		const thresholds = getThresholdConfig();
+		const violations = checkThresholdViolations(network, thresholds);
+		const activeViolations = this.updateWarningState(violations);
+
+		if (network.p2p) {
+			statusText += "Direct ";
+		} else {
+			statusText += network.preferred_derp + " ";
+		}
+
+		const latencyText = isStale
+			? `(~${network.latency.toFixed(2)}ms)`
+			: `(${network.latency.toFixed(2)}ms)`;
+		statusText += latencyText;
+		this.statusBarItem.text = statusText;
+
+		if (this.isWarningActive) {
+			this.statusBarItem.backgroundColor = new vscode.ThemeColor(
+				"statusBarItem.warningBackground",
+			);
+			this.statusBarItem.command = getWarningCommand(activeViolations);
+		} else {
+			this.statusBarItem.backgroundColor = undefined;
+			this.statusBarItem.command = undefined;
+		}
+
+		this.statusBarItem.tooltip = buildNetworkTooltip(
+			network,
+			activeViolations,
+			thresholds,
+		);
+
+		this.statusBarItem.show();
+	}
+
+	/**
+	 * Updates the debounce counter and returns the effective violations
+	 * (current violations when warning is active, all-clear otherwise).
+	 */
+	private updateWarningState(
+		violations: ThresholdViolations,
+	): ThresholdViolations {
+		if (hasAnyViolation(violations)) {
+			this.warningCounter = Math.min(
+				this.warningCounter + 1,
+				WARNING_DEBOUNCE_THRESHOLD,
+			);
+		} else {
+			this.warningCounter = Math.max(this.warningCounter - 1, 0);
+		}
+
+		if (this.warningCounter >= WARNING_DEBOUNCE_THRESHOLD) {
+			this.isWarningActive = true;
+		} else if (this.warningCounter === 0) {
+			this.isWarningActive = false;
+		}
+
+		return this.isWarningActive ? violations : NO_VIOLATIONS;
+	}
+
+	dispose(): void {
+		this.diagnosticsCommand.dispose();
+	}
+}

--- a/src/remote/sshProcess.ts
+++ b/src/remote/sshProcess.ts
@@ -255,7 +255,6 @@ export class SshProcessMonitor implements vscode.Disposable {
 			this.pendingTimeout = undefined;
 		}
 		this.statusBarItem.dispose();
-		this.reporter.dispose();
 		this._onLogFilePathChange.dispose();
 		this._onPidChange.dispose();
 	}
@@ -462,9 +461,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 
 		while (!this.disposed && this.currentPid !== undefined) {
 			const filePath = path.join(networkInfoPath, `${this.currentPid}.json`);
-			let search: { needed: true; reason: string } | { needed: false } = {
-				needed: false,
-			};
+			let searchReason: string | undefined;
 
 			try {
 				const stats = await fs.stat(filePath);
@@ -472,10 +469,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 				readFailures = 0;
 
 				if (ageMs > staleThreshold) {
-					search = {
-						needed: true,
-						reason: `Network info stale (${Math.round(ageMs / 1000)}s old)`,
-					};
+					searchReason = `Network info stale (${Math.round(ageMs / 1000)}s old)`;
 				} else {
 					const content = await fs.readFile(filePath, "utf8");
 					const network = JSON.parse(content) as NetworkInfo;
@@ -488,22 +482,18 @@ export class SshProcessMonitor implements vscode.Disposable {
 					`Failed to read network info (attempt ${readFailures}): ${(error as Error).message}`,
 				);
 				if (readFailures >= maxReadFailures) {
-					search = {
-						needed: true,
-						reason: `Network info missing for ${readFailures} attempts`,
-					};
+					searchReason = `Network info missing for ${readFailures} attempts`;
 				}
 			}
 
-			// Search for new process if needed (with throttling)
-			if (search.needed) {
+			if (searchReason !== undefined) {
 				const timeSinceLastSearch = Date.now() - this.lastStaleSearchTime;
 				if (timeSinceLastSearch < staleThreshold) {
 					await this.delay(staleThreshold - timeSinceLastSearch);
 					continue;
 				}
 
-				logger.debug(`${search.reason}, searching for new SSH process`);
+				logger.debug(`${searchReason}, searching for new SSH process`);
 				// searchForProcess will update PID if a different process is found
 				this.lastStaleSearchTime = Date.now();
 				await this.searchForProcess();

--- a/src/remote/sshProcess.ts
+++ b/src/remote/sshProcess.ts
@@ -1,11 +1,13 @@
 import find from "find-process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import prettyBytes from "pretty-bytes";
 import * as vscode from "vscode";
 
-import { type Logger } from "../logging/logger";
 import { findPort } from "../util";
+
+import { NetworkStatusReporter } from "./networkStatus";
+
+import type { Logger } from "../logging/logger";
 
 /**
  * Network information from the Coder CLI.
@@ -76,6 +78,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 	private logFilePath: string | undefined;
 	private pendingTimeout: NodeJS.Timeout | undefined;
 	private lastStaleSearchTime = 0;
+	private readonly reporter: NetworkStatusReporter;
 
 	/**
 	 * Helper to clean up files in a directory.
@@ -195,6 +198,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 			vscode.StatusBarAlignment.Left,
 			1000,
 		);
+		this.reporter = new NetworkStatusReporter(this.statusBarItem);
 	}
 
 	/**
@@ -251,6 +255,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 			this.pendingTimeout = undefined;
 		}
 		this.statusBarItem.dispose();
+		this.reporter.dispose();
 		this._onLogFilePathChange.dispose();
 		this._onPidChange.dispose();
 	}
@@ -475,7 +480,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 					const content = await fs.readFile(filePath, "utf8");
 					const network = JSON.parse(content) as NetworkInfo;
 					const isStale = ageMs > networkPollInterval * 2;
-					this.updateStatusBar(network, isStale);
+					this.reporter.update(network, isStale);
 				}
 			} catch (error) {
 				readFailures++;
@@ -507,63 +512,6 @@ export class SshProcessMonitor implements vscode.Disposable {
 
 			await this.delay(networkPollInterval);
 		}
-	}
-
-	/**
-	 * Updates the status bar with network information.
-	 */
-	private updateStatusBar(network: NetworkInfo, isStale: boolean): void {
-		let statusText = "$(globe) ";
-
-		// Coder Connect doesn't populate any other stats
-		if (network.using_coder_connect) {
-			this.statusBarItem.text = statusText + "Coder Connect ";
-			this.statusBarItem.tooltip = "You're connected using Coder Connect.";
-			this.statusBarItem.show();
-			return;
-		}
-
-		if (network.p2p) {
-			statusText += "Direct ";
-			this.statusBarItem.tooltip = "You're connected peer-to-peer ✨.";
-		} else {
-			statusText += network.preferred_derp + " ";
-			this.statusBarItem.tooltip =
-				"You're connected through a relay 🕵.\nWe'll switch over to peer-to-peer when available.";
-		}
-
-		let tooltip = this.statusBarItem.tooltip;
-		tooltip +=
-			"\n\nDownload ↓ " +
-			prettyBytes(network.download_bytes_sec, { bits: true }) +
-			"/s • Upload ↑ " +
-			prettyBytes(network.upload_bytes_sec, { bits: true }) +
-			"/s\n";
-
-		if (!network.p2p) {
-			const derpLatency = network.derp_latency[network.preferred_derp];
-			tooltip += `You ↔ ${derpLatency.toFixed(2)}ms ↔ ${network.preferred_derp} ↔ ${(network.latency - derpLatency).toFixed(2)}ms ↔ Workspace`;
-
-			let first = true;
-			for (const region of Object.keys(network.derp_latency)) {
-				if (region === network.preferred_derp) {
-					continue;
-				}
-				if (first) {
-					tooltip += `\n\nOther regions:`;
-					first = false;
-				}
-				tooltip += `\n${region}: ${Math.round(network.derp_latency[region] * 100) / 100}ms`;
-			}
-		}
-
-		this.statusBarItem.tooltip = tooltip;
-		const latencyText = isStale
-			? `(~${network.latency.toFixed(2)}ms)`
-			: `(${network.latency.toFixed(2)}ms)`;
-		statusText += latencyText;
-		this.statusBarItem.text = statusText;
-		this.statusBarItem.show();
 	}
 }
 

--- a/src/remote/sshProcess.ts
+++ b/src/remote/sshProcess.ts
@@ -461,6 +461,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 
 		while (!this.disposed && this.currentPid !== undefined) {
 			const filePath = path.join(networkInfoPath, `${this.currentPid}.json`);
+			// undefined = file read OK; string = reason to trigger a new process search
 			let searchReason: string | undefined;
 
 			try {

--- a/test/mocks/testHelpers.ts
+++ b/test/mocks/testHelpers.ts
@@ -15,12 +15,28 @@ import type { IncomingMessage } from "node:http";
 import type { CoderApi } from "@/api/coderApi";
 import type { CliCredentialManager } from "@/core/cliCredentialManager";
 import type { Logger } from "@/logging/logger";
+import type { NetworkInfo } from "@/remote/sshProcess";
 import type {
 	EventHandler,
 	EventPayloadMap,
 	ParsedMessageEvent,
 	UnidirectionalStream,
 } from "@/websocket/eventStreamConnection";
+
+export function makeNetworkInfo(
+	overrides: Partial<NetworkInfo> = {},
+): NetworkInfo {
+	return {
+		p2p: true,
+		latency: 50,
+		preferred_derp: "NYC",
+		derp_latency: { NYC: 10 },
+		upload_bytes_sec: 1_250_000,
+		download_bytes_sec: 6_250_000,
+		using_coder_connect: false,
+		...overrides,
+	};
+}
 
 /**
  * Mock configuration provider that integrates with the vscode workspace configuration mock.
@@ -480,23 +496,25 @@ export function createMockStream(
  * Mock status bar that integrates with vscode.window.createStatusBarItem.
  * Use this to inspect status bar state in tests.
  */
-export class MockStatusBar {
+export class MockStatusBarItem implements vscode.StatusBarItem {
+	readonly id = "mock-status-bar";
 	text = "";
-	tooltip: string | vscode.MarkdownString = "";
+	tooltip: string | vscode.MarkdownString | undefined = "";
 	backgroundColor: vscode.ThemeColor | undefined;
 	color: string | vscode.ThemeColor | undefined;
 	command: string | vscode.Command | undefined;
 	accessibilityInformation: vscode.AccessibilityInformation | undefined;
 	name: string | undefined;
-	priority: number | undefined;
-	alignment: vscode.StatusBarAlignment = vscode.StatusBarAlignment.Left;
+	readonly priority: number | undefined = undefined;
+	readonly alignment: vscode.StatusBarAlignment =
+		vscode.StatusBarAlignment.Left;
 
 	readonly show = vi.fn();
 	readonly hide = vi.fn();
 	readonly dispose = vi.fn();
 
 	constructor() {
-		this.setupVSCodeMock();
+		vi.mocked(vscode.window.createStatusBarItem).mockReturnValue(this);
 	}
 
 	/**
@@ -511,15 +529,6 @@ export class MockStatusBar {
 		this.show.mockClear();
 		this.hide.mockClear();
 		this.dispose.mockClear();
-	}
-
-	/**
-	 * Setup the vscode.window.createStatusBarItem mock
-	 */
-	private setupVSCodeMock(): void {
-		vi.mocked(vscode.window.createStatusBarItem).mockReturnValue(
-			this as unknown as vscode.StatusBarItem,
-		);
 	}
 }
 

--- a/test/mocks/vscode.runtime.ts
+++ b/test/mocks/vscode.runtime.ts
@@ -48,6 +48,23 @@ export const InputBoxValidationSeverity = E({
 	Error: 3,
 });
 
+export class MarkdownString {
+	value: string;
+	isTrusted = false;
+	supportThemeIcons = false;
+
+	constructor(value = "") {
+		this.value = value;
+	}
+}
+
+export class ThemeColor {
+	id: string;
+	constructor(id: string) {
+		this.id = id;
+	}
+}
+
 export class Uri {
 	constructor(
 		public scheme: string,
@@ -126,7 +143,7 @@ export const window = {
 };
 
 export const commands = {
-	registerCommand: vi.fn(),
+	registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
 	executeCommand: vi.fn(),
 };
 
@@ -178,6 +195,8 @@ const vscode = {
 	InputBoxValidationSeverity,
 	Uri,
 	EventEmitter,
+	MarkdownString,
+	ThemeColor,
 	window,
 	commands,
 	workspace,

--- a/test/unit/remote/networkStatus.test.ts
+++ b/test/unit/remote/networkStatus.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	buildNetworkTooltip,
+	checkThresholdViolations,
+	getWarningCommand,
+	hasAnyViolation,
+	type ThresholdViolations,
+} from "@/remote/networkStatus";
+
+import type { NetworkInfo } from "@/remote/sshProcess";
+
+function makeNetwork(overrides: Partial<NetworkInfo> = {}): NetworkInfo {
+	return {
+		p2p: true,
+		latency: 50,
+		preferred_derp: "NYC",
+		derp_latency: { NYC: 10 },
+		upload_bytes_sec: 1_250_000, // 10 Mbps
+		download_bytes_sec: 6_250_000, // 50 Mbps
+		using_coder_connect: false,
+		...overrides,
+	};
+}
+
+const defaultThresholds = { latencyMs: 200, downloadMbps: 5, uploadMbps: 0 };
+
+const noViolations: ThresholdViolations = {
+	latency: false,
+	download: false,
+	upload: false,
+};
+
+function tooltip(
+	overrides: Partial<NetworkInfo> = {},
+	options: {
+		violations?: ThresholdViolations;
+		thresholds?: {
+			latencyMs: number;
+			downloadMbps: number;
+			uploadMbps: number;
+		};
+	} = {},
+) {
+	return buildNetworkTooltip(
+		makeNetwork(overrides),
+		options.violations ?? noViolations,
+		options.thresholds ?? defaultThresholds,
+	);
+}
+
+describe("checkThresholdViolations", () => {
+	interface TestCase {
+		desc: string;
+		network: Partial<NetworkInfo>;
+		thresholds?: typeof defaultThresholds;
+		expected: ThresholdViolations;
+	}
+
+	it.each<TestCase>([
+		{
+			desc: "no violations when within thresholds",
+			network: {},
+			expected: { latency: false, download: false, upload: false },
+		},
+		{
+			desc: "detects high latency",
+			network: { latency: 250 },
+			expected: { latency: true, download: false, upload: false },
+		},
+		{
+			desc: "detects low download (4 Mbps < 5 Mbps threshold)",
+			network: { download_bytes_sec: 500_000 },
+			expected: { latency: false, download: true, upload: false },
+		},
+		{
+			desc: "detects low upload when threshold enabled",
+			network: { upload_bytes_sec: 100_000 },
+			thresholds: { ...defaultThresholds, uploadMbps: 1 },
+			expected: { latency: false, download: false, upload: true },
+		},
+		{
+			desc: "ignores upload when threshold is 0",
+			network: { upload_bytes_sec: 0 },
+			expected: { latency: false, download: false, upload: false },
+		},
+		{
+			desc: "ignores latency when threshold is 0",
+			network: { latency: 9999 },
+			thresholds: { ...defaultThresholds, latencyMs: 0 },
+			expected: { latency: false, download: false, upload: false },
+		},
+		{
+			desc: "detects multiple simultaneous violations",
+			network: { latency: 300, download_bytes_sec: 100_000 },
+			expected: { latency: true, download: true, upload: false },
+		},
+	])("$desc", ({ network, thresholds, expected }) => {
+		expect(
+			checkThresholdViolations(
+				makeNetwork(network),
+				thresholds ?? defaultThresholds,
+			),
+		).toEqual(expected);
+	});
+
+	it("handles exact boundary (5 Mbps = 625,000 bytes/sec)", () => {
+		const at = checkThresholdViolations(
+			makeNetwork({ download_bytes_sec: 625_000 }),
+			defaultThresholds,
+		);
+		expect(at.download).toBe(false);
+
+		const below = checkThresholdViolations(
+			makeNetwork({ download_bytes_sec: 624_999 }),
+			defaultThresholds,
+		);
+		expect(below.download).toBe(true);
+	});
+});
+
+describe("hasAnyViolation", () => {
+	it.each<{ violations: ThresholdViolations; expected: boolean }>([
+		{
+			violations: { latency: false, download: false, upload: false },
+			expected: false,
+		},
+		{
+			violations: { latency: true, download: false, upload: false },
+			expected: true,
+		},
+		{
+			violations: { latency: false, download: true, upload: false },
+			expected: true,
+		},
+		{
+			violations: { latency: false, download: false, upload: true },
+			expected: true,
+		},
+	])("returns $expected for %j", ({ violations, expected }) => {
+		expect(hasAnyViolation(violations)).toBe(expected);
+	});
+});
+
+describe("getWarningCommand", () => {
+	it.each<{ desc: string; violations: ThresholdViolations; expected: string }>([
+		{
+			desc: "ping for latency only",
+			violations: { latency: true, download: false, upload: false },
+			expected: "coder.pingWorkspace",
+		},
+		{
+			desc: "speedtest for download only",
+			violations: { latency: false, download: true, upload: false },
+			expected: "coder.speedTest",
+		},
+		{
+			desc: "speedtest for upload only",
+			violations: { latency: false, download: false, upload: true },
+			expected: "coder.speedTest",
+		},
+		{
+			desc: "speedtest for download + upload",
+			violations: { latency: false, download: true, upload: true },
+			expected: "coder.speedTest",
+		},
+		{
+			desc: "diagnostics for latency + throughput",
+			violations: { latency: true, download: true, upload: false },
+			expected: "coder.showNetworkDiagnostics",
+		},
+		{
+			desc: "diagnostics for all violations",
+			violations: { latency: true, download: true, upload: true },
+			expected: "coder.showNetworkDiagnostics",
+		},
+	])("returns $expected for $desc", ({ violations, expected }) => {
+		expect(getWarningCommand(violations)).toBe(expected);
+	});
+});
+
+describe("buildNetworkTooltip", () => {
+	it("shows all metrics without warnings in normal state", () => {
+		const t = tooltip();
+		expect(t.value).toContain("Latency: 50.00ms");
+		expect(t.value).toContain("Download: 50 Mbit/s");
+		expect(t.value).toContain("Upload: 10 Mbit/s");
+		expect(t.value).not.toContain("$(warning)");
+		expect(t.value).not.toContain("Click for diagnostics");
+		expect(t.value).not.toContain("Configure thresholds");
+	});
+
+	it("shows warning markers and actions when thresholds violated", () => {
+		const violations: ThresholdViolations = {
+			latency: true,
+			download: false,
+			upload: false,
+		};
+		const t = tooltip({ latency: 350 }, { violations });
+		expect(t.value).toContain(
+			"Latency: 350.00ms $(warning) (threshold: 200ms)",
+		);
+		expect(t.value).not.toContain("Download:$(warning)");
+		expect(t.value).toContain("Click for diagnostics");
+		expect(t.value).toContain("Configure thresholds");
+	});
+
+	it("shows multiple warning markers when multiple thresholds crossed", () => {
+		const violations: ThresholdViolations = {
+			latency: true,
+			download: true,
+			upload: false,
+		};
+		const t = tooltip(
+			{ latency: 300, download_bytes_sec: 100_000 },
+			{ violations },
+		);
+		expect(t.value).toContain("Latency: 300.00ms $(warning)");
+		expect(t.value).toContain("Download: 800 kbit/s $(warning)");
+		expect(t.value).toContain("Click for diagnostics");
+	});
+
+	it.each<{ desc: string; overrides: Partial<NetworkInfo>; expected: string }>([
+		{
+			desc: "P2P",
+			overrides: { p2p: true },
+			expected: "Connection: Direct (P2P)",
+		},
+		{
+			desc: "relay",
+			overrides: { p2p: false, preferred_derp: "SFO" },
+			expected: "Connection: SFO (relay)",
+		},
+		{
+			desc: "Coder Connect",
+			overrides: { using_coder_connect: true },
+			expected: "Connection: Coder Connect",
+		},
+	])("shows $desc connection type", ({ overrides, expected }) => {
+		expect(tooltip(overrides).value).toContain(expected);
+	});
+});

--- a/test/unit/remote/networkStatus.test.ts
+++ b/test/unit/remote/networkStatus.test.ts
@@ -40,28 +40,19 @@ describe("NetworkStatusReporter status bar text", () => {
 		expect(bar.text).toBe("$(globe) SFO (40.00ms)");
 	});
 
-	it("shows the Coder Connect label alongside latency", () => {
+	it("shows just the Coder Connect label, ignoring any reported latency", () => {
 		const { bar, reporter } = setup();
 		reporter.update(
 			makeNetworkInfo({ using_coder_connect: true, latency: 30 }),
 			false,
 		);
-		expect(bar.text).toBe("$(globe) Coder Connect (30.00ms)");
+		expect(bar.text).toBe("$(globe) Coder Connect");
 	});
 
 	it("marks stale readings with a leading tilde", () => {
 		const { bar, reporter } = setup();
 		reporter.update(makeNetworkInfo({ latency: 100 }), true);
 		expect(bar.text).toContain("(~100.00ms)");
-	});
-
-	it("omits latency when the reading is 0", () => {
-		const { bar, reporter } = setup();
-		reporter.update(
-			makeNetworkInfo({ using_coder_connect: true, latency: 0 }),
-			false,
-		);
-		expect(bar.text).toBe("$(globe) Coder Connect");
 	});
 });
 
@@ -129,14 +120,6 @@ describe("NetworkStatusReporter tooltip", () => {
 		expect(t).not.toContain("Download:");
 		expect(t).not.toContain("Upload:");
 		expect(t).not.toContain("Latency:");
-	});
-
-	it("omits the latency line when the reading is 0 on an SSH connection", () => {
-		const { bar, reporter } = setup(200);
-		reporter.update(makeNetworkInfo({ latency: 0 }), false);
-		const t = tooltipOf(bar);
-		expect(t).not.toContain("Latency:");
-		expect(t).toContain("Download:");
 	});
 });
 

--- a/test/unit/remote/networkStatus.test.ts
+++ b/test/unit/remote/networkStatus.test.ts
@@ -1,131 +1,173 @@
 import { describe, expect, it } from "vitest";
 import { ThemeColor } from "vscode";
 
-import {
-	buildNetworkTooltip,
-	isLatencySlow,
-	NetworkStatusReporter,
-	type NetworkThresholds,
-} from "@/remote/networkStatus";
+import { NetworkStatusReporter } from "@/remote/networkStatus";
 
 import {
+	makeNetworkInfo,
 	MockConfigurationProvider,
-	MockStatusBar,
+	MockStatusBarItem,
 } from "../../mocks/testHelpers";
 
-import type { NetworkInfo } from "@/remote/sshProcess";
-
-function makeNetwork(overrides: Partial<NetworkInfo> = {}): NetworkInfo {
-	return {
-		p2p: true,
-		latency: 50,
-		preferred_derp: "NYC",
-		derp_latency: { NYC: 10 },
-		upload_bytes_sec: 1_250_000,
-		download_bytes_sec: 6_250_000,
-		using_coder_connect: false,
-		...overrides,
-	};
+function setup(latencyMs?: number) {
+	const cfg = new MockConfigurationProvider();
+	if (latencyMs !== undefined) {
+		cfg.set("coder.networkThreshold.latencyMs", latencyMs);
+	}
+	const bar = new MockStatusBarItem();
+	const reporter = new NetworkStatusReporter(bar);
+	return { bar, reporter };
 }
 
-const defaultThresholds: NetworkThresholds = { latencyMs: 200 };
-
-function tooltip(
-	overrides: Partial<NetworkInfo> = {},
-	options: {
-		latencySlow?: boolean;
-		thresholds?: NetworkThresholds;
-	} = {},
-) {
-	return buildNetworkTooltip(
-		makeNetwork(overrides),
-		options.latencySlow ?? false,
-		options.thresholds ?? defaultThresholds,
-	);
+function tooltipOf(bar: MockStatusBarItem): string {
+	const t = bar.tooltip;
+	return typeof t === "string" ? t : (t?.value ?? "");
 }
 
-describe("isLatencySlow", () => {
-	it("returns false when latency is within threshold", () => {
-		expect(isLatencySlow(makeNetwork({ latency: 50 }), defaultThresholds)).toBe(
+describe("NetworkStatusReporter status bar text", () => {
+	it("shows Direct prefix for P2P connections", () => {
+		const { bar, reporter } = setup();
+		reporter.update(makeNetworkInfo({ p2p: true, latency: 25.5 }), false);
+		expect(bar.text).toBe("$(globe) Direct (25.50ms)");
+	});
+
+	it("shows the DERP region for relay connections", () => {
+		const { bar, reporter } = setup();
+		reporter.update(
+			makeNetworkInfo({ p2p: false, preferred_derp: "SFO", latency: 40 }),
 			false,
 		);
+		expect(bar.text).toBe("$(globe) SFO (40.00ms)");
 	});
 
-	it("returns true when latency exceeds threshold", () => {
-		expect(
-			isLatencySlow(makeNetwork({ latency: 250 }), defaultThresholds),
-		).toBe(true);
-	});
-
-	it("ignores latency when threshold is 0", () => {
-		expect(
-			isLatencySlow(makeNetwork({ latency: 9999 }), { latencyMs: 0 }),
-		).toBe(false);
-	});
-});
-
-describe("buildNetworkTooltip", () => {
-	it("shows all metrics without warning or actions in normal state", () => {
-		const t = tooltip();
-		expect(t.value).toContain("Latency: 50.00ms");
-		expect(t.value).toContain("Download: 50 Mbit/s");
-		expect(t.value).toContain("Upload: 10 Mbit/s");
-		expect(t.value).not.toContain("$(warning)");
-		expect(t.value).not.toContain("Slow connection");
-		expect(t.value).not.toContain("command:coder.pingWorkspace");
-	});
-
-	it("shows warning header, threshold, and action links when latency is slow", () => {
-		const t = tooltip({ latency: 350 }, { latencySlow: true });
-		expect(t.value).toContain("$(warning) **Slow connection detected**");
-		expect(t.value).toContain("Latency: 350.00ms (threshold: 200ms)");
-		expect(t.value).toContain("command:coder.pingWorkspace");
-		expect(t.value).toContain("command:workbench.action.openSettings");
-		expect(t.value).toContain("Ping workspace");
-		expect(t.value).toContain("Configure threshold");
-	});
-
-	it("does not mark throughput lines with warnings", () => {
-		const t = tooltip({ download_bytes_sec: 100_000 }, { latencySlow: true });
-		expect(t.value).not.toContain("Download: 800 kbit/s $(warning)");
-	});
-
-	it.each<{ desc: string; overrides: Partial<NetworkInfo>; expected: string }>([
-		{
-			desc: "P2P",
-			overrides: { p2p: true },
-			expected: "Connection: Direct (P2P)",
-		},
-		{
-			desc: "relay",
-			overrides: { p2p: false, preferred_derp: "SFO" },
-			expected: "Connection: SFO (relay)",
-		},
-		{
-			desc: "Coder Connect",
-			overrides: { using_coder_connect: true },
-			expected: "Connection: Coder Connect",
-		},
-	])("shows $desc connection type", ({ overrides, expected }) => {
-		expect(tooltip(overrides).value).toContain(expected);
-	});
-});
-
-describe("NetworkStatusReporter hysteresis", () => {
-	function setup(latencyMs: number) {
-		const cfg = new MockConfigurationProvider();
-		cfg.set("coder.networkThreshold.latencyMs", latencyMs);
-		const bar = new MockStatusBar();
-		const reporter = new NetworkStatusReporter(
-			bar as unknown as import("vscode").StatusBarItem,
+	it("shows the Coder Connect label alongside latency", () => {
+		const { bar, reporter } = setup();
+		reporter.update(
+			makeNetworkInfo({ using_coder_connect: true, latency: 30 }),
+			false,
 		);
-		return { bar, reporter };
-	}
+		expect(bar.text).toBe("$(globe) Coder Connect (30.00ms)");
+	});
 
-	const slow = makeNetwork({ latency: 500 });
-	const healthy = makeNetwork({ latency: 50 });
+	it("marks stale readings with a leading tilde", () => {
+		const { bar, reporter } = setup();
+		reporter.update(makeNetworkInfo({ latency: 100 }), true);
+		expect(bar.text).toContain("(~100.00ms)");
+	});
 
-	it("does not warn if slow polls never reach the debounce threshold", () => {
+	it("omits latency when the reading is 0", () => {
+		const { bar, reporter } = setup();
+		reporter.update(
+			makeNetworkInfo({ using_coder_connect: true, latency: 0 }),
+			false,
+		);
+		expect(bar.text).toBe("$(globe) Coder Connect");
+	});
+});
+
+describe("NetworkStatusReporter tooltip", () => {
+	it("leads with a friendly P2P summary and omits action links when healthy", () => {
+		const { bar, reporter } = setup(200);
+		reporter.update(makeNetworkInfo({ p2p: true, latency: 50 }), false);
+		const t = tooltipOf(bar);
+		expect(t).toContain("Directly connected peer-to-peer");
+		expect(t).toContain("Latency: 50.00ms (threshold: 200ms)");
+		expect(t).toContain("Download: 50 Mbit/s");
+		expect(t).toContain("Upload: 10 Mbit/s");
+		expect(t).not.toContain("Slow connection detected");
+		expect(t).not.toContain("Run latency test");
+		expect(t).not.toContain("Configure threshold");
+	});
+
+	it("leads with a relay explainer mentioning the DERP region", () => {
+		const { bar, reporter } = setup(200);
+		reporter.update(
+			makeNetworkInfo({ p2p: false, preferred_derp: "SFO", latency: 40 }),
+			false,
+		);
+		const t = tooltipOf(bar);
+		expect(t).toContain("Connected via SFO relay");
+		expect(t).toContain("Will switch to peer-to-peer when available");
+	});
+
+	it("keeps the connection summary and adds warning header + action links when slow", () => {
+		const { bar, reporter } = setup(100);
+		reporter.update(makeNetworkInfo({ p2p: true, latency: 350 }), false);
+		reporter.update(makeNetworkInfo({ p2p: true, latency: 350 }), false);
+		const t = tooltipOf(bar);
+		expect(t).toContain("$(warning) **Slow connection detected**");
+		expect(t).toContain("Directly connected peer-to-peer");
+		expect(t).toContain("Latency: 350.00ms (threshold: 100ms)");
+		expect(t).toContain("Run latency test");
+		expect(t).toContain("Configure threshold");
+	});
+
+	it("appends a stale footer at the bottom of the tooltip", () => {
+		const { bar, reporter } = setup(200);
+		reporter.update(makeNetworkInfo({ latency: 50 }), true);
+		const t = tooltipOf(bar);
+		expect(t).toContain("Readings are stale");
+		// Footer placement: stale banner should come after the metrics.
+		expect(t.indexOf("Upload:")).toBeLessThan(t.indexOf("Readings are stale"));
+	});
+
+	it("omits threshold annotation and warning when disabled", () => {
+		const { bar, reporter } = setup(0);
+		reporter.update(makeNetworkInfo({ latency: 9999 }), false);
+		const t = tooltipOf(bar);
+		expect(t).toContain("Latency: 9999.00ms");
+		expect(t).not.toContain("threshold:");
+		expect(t).not.toContain("Slow connection detected");
+	});
+
+	it("shows a dedicated message for Coder Connect instead of empty metrics", () => {
+		const { bar, reporter } = setup(200);
+		reporter.update(makeNetworkInfo({ using_coder_connect: true }), false);
+		const t = tooltipOf(bar);
+		expect(t).toContain("Connected using Coder Connect");
+		expect(t).toContain("Detailed network stats aren't collected");
+		expect(t).not.toContain("Download:");
+		expect(t).not.toContain("Upload:");
+		expect(t).not.toContain("Latency:");
+	});
+
+	it("omits the latency line when the reading is 0 on an SSH connection", () => {
+		const { bar, reporter } = setup(200);
+		reporter.update(makeNetworkInfo({ latency: 0 }), false);
+		const t = tooltipOf(bar);
+		expect(t).not.toContain("Latency:");
+		expect(t).toContain("Download:");
+	});
+});
+
+describe("NetworkStatusReporter warning state", () => {
+	const slow = makeNetworkInfo({ latency: 500 });
+	const healthy = makeNetworkInfo({ latency: 50 });
+
+	it("does not warn on a single slow poll", () => {
+		const { bar, reporter } = setup(100);
+		reporter.update(slow, false);
+		expect(bar.backgroundColor).toBeUndefined();
+		expect(bar.command).toBeUndefined();
+	});
+
+	it("warns after two consecutive slow polls", () => {
+		const { bar, reporter } = setup(100);
+		reporter.update(slow, false);
+		reporter.update(slow, false);
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+		expect(bar.command).toBe("coder.pingWorkspace");
+	});
+
+	it("stays warning across a single healthy poll mid-streak", () => {
+		const { bar, reporter } = setup(100);
+		reporter.update(slow, false);
+		reporter.update(slow, false);
+		reporter.update(healthy, false);
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+	});
+
+	it("clears after enough healthy polls to drain the counter", () => {
 		const { bar, reporter } = setup(100);
 		reporter.update(slow, false);
 		reporter.update(slow, false);
@@ -135,29 +177,23 @@ describe("NetworkStatusReporter hysteresis", () => {
 		expect(bar.command).toBeUndefined();
 	});
 
-	it("stays warning if a single healthy poll appears mid-streak", () => {
+	it("never warns for Coder Connect, even if the CLI reports high latency", () => {
 		const { bar, reporter } = setup(100);
-		for (let i = 0; i < 3; i++) {
-			reporter.update(slow, false);
-		}
-		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
-
-		reporter.update(healthy, false);
-		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
-
-		reporter.update(slow, false);
-		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
-	});
-
-	it("clears immediately when Coder Connect takes over", () => {
-		const { bar, reporter } = setup(100);
-		for (let i = 0; i < 3; i++) {
-			reporter.update(slow, false);
-		}
-		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
-
-		reporter.update(makeNetwork({ using_coder_connect: true }), false);
+		const slowCoderConnect = makeNetworkInfo({
+			using_coder_connect: true,
+			latency: 500,
+		});
+		reporter.update(slowCoderConnect, false);
+		reporter.update(slowCoderConnect, false);
 		expect(bar.backgroundColor).toBeUndefined();
 		expect(bar.command).toBeUndefined();
+	});
+
+	it("never warns when the threshold is 0", () => {
+		const { bar, reporter } = setup(0);
+		for (let i = 0; i < 5; i++) {
+			reporter.update(makeNetworkInfo({ latency: 9999 }), false);
+		}
+		expect(bar.backgroundColor).toBeUndefined();
 	});
 });

--- a/test/unit/remote/networkStatus.test.ts
+++ b/test/unit/remote/networkStatus.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { ThemeColor } from "vscode";
 
 import {
 	buildNetworkTooltip,
-	checkThresholdViolations,
-	getWarningCommand,
-	hasAnyViolation,
-	type ThresholdViolations,
+	isLatencySlow,
+	NetworkStatusReporter,
+	type NetworkThresholds,
 } from "@/remote/networkStatus";
+
+import {
+	MockConfigurationProvider,
+	MockStatusBar,
+} from "../../mocks/testHelpers";
 
 import type { NetworkInfo } from "@/remote/sshProcess";
 
@@ -16,208 +21,73 @@ function makeNetwork(overrides: Partial<NetworkInfo> = {}): NetworkInfo {
 		latency: 50,
 		preferred_derp: "NYC",
 		derp_latency: { NYC: 10 },
-		upload_bytes_sec: 1_250_000, // 10 Mbps
-		download_bytes_sec: 6_250_000, // 50 Mbps
+		upload_bytes_sec: 1_250_000,
+		download_bytes_sec: 6_250_000,
 		using_coder_connect: false,
 		...overrides,
 	};
 }
 
-const defaultThresholds = { latencyMs: 200, downloadMbps: 5, uploadMbps: 0 };
-
-const noViolations: ThresholdViolations = {
-	latency: false,
-	download: false,
-	upload: false,
-};
+const defaultThresholds: NetworkThresholds = { latencyMs: 200 };
 
 function tooltip(
 	overrides: Partial<NetworkInfo> = {},
 	options: {
-		violations?: ThresholdViolations;
-		thresholds?: {
-			latencyMs: number;
-			downloadMbps: number;
-			uploadMbps: number;
-		};
+		latencySlow?: boolean;
+		thresholds?: NetworkThresholds;
 	} = {},
 ) {
 	return buildNetworkTooltip(
 		makeNetwork(overrides),
-		options.violations ?? noViolations,
+		options.latencySlow ?? false,
 		options.thresholds ?? defaultThresholds,
 	);
 }
 
-describe("checkThresholdViolations", () => {
-	interface TestCase {
-		desc: string;
-		network: Partial<NetworkInfo>;
-		thresholds?: typeof defaultThresholds;
-		expected: ThresholdViolations;
-	}
+describe("isLatencySlow", () => {
+	it("returns false when latency is within threshold", () => {
+		expect(isLatencySlow(makeNetwork({ latency: 50 }), defaultThresholds)).toBe(
+			false,
+		);
+	});
 
-	it.each<TestCase>([
-		{
-			desc: "no violations when within thresholds",
-			network: {},
-			expected: { latency: false, download: false, upload: false },
-		},
-		{
-			desc: "detects high latency",
-			network: { latency: 250 },
-			expected: { latency: true, download: false, upload: false },
-		},
-		{
-			desc: "detects low download (4 Mbps < 5 Mbps threshold)",
-			network: { download_bytes_sec: 500_000 },
-			expected: { latency: false, download: true, upload: false },
-		},
-		{
-			desc: "detects low upload when threshold enabled",
-			network: { upload_bytes_sec: 100_000 },
-			thresholds: { ...defaultThresholds, uploadMbps: 1 },
-			expected: { latency: false, download: false, upload: true },
-		},
-		{
-			desc: "ignores upload when threshold is 0",
-			network: { upload_bytes_sec: 0 },
-			expected: { latency: false, download: false, upload: false },
-		},
-		{
-			desc: "ignores latency when threshold is 0",
-			network: { latency: 9999 },
-			thresholds: { ...defaultThresholds, latencyMs: 0 },
-			expected: { latency: false, download: false, upload: false },
-		},
-		{
-			desc: "detects multiple simultaneous violations",
-			network: { latency: 300, download_bytes_sec: 100_000 },
-			expected: { latency: true, download: true, upload: false },
-		},
-	])("$desc", ({ network, thresholds, expected }) => {
+	it("returns true when latency exceeds threshold", () => {
 		expect(
-			checkThresholdViolations(
-				makeNetwork(network),
-				thresholds ?? defaultThresholds,
-			),
-		).toEqual(expected);
+			isLatencySlow(makeNetwork({ latency: 250 }), defaultThresholds),
+		).toBe(true);
 	});
 
-	it("handles exact boundary (5 Mbps = 625,000 bytes/sec)", () => {
-		const at = checkThresholdViolations(
-			makeNetwork({ download_bytes_sec: 625_000 }),
-			defaultThresholds,
-		);
-		expect(at.download).toBe(false);
-
-		const below = checkThresholdViolations(
-			makeNetwork({ download_bytes_sec: 624_999 }),
-			defaultThresholds,
-		);
-		expect(below.download).toBe(true);
-	});
-});
-
-describe("hasAnyViolation", () => {
-	it.each<{ violations: ThresholdViolations; expected: boolean }>([
-		{
-			violations: { latency: false, download: false, upload: false },
-			expected: false,
-		},
-		{
-			violations: { latency: true, download: false, upload: false },
-			expected: true,
-		},
-		{
-			violations: { latency: false, download: true, upload: false },
-			expected: true,
-		},
-		{
-			violations: { latency: false, download: false, upload: true },
-			expected: true,
-		},
-	])("returns $expected for %j", ({ violations, expected }) => {
-		expect(hasAnyViolation(violations)).toBe(expected);
-	});
-});
-
-describe("getWarningCommand", () => {
-	it.each<{ desc: string; violations: ThresholdViolations; expected: string }>([
-		{
-			desc: "ping for latency only",
-			violations: { latency: true, download: false, upload: false },
-			expected: "coder.pingWorkspace",
-		},
-		{
-			desc: "speedtest for download only",
-			violations: { latency: false, download: true, upload: false },
-			expected: "coder.speedTest",
-		},
-		{
-			desc: "speedtest for upload only",
-			violations: { latency: false, download: false, upload: true },
-			expected: "coder.speedTest",
-		},
-		{
-			desc: "speedtest for download + upload",
-			violations: { latency: false, download: true, upload: true },
-			expected: "coder.speedTest",
-		},
-		{
-			desc: "diagnostics for latency + throughput",
-			violations: { latency: true, download: true, upload: false },
-			expected: "coder.showNetworkDiagnostics",
-		},
-		{
-			desc: "diagnostics for all violations",
-			violations: { latency: true, download: true, upload: true },
-			expected: "coder.showNetworkDiagnostics",
-		},
-	])("returns $expected for $desc", ({ violations, expected }) => {
-		expect(getWarningCommand(violations)).toBe(expected);
+	it("ignores latency when threshold is 0", () => {
+		expect(
+			isLatencySlow(makeNetwork({ latency: 9999 }), { latencyMs: 0 }),
+		).toBe(false);
 	});
 });
 
 describe("buildNetworkTooltip", () => {
-	it("shows all metrics without warnings in normal state", () => {
+	it("shows all metrics without warning or actions in normal state", () => {
 		const t = tooltip();
 		expect(t.value).toContain("Latency: 50.00ms");
 		expect(t.value).toContain("Download: 50 Mbit/s");
 		expect(t.value).toContain("Upload: 10 Mbit/s");
 		expect(t.value).not.toContain("$(warning)");
-		expect(t.value).not.toContain("Click for diagnostics");
-		expect(t.value).not.toContain("Configure thresholds");
+		expect(t.value).not.toContain("Slow connection");
+		expect(t.value).not.toContain("command:coder.pingWorkspace");
 	});
 
-	it("shows warning markers and actions when thresholds violated", () => {
-		const violations: ThresholdViolations = {
-			latency: true,
-			download: false,
-			upload: false,
-		};
-		const t = tooltip({ latency: 350 }, { violations });
-		expect(t.value).toContain(
-			"Latency: 350.00ms $(warning) (threshold: 200ms)",
-		);
-		expect(t.value).not.toContain("Download:$(warning)");
-		expect(t.value).toContain("Click for diagnostics");
-		expect(t.value).toContain("Configure thresholds");
+	it("shows warning header, threshold, and action links when latency is slow", () => {
+		const t = tooltip({ latency: 350 }, { latencySlow: true });
+		expect(t.value).toContain("$(warning) **Slow connection detected**");
+		expect(t.value).toContain("Latency: 350.00ms (threshold: 200ms)");
+		expect(t.value).toContain("command:coder.pingWorkspace");
+		expect(t.value).toContain("command:workbench.action.openSettings");
+		expect(t.value).toContain("Ping workspace");
+		expect(t.value).toContain("Configure threshold");
 	});
 
-	it("shows multiple warning markers when multiple thresholds crossed", () => {
-		const violations: ThresholdViolations = {
-			latency: true,
-			download: true,
-			upload: false,
-		};
-		const t = tooltip(
-			{ latency: 300, download_bytes_sec: 100_000 },
-			{ violations },
-		);
-		expect(t.value).toContain("Latency: 300.00ms $(warning)");
-		expect(t.value).toContain("Download: 800 kbit/s $(warning)");
-		expect(t.value).toContain("Click for diagnostics");
+	it("does not mark throughput lines with warnings", () => {
+		const t = tooltip({ download_bytes_sec: 100_000 }, { latencySlow: true });
+		expect(t.value).not.toContain("Download: 800 kbit/s $(warning)");
 	});
 
 	it.each<{ desc: string; overrides: Partial<NetworkInfo>; expected: string }>([
@@ -238,5 +108,56 @@ describe("buildNetworkTooltip", () => {
 		},
 	])("shows $desc connection type", ({ overrides, expected }) => {
 		expect(tooltip(overrides).value).toContain(expected);
+	});
+});
+
+describe("NetworkStatusReporter hysteresis", () => {
+	function setup(latencyMs: number) {
+		const cfg = new MockConfigurationProvider();
+		cfg.set("coder.networkThreshold.latencyMs", latencyMs);
+		const bar = new MockStatusBar();
+		const reporter = new NetworkStatusReporter(
+			bar as unknown as import("vscode").StatusBarItem,
+		);
+		return { bar, reporter };
+	}
+
+	const slow = makeNetwork({ latency: 500 });
+	const healthy = makeNetwork({ latency: 50 });
+
+	it("does not warn if slow polls never reach the debounce threshold", () => {
+		const { bar, reporter } = setup(100);
+		reporter.update(slow, false);
+		reporter.update(slow, false);
+		reporter.update(healthy, false);
+		reporter.update(healthy, false);
+		expect(bar.backgroundColor).toBeUndefined();
+		expect(bar.command).toBeUndefined();
+	});
+
+	it("stays warning if a single healthy poll appears mid-streak", () => {
+		const { bar, reporter } = setup(100);
+		for (let i = 0; i < 3; i++) {
+			reporter.update(slow, false);
+		}
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+
+		reporter.update(healthy, false);
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+
+		reporter.update(slow, false);
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+	});
+
+	it("clears immediately when Coder Connect takes over", () => {
+		const { bar, reporter } = setup(100);
+		for (let i = 0; i < 3; i++) {
+			reporter.update(slow, false);
+		}
+		expect(bar.backgroundColor).toBeInstanceOf(ThemeColor);
+
+		reporter.update(makeNetwork({ using_coder_connect: true }), false);
+		expect(bar.backgroundColor).toBeUndefined();
+		expect(bar.command).toBeUndefined();
 	});
 });

--- a/test/unit/remote/sshProcess.test.ts
+++ b/test/unit/remote/sshProcess.test.ts
@@ -13,23 +13,15 @@ import {
 
 import {
 	createMockLogger,
+	makeNetworkInfo,
 	MockConfigurationProvider,
-	MockStatusBar,
+	MockStatusBarItem,
 } from "../../mocks/testHelpers";
 
 import type * as fs from "node:fs";
 
 function makeNetworkJson(overrides: Partial<NetworkInfo> = {}): string {
-	return JSON.stringify({
-		p2p: true,
-		latency: 50,
-		preferred_derp: "NYC",
-		derp_latency: { NYC: 10 },
-		upload_bytes_sec: 1_000_000,
-		download_bytes_sec: 5_000_000,
-		using_coder_connect: false,
-		...overrides,
-	});
+	return JSON.stringify(makeNetworkInfo(overrides));
 }
 
 vi.mock("find-process", () => ({ default: vi.fn() }));
@@ -41,13 +33,13 @@ vi.mock("node:fs/promises", async () => {
 
 describe("SshProcessMonitor", () => {
 	let activeMonitors: SshProcessMonitor[] = [];
-	let statusBar: MockStatusBar;
+	let statusBar: MockStatusBarItem;
 
 	beforeEach(() => {
 		vi.restoreAllMocks();
 		vol.reset();
 		activeMonitors = [];
-		statusBar = new MockStatusBar();
+		statusBar = new MockStatusBarItem();
 		// Provide default threshold config so getThresholdConfig() works
 		new MockConfigurationProvider();
 
@@ -447,7 +439,7 @@ describe("SshProcessMonitor", () => {
 
 			expect(statusBar.text).toContain("Direct");
 			expect(statusBar.text).toContain("25.50ms");
-			expect(tooltipText()).toContain("Direct (P2P)");
+			expect(tooltipText()).toContain("Directly connected peer-to-peer");
 		});
 
 		it("shows relay connection with DERP region", async () => {
@@ -777,16 +769,11 @@ describe("SshProcessMonitor", () => {
 		});
 	});
 
-	describe("slowness detection", () => {
+	describe("slowness detection wiring", () => {
 		const sshLog = {
 			"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
 				"-> socksPort 12345 ->",
 		};
-
-		function setThresholds(latencyMs: number) {
-			const mockConfig = new MockConfigurationProvider();
-			mockConfig.set("coder.networkThreshold.latencyMs", latencyMs);
-		}
 
 		function startWithNetwork(networkOverrides: Partial<NetworkInfo> = {}) {
 			vol.fromJSON({
@@ -800,62 +787,18 @@ describe("SshProcessMonitor", () => {
 			});
 		}
 
-		it("shows warning background after 3 consecutive slow polls", async () => {
-			setThresholds(100);
+		it("surfaces a warning on the status bar when latency exceeds the configured threshold", async () => {
+			new MockConfigurationProvider().set(
+				"coder.networkThreshold.latencyMs",
+				100,
+			);
 			startWithNetwork({ latency: 200 });
 
 			await waitFor(
 				() => statusBar.backgroundColor instanceof ThemeColor,
 				2000,
 			);
-			expect(statusBar.backgroundColor).toBeInstanceOf(ThemeColor);
-		});
-
-		it("clears warning after 3 consecutive healthy polls", async () => {
-			setThresholds(100);
-			startWithNetwork({ latency: 200 });
-
-			await waitFor(
-				() => statusBar.backgroundColor instanceof ThemeColor,
-				2000,
-			);
-
-			// Improve latency — warning should clear after 3 healthy polls
-			vol.fromJSON({
-				...sshLog,
-				"/network/999.json": makeNetworkJson({ latency: 50 }),
-			});
-			await waitFor(() => statusBar.backgroundColor === undefined, 2000);
-			expect(statusBar.backgroundColor).toBeUndefined();
-		});
-
-		it("sets ping command when latency is slow", async () => {
-			setThresholds(100);
-			startWithNetwork({ latency: 200 });
-
-			await waitFor(() => statusBar.command === "coder.pingWorkspace", 2000);
 			expect(statusBar.command).toBe("coder.pingWorkspace");
-		});
-
-		it("does not show warning for Coder Connect connections", async () => {
-			setThresholds(100);
-			startWithNetwork({ using_coder_connect: true });
-
-			await waitFor(() => statusBar.text.includes("Coder Connect"), 2000);
-			expect(statusBar.backgroundColor).toBeUndefined();
-			expect(statusBar.command).toBeUndefined();
-		});
-
-		it("includes threshold info in tooltip when warning is active", async () => {
-			setThresholds(100);
-			startWithNetwork({ latency: 200 });
-
-			await waitFor(
-				() => statusBar.backgroundColor instanceof ThemeColor,
-				2000,
-			);
-			expect(tooltipText()).toContain("threshold: 100ms");
-			expect(tooltipText()).toContain("Ping workspace");
 		});
 	});
 

--- a/test/unit/remote/sshProcess.test.ts
+++ b/test/unit/remote/sshProcess.test.ts
@@ -3,15 +3,34 @@ import { vol } from "memfs";
 import * as fsPromises from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeColor } from "vscode";
 
 import {
 	SshProcessMonitor,
+	type NetworkInfo,
 	type SshProcessMonitorOptions,
 } from "@/remote/sshProcess";
 
-import { createMockLogger, MockStatusBar } from "../../mocks/testHelpers";
+import {
+	createMockLogger,
+	MockConfigurationProvider,
+	MockStatusBar,
+} from "../../mocks/testHelpers";
 
 import type * as fs from "node:fs";
+
+function makeNetworkJson(overrides: Partial<NetworkInfo> = {}): string {
+	return JSON.stringify({
+		p2p: true,
+		latency: 50,
+		preferred_derp: "NYC",
+		derp_latency: { NYC: 10 },
+		upload_bytes_sec: 1_000_000,
+		download_bytes_sec: 5_000_000,
+		using_coder_connect: false,
+		...overrides,
+	});
+}
 
 vi.mock("find-process", () => ({ default: vi.fn() }));
 
@@ -29,6 +48,8 @@ describe("SshProcessMonitor", () => {
 		vol.reset();
 		activeMonitors = [];
 		statusBar = new MockStatusBar();
+		// Provide default threshold config so getThresholdConfig() works
+		new MockConfigurationProvider();
 
 		// Default: process found immediately
 		vi.mocked(find).mockResolvedValue([
@@ -402,20 +423,20 @@ describe("SshProcessMonitor", () => {
 		});
 	});
 
+	function tooltipText(): string {
+		const t = statusBar.tooltip;
+		if (typeof t === "string") {
+			return t;
+		}
+		return t?.value ?? "";
+	}
+
 	describe("network status", () => {
 		it("shows P2P connection in status bar", async () => {
 			vol.fromJSON({
 				"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
 					"-> socksPort 12345 ->",
-				"/network/999.json": JSON.stringify({
-					p2p: true,
-					latency: 25.5,
-					preferred_derp: "NYC",
-					derp_latency: { NYC: 10 },
-					upload_bytes_sec: 1024,
-					download_bytes_sec: 2048,
-					using_coder_connect: false,
-				}),
+				"/network/999.json": makeNetworkJson({ latency: 25.5 }),
 			});
 
 			createMonitor({
@@ -426,21 +447,17 @@ describe("SshProcessMonitor", () => {
 
 			expect(statusBar.text).toContain("Direct");
 			expect(statusBar.text).toContain("25.50ms");
-			expect(statusBar.tooltip).toContain("peer-to-peer");
+			expect(tooltipText()).toContain("Direct (P2P)");
 		});
 
 		it("shows relay connection with DERP region", async () => {
 			vol.fromJSON({
 				"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
 					"-> socksPort 12345 ->",
-				"/network/999.json": JSON.stringify({
+				"/network/999.json": makeNetworkJson({
 					p2p: false,
-					latency: 50,
 					preferred_derp: "SFO",
 					derp_latency: { SFO: 20, NYC: 40 },
-					upload_bytes_sec: 512,
-					download_bytes_sec: 1024,
-					using_coder_connect: false,
 				}),
 			});
 
@@ -451,22 +468,14 @@ describe("SshProcessMonitor", () => {
 			await waitFor(() => statusBar.text.includes("SFO"));
 
 			expect(statusBar.text).toContain("SFO");
-			expect(statusBar.tooltip).toContain("relay");
+			expect(tooltipText()).toContain("relay");
 		});
 
 		it("shows Coder Connect status", async () => {
 			vol.fromJSON({
 				"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
 					"-> socksPort 12345 ->",
-				"/network/999.json": JSON.stringify({
-					p2p: false,
-					latency: 0,
-					preferred_derp: "",
-					derp_latency: {},
-					upload_bytes_sec: 0,
-					download_bytes_sec: 0,
-					using_coder_connect: true,
-				}),
+				"/network/999.json": makeNetworkJson({ using_coder_connect: true }),
 			});
 
 			createMonitor({
@@ -765,6 +774,113 @@ describe("SshProcessMonitor", () => {
 
 			// Should not throw, and dispose should only be called once on status bar
 			expect(statusBar.dispose).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("slowness detection", () => {
+		const sshLog = {
+			"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
+				"-> socksPort 12345 ->",
+		};
+
+		function setThresholds(
+			latencyMs: number,
+			downloadMbps = 0,
+			uploadMbps = 0,
+		) {
+			const mockConfig = new MockConfigurationProvider();
+			mockConfig.set("coder.networkThreshold.latencyMs", latencyMs);
+			mockConfig.set("coder.networkThreshold.downloadMbps", downloadMbps);
+			mockConfig.set("coder.networkThreshold.uploadMbps", uploadMbps);
+		}
+
+		function startWithNetwork(networkOverrides: Partial<NetworkInfo> = {}) {
+			vol.fromJSON({
+				...sshLog,
+				"/network/999.json": makeNetworkJson(networkOverrides),
+			});
+			return createMonitor({
+				codeLogDir: "/logs/window1",
+				networkInfoPath: "/network",
+				networkPollInterval: 10,
+			});
+		}
+
+		it("shows warning background after 3 consecutive slow polls", async () => {
+			setThresholds(100);
+			startWithNetwork({ latency: 200 });
+
+			await waitFor(
+				() => statusBar.backgroundColor instanceof ThemeColor,
+				2000,
+			);
+			expect(statusBar.backgroundColor).toBeInstanceOf(ThemeColor);
+		});
+
+		it("clears warning after 3 consecutive healthy polls", async () => {
+			setThresholds(100);
+			startWithNetwork({ latency: 200 });
+
+			await waitFor(
+				() => statusBar.backgroundColor instanceof ThemeColor,
+				2000,
+			);
+
+			// Improve latency — warning should clear after 3 healthy polls
+			vol.fromJSON({
+				...sshLog,
+				"/network/999.json": makeNetworkJson({ latency: 50 }),
+			});
+			await waitFor(() => statusBar.backgroundColor === undefined, 2000);
+			expect(statusBar.backgroundColor).toBeUndefined();
+		});
+
+		it("sets ping command when only latency is slow", async () => {
+			setThresholds(100);
+			startWithNetwork({ latency: 200 });
+
+			await waitFor(() => statusBar.command === "coder.pingWorkspace", 2000);
+			expect(statusBar.command).toBe("coder.pingWorkspace");
+		});
+
+		it("sets speedtest command when only download is slow", async () => {
+			setThresholds(0, 10);
+			startWithNetwork({ download_bytes_sec: 500_000 }); // 4 Mbps < 10
+
+			await waitFor(() => statusBar.command === "coder.speedTest", 2000);
+			expect(statusBar.command).toBe("coder.speedTest");
+		});
+
+		it("sets diagnostics command when multiple thresholds are crossed", async () => {
+			setThresholds(100, 10);
+			startWithNetwork({ latency: 200, download_bytes_sec: 500_000 });
+
+			await waitFor(
+				() => statusBar.command === "coder.showNetworkDiagnostics",
+				2000,
+			);
+			expect(statusBar.command).toBe("coder.showNetworkDiagnostics");
+		});
+
+		it("does not show warning for Coder Connect connections", async () => {
+			setThresholds(100);
+			startWithNetwork({ using_coder_connect: true });
+
+			await waitFor(() => statusBar.text.includes("Coder Connect"), 2000);
+			expect(statusBar.backgroundColor).toBeUndefined();
+			expect(statusBar.command).toBeUndefined();
+		});
+
+		it("includes threshold info in tooltip when warning is active", async () => {
+			setThresholds(100);
+			startWithNetwork({ latency: 200 });
+
+			await waitFor(
+				() => statusBar.backgroundColor instanceof ThemeColor,
+				2000,
+			);
+			expect(tooltipText()).toContain("threshold: 100ms");
+			expect(tooltipText()).toContain("Click for diagnostics");
 		});
 	});
 

--- a/test/unit/remote/sshProcess.test.ts
+++ b/test/unit/remote/sshProcess.test.ts
@@ -783,15 +783,9 @@ describe("SshProcessMonitor", () => {
 				"-> socksPort 12345 ->",
 		};
 
-		function setThresholds(
-			latencyMs: number,
-			downloadMbps = 0,
-			uploadMbps = 0,
-		) {
+		function setThresholds(latencyMs: number) {
 			const mockConfig = new MockConfigurationProvider();
 			mockConfig.set("coder.networkThreshold.latencyMs", latencyMs);
-			mockConfig.set("coder.networkThreshold.downloadMbps", downloadMbps);
-			mockConfig.set("coder.networkThreshold.uploadMbps", uploadMbps);
 		}
 
 		function startWithNetwork(networkOverrides: Partial<NetworkInfo> = {}) {
@@ -835,31 +829,12 @@ describe("SshProcessMonitor", () => {
 			expect(statusBar.backgroundColor).toBeUndefined();
 		});
 
-		it("sets ping command when only latency is slow", async () => {
+		it("sets ping command when latency is slow", async () => {
 			setThresholds(100);
 			startWithNetwork({ latency: 200 });
 
 			await waitFor(() => statusBar.command === "coder.pingWorkspace", 2000);
 			expect(statusBar.command).toBe("coder.pingWorkspace");
-		});
-
-		it("sets speedtest command when only download is slow", async () => {
-			setThresholds(0, 10);
-			startWithNetwork({ download_bytes_sec: 500_000 }); // 4 Mbps < 10
-
-			await waitFor(() => statusBar.command === "coder.speedTest", 2000);
-			expect(statusBar.command).toBe("coder.speedTest");
-		});
-
-		it("sets diagnostics command when multiple thresholds are crossed", async () => {
-			setThresholds(100, 10);
-			startWithNetwork({ latency: 200, download_bytes_sec: 500_000 });
-
-			await waitFor(
-				() => statusBar.command === "coder.showNetworkDiagnostics",
-				2000,
-			);
-			expect(statusBar.command).toBe("coder.showNetworkDiagnostics");
 		});
 
 		it("does not show warning for Coder Connect connections", async () => {
@@ -880,7 +855,7 @@ describe("SshProcessMonitor", () => {
 				2000,
 			);
 			expect(tooltipText()).toContain("threshold: 100ms");
-			expect(tooltipText()).toContain("Click for diagnostics");
+			expect(tooltipText()).toContain("Ping workspace");
 		});
 	});
 

--- a/test/unit/workspace/workspaceMonitor.test.ts
+++ b/test/unit/workspace/workspaceMonitor.test.ts
@@ -7,7 +7,7 @@ import {
 	MockConfigurationProvider,
 	MockContextManager,
 	MockEventStream,
-	MockStatusBar,
+	MockStatusBarItem,
 	createMockLogger,
 } from "../../mocks/testHelpers";
 import { workspace as createWorkspace } from "../../mocks/workspace";
@@ -37,7 +37,7 @@ describe("WorkspaceMonitor", () => {
 
 	async function setup(stream = new MockEventStream<ServerSentEvent>()) {
 		const config = new MockConfigurationProvider();
-		const statusBar = new MockStatusBar();
+		const statusBar = new MockStatusBarItem();
 		const contextManager = new MockContextManager();
 		const client = {
 			watchWorkspace: vi.fn().mockResolvedValue(stream),


### PR DESCRIPTION
## What this adds

- New setting `coder.networkThreshold.latencyMs` (default **250ms**, set to `0` to disable, minimum `0`) that triggers a yellow status-bar warning when the workspace connection latency crosses the threshold.
- Warning state is debounced over **2 consecutive polls** to avoid flicker on single-sample spikes. Counter drains symmetrically on healthy polls.
- Clicking the warning runs `coder.pingWorkspace` (latency diagnostic); tooltip action links also offer direct shortcuts to the ping command and the settings entry for the threshold.

## Tooltip layout

- **P2P**: `$(zap) Directly connected peer-to-peer.`
- **Relay**: `$(broadcast) Connected via <DERP> relay. Will switch to peer-to-peer when available.` (preserves the helpful fallback note from the old tooltip)
- **Coder Connect**: dedicated message. The CLI only sets `using_coder_connect: true` and leaves latency/throughput at zero, so `update()` short-circuits to a fixed label and tooltip and skips the slowness machinery entirely.
- **Slow connection** (non-Coder-Connect): adds `$(warning) Slow connection detected` header plus action links ("Run latency test", "Configure threshold").
- **Stale readings**: tilde in status bar (`(~50ms)`) plus `$(history)` footer in the tooltip.

Closes #887