### PR TITLE
fix: defer outdated notification until state machine completes

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -761,6 +761,15 @@ export class Commands {
 		if (!this.workspace || !this.remoteWorkspaceClient) {
 			return;
 		}
+		const showUpToDate = () =>
+			vscode.window.showInformationMessage(
+				"The workspace is already up to date.",
+			);
+
+		if (!this.workspace.outdated) {
+			showUpToDate();
+			return;
+		}
 		const action = await vscodeProposed.window.showWarningMessage(
 			"Update Workspace",
 			{
@@ -771,6 +780,15 @@ export class Commands {
 			"Update and Restart",
 		);
 		if (action !== "Update and Restart") {
+			return;
+		}
+
+		// Re-check; workspace may have been updated or disconnected while the modal was open.
+		if (!this.workspace) {
+			return;
+		}
+		if (!this.workspace.outdated) {
+			showUpToDate();
 			return;
 		}
 

--- a/src/workspace/workspaceMonitor.ts
+++ b/src/workspace/workspaceMonitor.ts
@@ -43,6 +43,8 @@ export class WorkspaceMonitor implements vscode.Disposable {
 	// For logging.
 	private readonly name: string;
 
+	private latestWorkspace: Workspace;
+
 	private constructor(
 		workspace: Workspace,
 		private readonly client: CoderApi,
@@ -50,6 +52,7 @@ export class WorkspaceMonitor implements vscode.Disposable {
 		private readonly contextManager: ContextManager,
 	) {
 		this.name = createWorkspaceIdentifier(workspace);
+		this.latestWorkspace = workspace;
 
 		const statusBarItem = vscode.window.createStatusBarItem(
 			vscode.StatusBarAlignment.Left,
@@ -115,6 +118,7 @@ export class WorkspaceMonitor implements vscode.Disposable {
 
 	public markInitialSetupComplete(): void {
 		this.completedInitialSetup = true;
+		this.maybeNotify(this.latestWorkspace);
 	}
 
 	/**
@@ -130,6 +134,7 @@ export class WorkspaceMonitor implements vscode.Disposable {
 	}
 
 	private update(workspace: Workspace) {
+		this.latestWorkspace = workspace;
 		this.updateContext(workspace);
 		this.updateStatusBar(workspace);
 	}
@@ -139,10 +144,9 @@ export class WorkspaceMonitor implements vscode.Disposable {
 		if (areNotificationsDisabled(cfg)) {
 			return;
 		}
-		this.maybeNotifyOutdated(workspace, cfg);
 		this.maybeNotifyAutostop(workspace);
 		if (this.completedInitialSetup) {
-			// This instance might be created before the workspace is running
+			this.maybeNotifyOutdated(workspace, cfg);
 			this.maybeNotifyDeletion(workspace);
 			this.maybeNotifyNotRunning(workspace);
 		}
@@ -239,7 +243,7 @@ export class WorkspaceMonitor implements vscode.Disposable {
 							if (action === "Update") {
 								vscode.commands.executeCommand(
 									"coder.workspace.update",
-									workspace,
+									this.latestWorkspace,
 									this.client,
 								);
 							}

--- a/test/unit/workspace/workspaceMonitor.test.ts
+++ b/test/unit/workspace/workspaceMonitor.test.ts
@@ -153,9 +153,10 @@ describe("WorkspaceMonitor", () => {
 			);
 		});
 
-		it("does not show deletion or not-running notifications before initial setup", async () => {
+		it("does not show deletion, outdated, or not-running notifications before initial setup", async () => {
 			const { stream } = await setup();
 
+			stream.pushMessage(workspaceEvent({ outdated: true }));
 			stream.pushMessage(
 				workspaceEvent({ deleting_at: minutesFromNow(12 * 60) }),
 			);
@@ -167,9 +168,26 @@ describe("WorkspaceMonitor", () => {
 		});
 
 		it("fetches template details for outdated notification", async () => {
-			const { stream } = await setup();
+			const { monitor, stream } = await setup();
+			monitor.markInitialSetupComplete();
 
 			stream.pushMessage(workspaceEvent({ outdated: true }));
+
+			await vi.waitFor(() => {
+				expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+					expect.stringContaining("template v2"),
+					"Update",
+				);
+			});
+		});
+
+		it("fires outdated notification on markInitialSetupComplete", async () => {
+			const { monitor, stream } = await setup();
+
+			stream.pushMessage(workspaceEvent({ outdated: true }));
+			expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+
+			monitor.markInitialSetupComplete();
 
 			await vi.waitFor(() => {
 				expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
@@ -197,11 +215,12 @@ describe("WorkspaceMonitor", () => {
 
 	describe("disableUpdateNotifications", () => {
 		it("suppresses outdated notification but allows other types", async () => {
-			const { stream, client, config } = await setup();
+			const { monitor, stream, config } = await setup();
+			monitor.markInitialSetupComplete();
 			config.set("coder.disableUpdateNotifications", true);
 
 			stream.pushMessage(workspaceEvent({ outdated: true }));
-			expect(client.getTemplate).not.toHaveBeenCalled();
+			expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
 
 			stream.pushMessage(
 				workspaceEvent({
@@ -217,7 +236,8 @@ describe("WorkspaceMonitor", () => {
 		});
 
 		it("shows outdated notification after re-enabling", async () => {
-			const { stream, config } = await setup();
+			const { monitor, stream, config } = await setup();
+			monitor.markInitialSetupComplete();
 			config.set("coder.disableUpdateNotifications", true);
 
 			stream.pushMessage(workspaceEvent({ outdated: true }));


### PR DESCRIPTION
- Delay the outdated workspace notification until after the state machine finishes so it does not fire during an in-progress update (e.g. after "Update and Restart" reloads the window).
- Re-evaluate deferred notifications when `markInitialSetupComplete()` is called so the notification still fires for workspaces that are outdated after a normal startup.
- Add staleness checks to `Commands.updateWorkspace()` so it verifies the workspace is still outdated before showing the modal and again after the user confirms.
- Pass `latestWorkspace` instead of the stale closure-captured workspace when the user clicks "Update" in the notification.