### PR TITLE
chore: upgrade devcontainer to Node 24 on Debian trixie

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm@sha256:7653612ebf9384fa1cbd32413d8f4fbf7daaf24e39e8664d9fc030de8c0c0af2
+FROM mcr.microsoft.com/devcontainers/typescript-node:24-trixie@sha256:58cdebfe398bd451d5f51a567a00d9880691a17a93236d2be07354b80e6e289e
 
 # VS Code/Electron share Chromium's native library requirements; playwright
-# install-deps tracks that list upstream. xvfb enables headless test runs.
+# install-deps tracks that list upstream. Electron also requires libgtk-3-0t64
+# which Playwright skips (its bundled Chromium doesn't use GTK).
+# xvfb enables headless test runs.
 RUN npx --yes playwright install-deps chromium && \
 	apt-get update && \
-	apt-get install --yes --no-install-recommends xvfb && \
+	apt-get install --yes --no-install-recommends libgtk-3-0t64 xauth xvfb && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/* /root/.npm

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,7 @@
 
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/coder/vscode-coder)
 
-A ready-to-code environment matching CI: Node 22, pnpm, and `xvfb` for
+A ready-to-code environment with Node 24 on Debian trixie, pnpm, and `xvfb` for
 headless integration tests. Click the badge above (or run **Dev
 Containers: Clone Repository in Container Volume…** from the command
 palette) to spin it up.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,6 @@
 		"dockerfile": "Dockerfile"
 	},
 	"remoteUser": "node",
-	"containerEnv": {
-		"DBUS_SESSION_BUS_ADDRESS": "disabled:"
-	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 		"dockerfile": "Dockerfile"
 	},
 	"remoteUser": "node",
+	"containerEnv": {
+		"DBUS_SESSION_BUS_ADDRESS": "disabled:"
+	},
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,5 @@
 			]
 		}
 	},
-	"postCreateCommand": "pnpm install --frozen-lockfile"
+	"postCreateCommand": "pnpm install --frozen-lockfile --force"
 }

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -10,7 +10,7 @@ const baseConfig = {
 	files: "out/test/integration/**/*.test.js",
 	extensionDevelopmentPath: ".",
 	extensionTestsPath: "./out/test",
-	launchArgs: ["--enable-proposed-api", "coder.coder-remote"],
+	launchArgs: ["--enable-proposed-api", "coder.coder-remote", "--disable-gpu"],
 	mocha: {
 		ui: "tdd",
 		timeout: 20000,


### PR DESCRIPTION
Two fixes for the devcontainer:

1. **Node 24 + Debian trixie** — Update base image from `typescript-node:22-bookworm` to `typescript-node:24-trixie` (pinned digest). Matches the [dogfood vscode-coder template](https://github.com/coder/coder/blob/main/dogfood/vscode-coder/Dockerfile) and the `>= 22` engines constraint. Playwright 1.59+ has full `debian13` support with correct trixie package names (e.g. `libasound2t64`), resolved in [microsoft/playwright#36916](https://github.com/microsoft/playwright/issues/36916).

2. **pnpm prompt** — Add `--force` to `postCreateCommand` to suppress the interactive "modules will be removed and reinstalled" confirmation.

> [!NOTE]
> Generated by Coder Agents