### PR TITLE
feat: add devcontainer for headless integration testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm@sha256:7958dd7e6fe4242fce6ba4f57b9de561ea82233d5542921b5335d435c2c78791
 
-# Electron and VS Code need native Chromium libraries to run tests.
-# Playwright's install-deps handles installing them automatically.
+# Electron and VS Code need the same native libraries as Chromium to run
+# integration tests. Playwright's install-deps maintains that list upstream.
 # xvfb provides a virtual X display for headless test execution.
-RUN npx playwright install-deps chromium && \
-	apt-get update --quiet && apt-get install --yes --no-install-recommends xvfb && \
+RUN npx --yes playwright install-deps chromium && \
+	apt-get install --yes --no-install-recommends xvfb && \
 	apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* /root/.npm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm@sha256:7958dd7e6fe4242fce6ba4f57b9de561ea82233d5542921b5335d435c2c78791
+FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm@sha256:7653612ebf9384fa1cbd32413d8f4fbf7daaf24e39e8664d9fc030de8c0c0af2
 
-# Electron and VS Code need the same native libraries as Chromium to run
-# integration tests. Playwright's install-deps maintains that list upstream.
-# xvfb provides a virtual X display for headless test execution.
+# VS Code/Electron share Chromium's native library requirements; playwright
+# install-deps tracks that list upstream. xvfb enables headless test runs.
 RUN npx --yes playwright install-deps chromium && \
+	apt-get update && \
 	apt-get install --yes --no-install-recommends xvfb && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /root/.npm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/devcontainers/typescript-node:24-bookworm@sha256:7958dd7e6fe4242fce6ba4f57b9de561ea82233d5542921b5335d435c2c78791
+
+# Electron and VS Code need native Chromium libraries to run tests.
+# Playwright's install-deps handles installing them automatically.
+# xvfb provides a virtual X display for headless test execution.
+RUN npx playwright install-deps chromium && \
+	apt-get update --quiet && apt-get install --yes --no-install-recommends xvfb && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,10 @@
+# vscode-coder devcontainer
+
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/coder/vscode-coder)
+
+A ready-to-code environment matching CI: Node 22, pnpm, and `xvfb` for
+headless integration tests. Click the badge above (or run **Dev
+Containers: Clone Repository in Container Volume…** from the command
+palette) to spin it up.
+
+See [`AGENTS.md`](../AGENTS.md) for build, lint, and test commands.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,14 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"remoteUser": "node",
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"esbenp.prettier-vscode",
 				"dbaeumer.vscode-eslint",
 				"vitest.explorer",
-				"ms-vscode.extension-test-runner",
-				"christian-kohler.npm-intellisense"
+				"ms-vscode.extension-test-runner"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "vscode-coder",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"esbenp.prettier-vscode",
+				"dbaeumer.vscode-eslint",
+				"vitest.explorer",
+				"ms-vscode.extension-test-runner",
+				"christian-kohler.npm-intellisense"
+			]
+		}
+	},
+	"postCreateCommand": "CI=true pnpm install"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,5 @@
 			]
 		}
 	},
-	"postCreateCommand": "CI=true pnpm install"
+	"postCreateCommand": "pnpm install --frozen-lockfile"
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.vscode-test/
 /.nyc_output/
 /coverage/
+/.pnpm-store/
 *.vsix
 pnpm-debug.log
 .eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,13 +38,12 @@ doesn't make sense. Honesty over agreeableness.
 | **All unit tests**        | `pnpm test`                                         |
 | **Extension tests**       | `pnpm test:extension`                               |
 | **Webview tests**         | `pnpm test:webview`                                 |
-| **Integration tests**     | `pnpm test:integration` (see note on headless)      |
+| **Integration tests**     | `pnpm test:integration`                             |
 | **Single extension test** | `pnpm test:extension ./test/unit/filename.test.ts`  |
 | **Single webview test**   | `pnpm test:webview ./test/webview/filename.test.ts` |
 
 Integration tests launch VS Code and need a display. On headless
-environments (CI, devcontainers, SSH) prefix the command with
-`xvfb-run -a` (requires the `xvfb` package):
+environments (CI, devcontainers) prefix with `xvfb-run -a`:
 
 ```sh
 xvfb-run -a pnpm test:integration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ doesn't make sense. Honesty over agreeableness.
 | **All unit tests**        | `pnpm test`                                         |
 | **Extension tests**       | `pnpm test:extension`                               |
 | **Webview tests**         | `pnpm test:webview`                                 |
-| **Integration tests**     | `pnpm test:integration`                             |
+| **Integration tests**     | `pnpm test:integration` (see note on headless)      |
 | **Single extension test** | `pnpm test:extension ./test/unit/filename.test.ts`  |
 | **Single webview test**   | `pnpm test:webview ./test/webview/filename.test.ts` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,14 @@ doesn't make sense. Honesty over agreeableness.
 | **Single extension test** | `pnpm test:extension ./test/unit/filename.test.ts`  |
 | **Single webview test**   | `pnpm test:webview ./test/webview/filename.test.ts` |
 
+Integration tests launch VS Code and need a display. On headless
+environments (CI, devcontainers, SSH) prefix the command with
+`xvfb-run -a` (requires the `xvfb` package):
+
+```sh
+xvfb-run -a pnpm test:integration
+```
+
 ## Testing
 
 - Test observable behavior and outputs, not implementation details


### PR DESCRIPTION
## Summary

Add a `.devcontainer/` configuration that reproduces CI locally and removes the first-run `xvfb` setup friction. Contributors can open the repo in a Dev Container (badge in `.devcontainer/README.md`) and run the full test suite, including integration tests, out of the box.

## What's in it

- **`Dockerfile`**: `typescript-node:22-bookworm` (digest-pinned, matches CI's Node 22 and `package.json` engines). Installs Chromium native libs via `playwright install-deps` (upstream-maintained list) and `xvfb` for headless test execution.
- **`devcontainer.json`**: `remoteUser: node` so `pnpm install` writes files as UID 1000 on the mounted workspace. Recommended extensions: Prettier, ESLint, Vitest, Extension Test Runner. `postCreateCommand: pnpm install --frozen-lockfile` (matches CI, no `CI=true` env leak).
- **`README.md`**: One-click "Open in Dev Containers" badge and a pointer to `AGENTS.md`.
- **`.github/dependabot.yml`**: New docker ecosystem entry for `/.devcontainer` (weekly, 7-day cooldown) to keep the base image digest current.
- **`.gitignore`**: Ignore `.pnpm-store/` (pnpm's workspace fallback when the default store sits on a different filesystem than the bind mount).
- **`AGENTS.md`**: Document `xvfb-run -a pnpm test:integration` for headless environments (CI, devcontainers).

> [!NOTE]
> Generated by Coder Agents

Closes #909