### PR TITLE
chore: exclude dev artifacts from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -26,6 +26,8 @@ esbuild.mjs
 # Package manager files
 pnpm-lock.yaml
 pnpm-workspace.yaml
+pnpm-debug.log
+.pnpm-store/**
 
 # Webview packages (exclude everything except built output in dist/webviews)
 packages/**
@@ -40,6 +42,7 @@ flake.lock
 node_modules/**
 
 # Development tools and CI
+.devcontainer/**
 .github/**
 .claude/**
 
@@ -47,3 +50,6 @@ node_modules/**
 usage.md
 AGENTS.md
 *.gif
+
+# Build artifacts
+*.vsix


### PR DESCRIPTION
## Summary

Audited `.vscodeignore` against the actual repo contents and `.gitignore`. Found that `.devcontainer/` (3 files) was being packaged into the `.vsix` unnecessarily, and several `.gitignore` entries had no corresponding `.vscodeignore` coverage.

## Changes

Added to `.vscodeignore`:

| Entry | Why |
|---|---|
| `.devcontainer/**` | Devcontainer config (Dockerfile, devcontainer.json, README) was shipping in the extension package |
| `.pnpm-store/**` | Defensive — mirrors `.gitignore`; local pnpm store could leak if present |
| `pnpm-debug.log` | Defensive — mirrors `.gitignore`; debug log could leak if present |
| `*.vsix` | Defensive — mirrors `.gitignore`; prevents nesting built packages |

## Verification

`vsce ls --no-dependencies` before (17 files):
```
pgp-public.key, package.json, README.md, LICENSE, CHANGELOG.md,
media/tasks-logo.svg, media/shorthand-logo.svg, media/logo.png,
media/logo-white.svg, media/logo-black.svg, dist/extension.js,
.devcontainer/devcontainer.json,   ← shouldn't be here
.devcontainer/README.md,           ← shouldn't be here
.devcontainer/Dockerfile,          ← shouldn't be here
dist/webviews/tasks/index.js, dist/webviews/tasks/index.css,
dist/webviews/tasks/codicon.ttf
```

After (14 files): `.devcontainer/` removed, everything else unchanged.

---

> 🤖 Generated with [Coder Agents](https://coder.com/agents)