### PR TITLE
feat: include VS Code-side logs in support bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -597,6 +597,7 @@
 		"axios": "1.15.0",
 		"date-fns": "catalog:",
 		"eventsource": "^4.1.0",
+		"fflate": "^0.8.2",
 		"find-process": "^2.1.1",
 		"jsonc-parser": "^3.3.1",
 		"openpgp": "^6.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       eventsource:
         specifier: ^4.1.0
         version: 4.1.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       find-process:
         specifier: ^2.1.1
         version: 2.1.1
@@ -188,7 +191,7 @@ importers:
         version: 4.1.0
       coder:
         specifier: 'catalog:'
-        version: https://codeload.github.com/coder/coder/tar.gz/6b0bb02e5dcb1766e5d8c7aa88471019c80e49b4
+        version: https://codeload.github.com/coder/coder/tar.gz/ad1906589d5a794de86b94ecf22af19448a471d1
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -1955,8 +1958,8 @@ packages:
     resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
     engines: {node: '>=16'}
 
-  coder@https://codeload.github.com/coder/coder/tar.gz/6b0bb02e5dcb1766e5d8c7aa88471019c80e49b4:
-    resolution: {tarball: https://codeload.github.com/coder/coder/tar.gz/6b0bb02e5dcb1766e5d8c7aa88471019c80e49b4}
+  coder@https://codeload.github.com/coder/coder/tar.gz/ad1906589d5a794de86b94ecf22af19448a471d1:
+    resolution: {tarball: https://codeload.github.com/coder/coder/tar.gz/ad1906589d5a794de86b94ecf22af19448a471d1}
     version: 0.0.0
 
   color-convert@2.0.1:
@@ -2461,6 +2464,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -6138,7 +6144,7 @@ snapshots:
 
   cockatiel@3.2.1: {}
 
-  coder@https://codeload.github.com/coder/coder/tar.gz/6b0bb02e5dcb1766e5d8c7aa88471019c80e49b4: {}
+  coder@https://codeload.github.com/coder/coder/tar.gz/ad1906589d5a794de86b94ecf22af19448a471d1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -6725,6 +6731,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,6 +20,7 @@ import { type ServiceContainer } from "./core/container";
 import { type MementoManager } from "./core/mementoManager";
 import { type PathResolver } from "./core/pathResolver";
 import { type SecretsManager } from "./core/secretsManager";
+import { appendVsCodeLogs } from "./core/supportBundleLogs";
 import { type DeploymentManager } from "./deployment/deploymentManager";
 import { CertificateError } from "./error/certificateError";
 import { toError } from "./error/errorUtils";
@@ -256,6 +257,18 @@ export class Commands {
 
 				progress.report({ message: "Collecting diagnostics..." });
 				await cliExec.supportBundle(env, workspaceId, outputUri.fsPath, signal);
+
+				progress.report({ message: "Adding VS Code logs..." });
+				await appendVsCodeLogs(
+					outputUri.fsPath,
+					{
+						remoteSshLogPath: this.workspaceLogPath,
+						proxyLogDir: this.pathResolver.getProxyLogPath(),
+						extensionLogDir: this.pathResolver.getCodeLogDir(),
+					},
+					this.logger,
+				);
+
 				return outputUri;
 			},
 			{

--- a/src/core/supportBundleLogs.ts
+++ b/src/core/supportBundleLogs.ts
@@ -12,35 +12,17 @@ export interface LogSources {
 	extensionLogDir?: string;
 }
 
-// Matches proxy log filenames: coder-ssh-YYYYMMDD-HHMMSS-<nonce>.log
-const PROXY_LOG_DATE_RE =
-	/^coder-ssh-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-/;
 const PROXY_LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
-
-function isProxyLogRecent(filename: string, now: Date): boolean {
-	const match = PROXY_LOG_DATE_RE.exec(filename);
-	if (!match) {
-		return true;
-	}
-	const fileDate = new Date(
-		Number(match[1]),
-		Number(match[2]) - 1,
-		Number(match[3]),
-		Number(match[4]),
-		Number(match[5]),
-		Number(match[6]),
-	);
-	return now.getTime() - fileDate.getTime() <= PROXY_LOG_MAX_AGE_MS;
-}
 
 /** Collect regular files from a directory into zip-ready entries. */
 async function collectDirFiles(
 	dirPath: string,
 	zipPrefix: string,
 	logger: Logger,
-	filter?: (filename: string) => boolean,
+	maxAgeMs?: number,
 ): Promise<Record<string, Uint8Array>> {
 	const files: Record<string, Uint8Array> = {};
+	const now = Date.now();
 
 	let entries: string[];
 	try {
@@ -53,13 +35,13 @@ async function collectDirFiles(
 	}
 
 	for (const entry of entries) {
-		if (filter && !filter(entry)) {
-			continue;
-		}
 		const filePath = path.join(dirPath, entry);
 		try {
 			const stat = await fs.stat(filePath);
 			if (!stat.isFile()) {
+				continue;
+			}
+			if (maxAgeMs !== undefined && now - stat.mtimeMs > maxAgeMs) {
 				continue;
 			}
 			const content = await fs.readFile(filePath);
@@ -95,14 +77,13 @@ export async function collectLogFiles(
 	}
 
 	if (sources.proxyLogDir) {
-		const now = new Date();
 		Object.assign(
 			files,
 			await collectDirFiles(
 				sources.proxyLogDir,
 				"vscode-logs/proxy",
 				logger,
-				(name) => isProxyLogRecent(name, now),
+				PROXY_LOG_MAX_AGE_MS,
 			),
 		);
 	}

--- a/src/core/supportBundleLogs.ts
+++ b/src/core/supportBundleLogs.ts
@@ -1,8 +1,8 @@
-import { unzipSync, zipSync } from "fflate";
+import { unzip, zip } from "fflate";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { promisify } from "node:util";
 
-import { toError } from "../error/errorUtils";
 import { type Logger } from "../logging/logger";
 import { renameWithRetry } from "../util";
 
@@ -12,99 +12,85 @@ export interface LogSources {
 	extensionLogDir?: string;
 }
 
-const PROXY_LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+const LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
 
-/** Collect regular files from a directory into zip-ready entries. */
+const unzipAsync = promisify(unzip);
+const zipAsync = promisify(zip);
+
 async function collectDirFiles(
 	dirPath: string,
-	zipPrefix: string,
 	logger: Logger,
-	maxAgeMs?: number,
-): Promise<Record<string, Uint8Array>> {
-	const files: Record<string, Uint8Array> = {};
-	const now = Date.now();
+): Promise<Map<string, Uint8Array>> {
+	const results = new Map<string, Uint8Array>();
 
 	let entries: string[];
 	try {
 		entries = await fs.readdir(dirPath);
 	} catch (error) {
-		logger.warn(
-			`Could not read log directory ${dirPath}: ${toError(error).message}`,
-		);
-		return files;
+		logger.warn(`Could not read log directory ${dirPath}`, error);
+		return results;
 	}
 
-	for (const entry of entries) {
-		const filePath = path.join(dirPath, entry);
-		try {
-			const stat = await fs.stat(filePath);
-			if (!stat.isFile()) {
-				continue;
-			}
-			if (maxAgeMs !== undefined && now - stat.mtimeMs > maxAgeMs) {
-				continue;
-			}
-			const content = await fs.readFile(filePath);
-			files[`${zipPrefix}/${entry}`] = new Uint8Array(content);
-		} catch (error) {
-			logger.warn(
-				`Could not read log file ${filePath}: ${toError(error).message}`,
-			);
-		}
-	}
+	const cutoff = Date.now() - LOG_MAX_AGE_MS;
 
-	return files;
+	await Promise.all(
+		entries.map(async (entry) => {
+			const filePath = path.join(dirPath, entry);
+			try {
+				const stat = await fs.stat(filePath);
+				if (!stat.isFile() || stat.mtimeMs < cutoff) {
+					return;
+				}
+				results.set(entry, await fs.readFile(filePath));
+			} catch (error) {
+				logger.warn(`Could not read log file ${filePath}`, error);
+			}
+		}),
+	);
+
+	return results;
 }
 
 /**
  * Gather log files from each source independently so a failure in one
  * does not affect the others.
  */
-export async function collectLogFiles(
+async function collectLogFiles(
 	sources: LogSources,
 	logger: Logger,
-): Promise<Record<string, Uint8Array>> {
-	const files: Record<string, Uint8Array> = {};
+): Promise<Map<string, Uint8Array>> {
+	const files = new Map<string, Uint8Array>();
 
 	if (sources.remoteSshLogPath) {
 		try {
-			const content = await fs.readFile(sources.remoteSshLogPath);
-			const name = path.basename(sources.remoteSshLogPath);
-			files[`vscode-logs/remote-ssh/${name}`] = new Uint8Array(content);
+			files.set(
+				`vscode-logs/remote-ssh/${path.basename(sources.remoteSshLogPath)}`,
+				await fs.readFile(sources.remoteSshLogPath),
+			);
 		} catch (error) {
-			logger.warn(`Could not read Remote SSH log: ${toError(error).message}`);
+			logger.warn("Could not read Remote SSH log", error);
 		}
 	}
 
 	if (sources.proxyLogDir) {
-		Object.assign(
-			files,
-			await collectDirFiles(
-				sources.proxyLogDir,
-				"vscode-logs/proxy",
-				logger,
-				PROXY_LOG_MAX_AGE_MS,
-			),
-		);
+		for (const [name, data] of await collectDirFiles(
+			sources.proxyLogDir,
+			logger,
+		)) {
+			files.set(`vscode-logs/proxy/${name}`, data);
+		}
 	}
 
 	if (sources.extensionLogDir) {
-		Object.assign(
-			files,
-			await collectDirFiles(
-				sources.extensionLogDir,
-				"vscode-logs/extension",
-				logger,
-			),
-		);
+		for (const [name, data] of await collectDirFiles(
+			sources.extensionLogDir,
+			logger,
+		)) {
+			files.set(`vscode-logs/extension/${name}`, data);
+		}
 	}
 
 	return files;
-}
-
-function vscodeBundlePath(zipPath: string): string {
-	const { dir, name, ext } = path.parse(zipPath);
-	return path.join(dir, `${name}-vscode${ext}`);
 }
 
 /**
@@ -117,44 +103,47 @@ export async function appendVsCodeLogs(
 	logger: Logger,
 ): Promise<void> {
 	const logFiles = await collectLogFiles(sources, logger);
-	const count = Object.keys(logFiles).length;
-	if (count === 0) {
+	if (logFiles.size === 0) {
 		logger.info("No VS Code logs found to add to support bundle");
 		return;
 	}
 
-	logger.info(`Adding ${count} VS Code log file(s) to support bundle`);
+	logger.info(`Adding ${logFiles.size} VS Code log file(s) to support bundle`);
 
-	let updatedData: Uint8Array;
+	// Write to a named temporary path first so a failure at the rename step
+	// leaves the user with a properly named file containing VS Code logs.
+	const parsed = path.parse(zipPath);
+	const vscodeBundlePath = path.join(
+		parsed.dir,
+		`${parsed.name}-vscode${parsed.ext}`,
+	);
+
 	try {
-		const existingData = new Uint8Array(await fs.readFile(zipPath));
-		const entries = unzipSync(existingData);
-		Object.assign(entries, logFiles);
-		updatedData = zipSync(entries);
+		const entries = await unzipAsync(await fs.readFile(zipPath));
+		for (const [name, data] of logFiles) {
+			entries[name] = data;
+		}
+		const updated = await zipAsync(entries);
+		await fs.writeFile(vscodeBundlePath, updated);
 	} catch (error) {
-		logger.error(
-			`Failed to add VS Code logs to support bundle: ${toError(error).message}`,
-		);
+		logger.error("Failed to add VS Code logs to support bundle", error);
+		try {
+			await fs.rm(vscodeBundlePath, { force: true });
+		} catch (cleanupError) {
+			logger.warn(
+				`Could not clean up partial bundle at ${vscodeBundlePath}`,
+				cleanupError,
+			);
+		}
 		return;
 	}
 
-	// Write to a named temporary path first so a failure mid-write leaves
-	// the user with a properly named file containing VS Code logs.
-	const tmpPath = vscodeBundlePath(zipPath);
 	try {
-		await fs.writeFile(tmpPath, updatedData);
-	} catch (error) {
-		logger.error(
-			`Failed to write updated support bundle: ${toError(error).message}`,
-		);
-		return;
-	}
-
-	try {
-		await renameWithRetry(fs.rename, tmpPath, zipPath);
+		await renameWithRetry(fs.rename, vscodeBundlePath, zipPath);
 	} catch (error) {
 		logger.warn(
-			`Could not replace original bundle, VS Code logs saved separately: ${toError(error).message}`,
+			`Could not replace original bundle; VS Code logs saved separately at ${vscodeBundlePath}`,
+			error,
 		);
 	}
 }

--- a/src/core/supportBundleLogs.ts
+++ b/src/core/supportBundleLogs.ts
@@ -1,0 +1,148 @@
+import { unzipSync, zipSync } from "fflate";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { toError } from "../error/errorUtils";
+import { type Logger } from "../logging/logger";
+import { renameWithRetry } from "../util";
+
+export interface LogSources {
+	remoteSshLogPath?: string;
+	proxyLogDir?: string;
+	extensionLogDir?: string;
+}
+
+/** Collect regular files from a directory into zip-ready entries. */
+async function collectDirFiles(
+	dirPath: string,
+	zipPrefix: string,
+	logger: Logger,
+): Promise<Record<string, Uint8Array>> {
+	const files: Record<string, Uint8Array> = {};
+
+	let entries: string[];
+	try {
+		entries = await fs.readdir(dirPath);
+	} catch (error) {
+		logger.warn(
+			`Could not read log directory ${dirPath}: ${toError(error).message}`,
+		);
+		return files;
+	}
+
+	for (const entry of entries) {
+		const filePath = path.join(dirPath, entry);
+		try {
+			const stat = await fs.stat(filePath);
+			if (!stat.isFile()) {
+				continue;
+			}
+			const content = await fs.readFile(filePath);
+			files[`${zipPrefix}/${entry}`] = new Uint8Array(content);
+		} catch (error) {
+			logger.warn(
+				`Could not read log file ${filePath}: ${toError(error).message}`,
+			);
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Gather log files from each source independently so a failure in one
+ * does not affect the others.
+ */
+export async function collectLogFiles(
+	sources: LogSources,
+	logger: Logger,
+): Promise<Record<string, Uint8Array>> {
+	const files: Record<string, Uint8Array> = {};
+
+	if (sources.remoteSshLogPath) {
+		try {
+			const content = await fs.readFile(sources.remoteSshLogPath);
+			const name = path.basename(sources.remoteSshLogPath);
+			files[`vscode-logs/remote-ssh/${name}`] = new Uint8Array(content);
+		} catch (error) {
+			logger.warn(`Could not read Remote SSH log: ${toError(error).message}`);
+		}
+	}
+
+	if (sources.proxyLogDir) {
+		Object.assign(
+			files,
+			await collectDirFiles(sources.proxyLogDir, "vscode-logs/proxy", logger),
+		);
+	}
+
+	if (sources.extensionLogDir) {
+		Object.assign(
+			files,
+			await collectDirFiles(
+				sources.extensionLogDir,
+				"vscode-logs/extension",
+				logger,
+			),
+		);
+	}
+
+	return files;
+}
+
+function vscodeBundlePath(zipPath: string): string {
+	const { dir, name, ext } = path.parse(zipPath);
+	return path.join(dir, `${name}-vscode${ext}`);
+}
+
+/**
+ * Best-effort: append VS Code logs to a support bundle zip.
+ * Uses atomic rename to avoid corrupting the original bundle on failure.
+ */
+export async function appendVsCodeLogs(
+	zipPath: string,
+	sources: LogSources,
+	logger: Logger,
+): Promise<void> {
+	const logFiles = await collectLogFiles(sources, logger);
+	const count = Object.keys(logFiles).length;
+	if (count === 0) {
+		logger.info("No VS Code logs found to add to support bundle");
+		return;
+	}
+
+	logger.info(`Adding ${count} VS Code log file(s) to support bundle`);
+
+	let updatedData: Uint8Array;
+	try {
+		const existingData = new Uint8Array(await fs.readFile(zipPath));
+		const entries = unzipSync(existingData);
+		Object.assign(entries, logFiles);
+		updatedData = zipSync(entries);
+	} catch (error) {
+		logger.error(
+			`Failed to add VS Code logs to support bundle: ${toError(error).message}`,
+		);
+		return;
+	}
+
+	// Write to a named temporary path first so a failure mid-write leaves
+	// the user with a properly named file containing VS Code logs.
+	const tmpPath = vscodeBundlePath(zipPath);
+	try {
+		await fs.writeFile(tmpPath, updatedData);
+	} catch (error) {
+		logger.error(
+			`Failed to write updated support bundle: ${toError(error).message}`,
+		);
+		return;
+	}
+
+	try {
+		await renameWithRetry(fs.rename, tmpPath, zipPath);
+	} catch (error) {
+		logger.warn(
+			`Could not replace original bundle, VS Code logs saved separately: ${toError(error).message}`,
+		);
+	}
+}

--- a/src/core/supportBundleLogs.ts
+++ b/src/core/supportBundleLogs.ts
@@ -12,6 +12,8 @@ export interface LogSources {
 	extensionLogDir?: string;
 }
 
+// 3 days is enough context for recent issues; matching the 7-day
+// rotation would bloat the bundle.
 const LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
 
 const unzipAsync = promisify(unzip);
@@ -102,48 +104,55 @@ export async function appendVsCodeLogs(
 	sources: LogSources,
 	logger: Logger,
 ): Promise<void> {
-	const logFiles = await collectLogFiles(sources, logger);
-	if (logFiles.size === 0) {
-		logger.info("No VS Code logs found to add to support bundle");
-		return;
-	}
-
-	logger.info(`Adding ${logFiles.size} VS Code log file(s) to support bundle`);
-
-	// Write to a named temporary path first so a failure at the rename step
-	// leaves the user with a properly named file containing VS Code logs.
-	const parsed = path.parse(zipPath);
-	const vscodeBundlePath = path.join(
-		parsed.dir,
-		`${parsed.name}-vscode${parsed.ext}`,
-	);
-
 	try {
-		const entries = await unzipAsync(await fs.readFile(zipPath));
-		for (const [name, data] of logFiles) {
-			entries[name] = data;
+		const logFiles = await collectLogFiles(sources, logger);
+		if (logFiles.size === 0) {
+			logger.info("No VS Code logs found to add to support bundle");
+			return;
 		}
-		const updated = await zipAsync(entries);
-		await fs.writeFile(vscodeBundlePath, updated);
-	} catch (error) {
-		logger.error("Failed to add VS Code logs to support bundle", error);
+
+		logger.info(
+			`Adding ${logFiles.size} VS Code log file(s) to support bundle`,
+		);
+
+		// Write to a named temporary path first so a failure at the rename step
+		// leaves the user with a properly named file containing VS Code logs.
+		const parsed = path.parse(zipPath);
+		const vscodeBundlePath = path.join(
+			parsed.dir,
+			`${parsed.name}-vscode${parsed.ext}`,
+		);
+
 		try {
-			await fs.rm(vscodeBundlePath, { force: true });
-		} catch (cleanupError) {
+			const entries = await unzipAsync(await fs.readFile(zipPath));
+			for (const [name, data] of logFiles) {
+				entries[name] = data;
+			}
+			const updated = await zipAsync(entries);
+			await fs.writeFile(vscodeBundlePath, updated);
+		} catch (error) {
+			logger.error("Failed to add VS Code logs to support bundle", error);
+			try {
+				await fs.rm(vscodeBundlePath, { force: true });
+			} catch (cleanupError) {
+				logger.warn(
+					`Could not clean up partial bundle at ${vscodeBundlePath}`,
+					cleanupError,
+				);
+			}
+			return;
+		}
+
+		try {
+			await renameWithRetry(fs.rename, vscodeBundlePath, zipPath);
+		} catch (error) {
 			logger.warn(
-				`Could not clean up partial bundle at ${vscodeBundlePath}`,
-				cleanupError,
+				`Could not replace original bundle; VS Code logs saved separately at ${vscodeBundlePath}`,
+				error,
 			);
 		}
-		return;
-	}
-
-	try {
-		await renameWithRetry(fs.rename, vscodeBundlePath, zipPath);
 	} catch (error) {
-		logger.warn(
-			`Could not replace original bundle; VS Code logs saved separately at ${vscodeBundlePath}`,
-			error,
-		);
+		// Best-effort: never let a failure here lose the user's bundle.
+		logger.error("Unexpected error appending VS Code logs", error);
 	}
 }

--- a/src/core/supportBundleLogs.ts
+++ b/src/core/supportBundleLogs.ts
@@ -12,11 +12,33 @@ export interface LogSources {
 	extensionLogDir?: string;
 }
 
+// Matches proxy log filenames: coder-ssh-YYYYMMDD-HHMMSS-<nonce>.log
+const PROXY_LOG_DATE_RE =
+	/^coder-ssh-(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-/;
+const PROXY_LOG_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+
+function isProxyLogRecent(filename: string, now: Date): boolean {
+	const match = PROXY_LOG_DATE_RE.exec(filename);
+	if (!match) {
+		return true;
+	}
+	const fileDate = new Date(
+		Number(match[1]),
+		Number(match[2]) - 1,
+		Number(match[3]),
+		Number(match[4]),
+		Number(match[5]),
+		Number(match[6]),
+	);
+	return now.getTime() - fileDate.getTime() <= PROXY_LOG_MAX_AGE_MS;
+}
+
 /** Collect regular files from a directory into zip-ready entries. */
 async function collectDirFiles(
 	dirPath: string,
 	zipPrefix: string,
 	logger: Logger,
+	filter?: (filename: string) => boolean,
 ): Promise<Record<string, Uint8Array>> {
 	const files: Record<string, Uint8Array> = {};
 
@@ -31,6 +53,9 @@ async function collectDirFiles(
 	}
 
 	for (const entry of entries) {
+		if (filter && !filter(entry)) {
+			continue;
+		}
 		const filePath = path.join(dirPath, entry);
 		try {
 			const stat = await fs.stat(filePath);
@@ -70,9 +95,15 @@ export async function collectLogFiles(
 	}
 
 	if (sources.proxyLogDir) {
+		const now = new Date();
 		Object.assign(
 			files,
-			await collectDirFiles(sources.proxyLogDir, "vscode-logs/proxy", logger),
+			await collectDirFiles(
+				sources.proxyLogDir,
+				"vscode-logs/proxy",
+				logger,
+				(name) => isProxyLogRecent(name, now),
+			),
 		);
 	}
 

--- a/test/unit/core/supportBundleLogs.test.ts
+++ b/test/unit/core/supportBundleLogs.test.ts
@@ -102,11 +102,46 @@ describe("appendVsCodeLogs", () => {
 
 	it("does not touch the zip when no logs are found", async () => {
 		const zipPath = await makeBundle();
-		const before = await fs.stat(zipPath);
+		const beforeStat = await fs.stat(zipPath);
+		const beforeBytes = await fs.readFile(zipPath);
 
 		await appendVsCodeLogs(zipPath, {}, logger);
 
-		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(beforeStat.mtimeMs);
+		expect(Buffer.compare(beforeBytes, await fs.readFile(zipPath))).toBe(0);
+	});
+
+	it("merges a large number of files without dropping any", async () => {
+		const zipPath = await makeBundle();
+
+		const proxyDir = path.join(tmpDir, "proxy");
+		const extDir = path.join(tmpDir, "ext");
+		await fs.mkdir(proxyDir);
+		await fs.mkdir(extDir);
+
+		const fileCount = 60;
+		await Promise.all(
+			Array.from({ length: fileCount }, (_, i) =>
+				Promise.all([
+					fs.writeFile(path.join(proxyDir, `proxy-${i}.log`), `proxy-${i}`),
+					fs.writeFile(path.join(extDir, `ext-${i}.log`), `ext-${i}`),
+				]),
+			),
+		);
+
+		await appendVsCodeLogs(
+			zipPath,
+			{ proxyLogDir: proxyDir, extensionLogDir: extDir },
+			logger,
+		);
+
+		const entries = await readZip(zipPath);
+		const keys = vsCodeLogKeys(entries);
+		expect(keys).toHaveLength(fileCount * 2);
+		for (let i = 0; i < fileCount; i++) {
+			expect(entries[`vscode-logs/proxy/proxy-${i}.log`]).toBe(`proxy-${i}`);
+			expect(entries[`vscode-logs/extension/ext-${i}.log`]).toBe(`ext-${i}`);
+		}
 	});
 
 	it("filters proxy logs older than 3 days by mtime", async () => {
@@ -175,7 +210,8 @@ describe("appendVsCodeLogs", () => {
 
 	it("keeps the -vscode.zip sibling when rename fails", async () => {
 		const zipPath = await makeBundle();
-		const before = await fs.stat(zipPath);
+		const beforeStat = await fs.stat(zipPath);
+		const beforeBytes = await fs.readFile(zipPath);
 
 		const sshLog = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(sshLog, "ssh content");
@@ -186,7 +222,8 @@ describe("appendVsCodeLogs", () => {
 
 		await appendVsCodeLogs(zipPath, { remoteSshLogPath: sshLog }, logger);
 
-		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(beforeStat.mtimeMs);
+		expect(Buffer.compare(beforeBytes, await fs.readFile(zipPath))).toBe(0);
 
 		const siblingPath = path.join(tmpDir, "coder-support-123-vscode.zip");
 		const entries = await readZip(siblingPath);
@@ -200,14 +237,16 @@ describe("appendVsCodeLogs", () => {
 	it("leaves the original zip intact and cleans up the partial sibling when corrupted", async () => {
 		const zipPath = path.join(tmpDir, "coder-support-123.zip");
 		await fs.writeFile(zipPath, "not a zip");
-		const before = await fs.stat(zipPath);
+		const beforeStat = await fs.stat(zipPath);
+		const beforeBytes = await fs.readFile(zipPath);
 
 		const logPath = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(logPath, "content");
 
 		await appendVsCodeLogs(zipPath, { remoteSshLogPath: logPath }, logger);
 
-		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(beforeStat.mtimeMs);
+		expect(Buffer.compare(beforeBytes, await fs.readFile(zipPath))).toBe(0);
 		expect(await fs.readdir(tmpDir)).not.toContain(
 			"coder-support-123-vscode.zip",
 		);

--- a/test/unit/core/supportBundleLogs.test.ts
+++ b/test/unit/core/supportBundleLogs.test.ts
@@ -2,11 +2,23 @@ import { strToU8, unzipSync, zipSync } from "fflate";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { appendVsCodeLogs, collectLogFiles } from "@/core/supportBundleLogs";
+import { appendVsCodeLogs } from "@/core/supportBundleLogs";
+import { renameWithRetry } from "@/util";
 
 import { createMockLogger } from "../../mocks/testHelpers";
+
+// Wrap renameWithRetry so individual tests can override it via
+// mockRejectedValueOnce; by default it calls through to the real impl.
+vi.mock("@/util", async () => {
+	const actual = await vi.importActual<typeof import("@/util")>("@/util");
+	return { ...actual, renameWithRetry: vi.fn(actual.renameWithRetry) };
+});
+
+// chmod to 0o000 is a no-op as root and on Windows.
+const canTestUnreadable =
+	process.getuid?.() !== 0 && process.platform !== "win32";
 
 let tmpDir: string;
 
@@ -26,8 +38,35 @@ async function setAge(filePath: string, daysAgo: number): Promise<void> {
 	await fs.utimes(filePath, past, past);
 }
 
-describe("collectLogFiles", () => {
-	it("collects from all three sources and skips subdirectories", async () => {
+async function makeBundle(): Promise<string> {
+	const zipPath = path.join(tmpDir, "coder-support-123.zip");
+	await fs.writeFile(
+		zipPath,
+		zipSync({ "server/info.txt": strToU8("server data") }),
+	);
+	return zipPath;
+}
+
+async function readZip(zipPath: string): Promise<Record<string, string>> {
+	const entries = unzipSync(await fs.readFile(zipPath));
+	return Object.fromEntries(
+		Object.entries(entries).map(([name, data]) => [
+			name,
+			Buffer.from(data).toString(),
+		]),
+	);
+}
+
+function vsCodeLogKeys(entries: Record<string, string>): string[] {
+	return Object.keys(entries)
+		.filter((k) => k.startsWith("vscode-logs/"))
+		.sort();
+}
+
+describe("appendVsCodeLogs", () => {
+	it("merges logs from all three sources and skips subdirectories", async () => {
+		const zipPath = await makeBundle();
+
 		const sshLog = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(sshLog, "ssh");
 
@@ -40,7 +79,8 @@ describe("collectLogFiles", () => {
 		await fs.mkdir(extDir);
 		await fs.writeFile(path.join(extDir, "Coder.log"), "ext");
 
-		const files = await collectLogFiles(
+		await appendVsCodeLogs(
+			zipPath,
 			{
 				remoteSshLogPath: sshLog,
 				proxyLogDir: proxyDir,
@@ -49,96 +89,127 @@ describe("collectLogFiles", () => {
 			logger,
 		);
 
-		expect(Object.keys(files).sort()).toEqual([
+		const entries = await readZip(zipPath);
+		expect(Object.keys(entries).sort()).toEqual([
+			"server/info.txt",
 			"vscode-logs/extension/Coder.log",
 			"vscode-logs/proxy/coder-ssh-recent.log",
 			"vscode-logs/remote-ssh/ssh.log",
 		]);
-		expect(
-			Buffer.from(files["vscode-logs/proxy/coder-ssh-recent.log"]).toString(),
-		).toBe("proxy");
-	});
-
-	it("returns empty when no sources are provided", async () => {
-		const files = await collectLogFiles({}, logger);
-		expect(Object.keys(files)).toHaveLength(0);
-	});
-
-	it("filters proxy logs older than 3 days by mtime", async () => {
-		const proxyDir = path.join(tmpDir, "proxy");
-		await fs.mkdir(proxyDir);
-
-		const recentFile = path.join(proxyDir, "recent.log");
-		const oldFile = path.join(proxyDir, "old.log");
-		await fs.writeFile(recentFile, "recent");
-		await fs.writeFile(oldFile, "old");
-		await setAge(oldFile, 5);
-
-		const files = await collectLogFiles({ proxyLogDir: proxyDir }, logger);
-
-		expect(Object.keys(files)).toEqual(["vscode-logs/proxy/recent.log"]);
-	});
-
-	it("skips missing or unreadable sources and collects the rest", async () => {
-		const proxyDir = path.join(tmpDir, "proxy");
-		await fs.mkdir(proxyDir);
-		await fs.writeFile(path.join(proxyDir, "good.log"), "ok");
-		await fs.writeFile(path.join(proxyDir, "bad.log"), "secret");
-		await fs.chmod(path.join(proxyDir, "bad.log"), 0o000);
-
-		const files = await collectLogFiles(
-			{
-				remoteSshLogPath: path.join(tmpDir, "nonexistent.log"),
-				proxyLogDir: proxyDir,
-				extensionLogDir: path.join(tmpDir, "no-such-dir"),
-			},
-			logger,
-		);
-
-		expect(Object.keys(files)).toEqual(["vscode-logs/proxy/good.log"]);
-
-		await fs.chmod(path.join(proxyDir, "bad.log"), 0o644);
-	});
-});
-
-describe("appendVsCodeLogs", () => {
-	let zipPath: string;
-	let originalZipBytes: Uint8Array;
-
-	beforeEach(async () => {
-		zipPath = path.join(tmpDir, "coder-support-123.zip");
-		originalZipBytes = zipSync({ "server/info.txt": strToU8("server data") });
-		await fs.writeFile(zipPath, originalZipBytes);
-	});
-
-	it("merges log files into the existing zip", async () => {
-		const logPath = path.join(tmpDir, "ssh.log");
-		await fs.writeFile(logPath, "ssh content");
-
-		await appendVsCodeLogs(zipPath, { remoteSshLogPath: logPath }, logger);
-
-		const zip = unzipSync(new Uint8Array(await fs.readFile(zipPath)));
-		expect(Buffer.from(zip["server/info.txt"]).toString()).toBe("server data");
-		expect(Buffer.from(zip["vscode-logs/remote-ssh/ssh.log"]).toString()).toBe(
-			"ssh content",
-		);
+		expect(entries["server/info.txt"]).toBe("server data");
+		expect(entries["vscode-logs/proxy/coder-ssh-recent.log"]).toBe("proxy");
 	});
 
 	it("does not touch the zip when no logs are found", async () => {
+		const zipPath = await makeBundle();
+		const before = await fs.stat(zipPath);
+
 		await appendVsCodeLogs(zipPath, {}, logger);
 
-		const data = new Uint8Array(await fs.readFile(zipPath));
-		expect(Buffer.from(data)).toEqual(Buffer.from(originalZipBytes));
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
 	});
 
-	it("leaves the original zip intact when it is corrupted", async () => {
+	it("filters proxy logs older than 3 days by mtime", async () => {
+		const zipPath = await makeBundle();
+
+		const proxyDir = path.join(tmpDir, "proxy");
+		await fs.mkdir(proxyDir);
+		await fs.writeFile(path.join(proxyDir, "recent.log"), "recent");
+		await fs.writeFile(path.join(proxyDir, "old.log"), "old");
+		await setAge(path.join(proxyDir, "old.log"), 5);
+
+		await appendVsCodeLogs(zipPath, { proxyLogDir: proxyDir }, logger);
+
+		expect(vsCodeLogKeys(await readZip(zipPath))).toEqual([
+			"vscode-logs/proxy/recent.log",
+		]);
+	});
+
+	it("filters extension logs older than 3 days by mtime", async () => {
+		const zipPath = await makeBundle();
+
+		const extDir = path.join(tmpDir, "ext");
+		await fs.mkdir(extDir);
+		await fs.writeFile(path.join(extDir, "Coder-recent.log"), "recent");
+		await fs.writeFile(path.join(extDir, "Coder-old.log"), "old");
+		await setAge(path.join(extDir, "Coder-old.log"), 5);
+
+		await appendVsCodeLogs(zipPath, { extensionLogDir: extDir }, logger);
+
+		expect(vsCodeLogKeys(await readZip(zipPath))).toEqual([
+			"vscode-logs/extension/Coder-recent.log",
+		]);
+	});
+
+	it.runIf(canTestUnreadable)(
+		"skips missing or unreadable sources and includes the rest",
+		async () => {
+			const zipPath = await makeBundle();
+
+			const proxyDir = path.join(tmpDir, "proxy");
+			await fs.mkdir(proxyDir);
+			await fs.writeFile(path.join(proxyDir, "good.log"), "ok");
+			const badLog = path.join(proxyDir, "bad.log");
+			await fs.writeFile(badLog, "secret");
+			await fs.chmod(badLog, 0o000);
+
+			try {
+				await appendVsCodeLogs(
+					zipPath,
+					{
+						remoteSshLogPath: path.join(tmpDir, "nonexistent.log"),
+						proxyLogDir: proxyDir,
+						extensionLogDir: path.join(tmpDir, "no-such-dir"),
+					},
+					logger,
+				);
+
+				expect(vsCodeLogKeys(await readZip(zipPath))).toEqual([
+					"vscode-logs/proxy/good.log",
+				]);
+			} finally {
+				await fs.chmod(badLog, 0o644);
+			}
+		},
+	);
+
+	it("keeps the -vscode.zip sibling when rename fails", async () => {
+		const zipPath = await makeBundle();
+		const before = await fs.stat(zipPath);
+
+		const sshLog = path.join(tmpDir, "ssh.log");
+		await fs.writeFile(sshLog, "ssh content");
+
+		vi.mocked(renameWithRetry).mockRejectedValueOnce(
+			new Error("simulated rename failure"),
+		);
+
+		await appendVsCodeLogs(zipPath, { remoteSshLogPath: sshLog }, logger);
+
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
+
+		const siblingPath = path.join(tmpDir, "coder-support-123-vscode.zip");
+		const entries = await readZip(siblingPath);
+		expect(Object.keys(entries).sort()).toEqual([
+			"server/info.txt",
+			"vscode-logs/remote-ssh/ssh.log",
+		]);
+		expect(entries["vscode-logs/remote-ssh/ssh.log"]).toBe("ssh content");
+	});
+
+	it("leaves the original zip intact and cleans up the partial sibling when corrupted", async () => {
+		const zipPath = path.join(tmpDir, "coder-support-123.zip");
 		await fs.writeFile(zipPath, "not a zip");
+		const before = await fs.stat(zipPath);
 
 		const logPath = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(logPath, "content");
 
 		await appendVsCodeLogs(zipPath, { remoteSshLogPath: logPath }, logger);
 
-		expect(await fs.readFile(zipPath, "utf-8")).toBe("not a zip");
+		expect((await fs.stat(zipPath)).mtimeMs).toBe(before.mtimeMs);
+		expect(await fs.readdir(tmpDir)).not.toContain(
+			"coder-support-123-vscode.zip",
+		);
 	});
 });

--- a/test/unit/core/supportBundleLogs.test.ts
+++ b/test/unit/core/supportBundleLogs.test.ts
@@ -20,11 +20,10 @@ afterEach(async () => {
 
 const logger = createMockLogger();
 
-function proxyLogName(daysAgo: number): string {
-	const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
-	const pad = (n: number) => String(n).padStart(2, "0");
-	const ts = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
-	return `coder-ssh-${ts}-abc123.log`;
+/** Set a file's mtime to N days in the past. */
+async function setAge(filePath: string, daysAgo: number): Promise<void> {
+	const past = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+	await fs.utimes(filePath, past, past);
 }
 
 describe("collectLogFiles", () => {
@@ -32,10 +31,9 @@ describe("collectLogFiles", () => {
 		const sshLog = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(sshLog, "ssh");
 
-		const recentLog = proxyLogName(1);
 		const proxyDir = path.join(tmpDir, "proxy");
 		await fs.mkdir(proxyDir);
-		await fs.writeFile(path.join(proxyDir, recentLog), "proxy");
+		await fs.writeFile(path.join(proxyDir, "coder-ssh-recent.log"), "proxy");
 		await fs.mkdir(path.join(proxyDir, "subdir"));
 
 		const extDir = path.join(tmpDir, "ext");
@@ -53,11 +51,11 @@ describe("collectLogFiles", () => {
 
 		expect(Object.keys(files).sort()).toEqual([
 			"vscode-logs/extension/Coder.log",
-			`vscode-logs/proxy/${recentLog}`,
+			"vscode-logs/proxy/coder-ssh-recent.log",
 			"vscode-logs/remote-ssh/ssh.log",
 		]);
 		expect(
-			Buffer.from(files[`vscode-logs/proxy/${recentLog}`]).toString(),
+			Buffer.from(files["vscode-logs/proxy/coder-ssh-recent.log"]).toString(),
 		).toBe("proxy");
 	});
 
@@ -66,18 +64,19 @@ describe("collectLogFiles", () => {
 		expect(Object.keys(files)).toHaveLength(0);
 	});
 
-	it("filters proxy logs older than 3 days by filename timestamp", async () => {
+	it("filters proxy logs older than 3 days by mtime", async () => {
 		const proxyDir = path.join(tmpDir, "proxy");
 		await fs.mkdir(proxyDir);
 
-		const recentLog = proxyLogName(1);
-		const oldLog = proxyLogName(5);
-		await fs.writeFile(path.join(proxyDir, recentLog), "recent");
-		await fs.writeFile(path.join(proxyDir, oldLog), "old");
+		const recentFile = path.join(proxyDir, "recent.log");
+		const oldFile = path.join(proxyDir, "old.log");
+		await fs.writeFile(recentFile, "recent");
+		await fs.writeFile(oldFile, "old");
+		await setAge(oldFile, 5);
 
 		const files = await collectLogFiles({ proxyLogDir: proxyDir }, logger);
 
-		expect(Object.keys(files)).toEqual([`vscode-logs/proxy/${recentLog}`]);
+		expect(Object.keys(files)).toEqual(["vscode-logs/proxy/recent.log"]);
 	});
 
 	it("skips missing or unreadable sources and collects the rest", async () => {

--- a/test/unit/core/supportBundleLogs.test.ts
+++ b/test/unit/core/supportBundleLogs.test.ts
@@ -20,14 +20,22 @@ afterEach(async () => {
 
 const logger = createMockLogger();
 
+function proxyLogName(daysAgo: number): string {
+	const d = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000);
+	const pad = (n: number) => String(n).padStart(2, "0");
+	const ts = `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+	return `coder-ssh-${ts}-abc123.log`;
+}
+
 describe("collectLogFiles", () => {
 	it("collects from all three sources and skips subdirectories", async () => {
 		const sshLog = path.join(tmpDir, "ssh.log");
 		await fs.writeFile(sshLog, "ssh");
 
+		const recentLog = proxyLogName(1);
 		const proxyDir = path.join(tmpDir, "proxy");
 		await fs.mkdir(proxyDir);
-		await fs.writeFile(path.join(proxyDir, "99.log"), "proxy");
+		await fs.writeFile(path.join(proxyDir, recentLog), "proxy");
 		await fs.mkdir(path.join(proxyDir, "subdir"));
 
 		const extDir = path.join(tmpDir, "ext");
@@ -45,17 +53,31 @@ describe("collectLogFiles", () => {
 
 		expect(Object.keys(files).sort()).toEqual([
 			"vscode-logs/extension/Coder.log",
-			"vscode-logs/proxy/99.log",
+			`vscode-logs/proxy/${recentLog}`,
 			"vscode-logs/remote-ssh/ssh.log",
 		]);
-		expect(Buffer.from(files["vscode-logs/proxy/99.log"]).toString()).toBe(
-			"proxy",
-		);
+		expect(
+			Buffer.from(files[`vscode-logs/proxy/${recentLog}`]).toString(),
+		).toBe("proxy");
 	});
 
 	it("returns empty when no sources are provided", async () => {
 		const files = await collectLogFiles({}, logger);
 		expect(Object.keys(files)).toHaveLength(0);
+	});
+
+	it("filters proxy logs older than 3 days by filename timestamp", async () => {
+		const proxyDir = path.join(tmpDir, "proxy");
+		await fs.mkdir(proxyDir);
+
+		const recentLog = proxyLogName(1);
+		const oldLog = proxyLogName(5);
+		await fs.writeFile(path.join(proxyDir, recentLog), "recent");
+		await fs.writeFile(path.join(proxyDir, oldLog), "old");
+
+		const files = await collectLogFiles({ proxyLogDir: proxyDir }, logger);
+
+		expect(Object.keys(files)).toEqual([`vscode-logs/proxy/${recentLog}`]);
 	});
 
 	it("skips missing or unreadable sources and collects the rest", async () => {

--- a/test/unit/core/supportBundleLogs.test.ts
+++ b/test/unit/core/supportBundleLogs.test.ts
@@ -1,0 +1,123 @@
+import { strToU8, unzipSync, zipSync } from "fflate";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { appendVsCodeLogs, collectLogFiles } from "@/core/supportBundleLogs";
+
+import { createMockLogger } from "../../mocks/testHelpers";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+	tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "support-bundle-"));
+});
+
+afterEach(async () => {
+	await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+const logger = createMockLogger();
+
+describe("collectLogFiles", () => {
+	it("collects from all three sources and skips subdirectories", async () => {
+		const sshLog = path.join(tmpDir, "ssh.log");
+		await fs.writeFile(sshLog, "ssh");
+
+		const proxyDir = path.join(tmpDir, "proxy");
+		await fs.mkdir(proxyDir);
+		await fs.writeFile(path.join(proxyDir, "99.log"), "proxy");
+		await fs.mkdir(path.join(proxyDir, "subdir"));
+
+		const extDir = path.join(tmpDir, "ext");
+		await fs.mkdir(extDir);
+		await fs.writeFile(path.join(extDir, "Coder.log"), "ext");
+
+		const files = await collectLogFiles(
+			{
+				remoteSshLogPath: sshLog,
+				proxyLogDir: proxyDir,
+				extensionLogDir: extDir,
+			},
+			logger,
+		);
+
+		expect(Object.keys(files).sort()).toEqual([
+			"vscode-logs/extension/Coder.log",
+			"vscode-logs/proxy/99.log",
+			"vscode-logs/remote-ssh/ssh.log",
+		]);
+		expect(Buffer.from(files["vscode-logs/proxy/99.log"]).toString()).toBe(
+			"proxy",
+		);
+	});
+
+	it("returns empty when no sources are provided", async () => {
+		const files = await collectLogFiles({}, logger);
+		expect(Object.keys(files)).toHaveLength(0);
+	});
+
+	it("skips missing or unreadable sources and collects the rest", async () => {
+		const proxyDir = path.join(tmpDir, "proxy");
+		await fs.mkdir(proxyDir);
+		await fs.writeFile(path.join(proxyDir, "good.log"), "ok");
+		await fs.writeFile(path.join(proxyDir, "bad.log"), "secret");
+		await fs.chmod(path.join(proxyDir, "bad.log"), 0o000);
+
+		const files = await collectLogFiles(
+			{
+				remoteSshLogPath: path.join(tmpDir, "nonexistent.log"),
+				proxyLogDir: proxyDir,
+				extensionLogDir: path.join(tmpDir, "no-such-dir"),
+			},
+			logger,
+		);
+
+		expect(Object.keys(files)).toEqual(["vscode-logs/proxy/good.log"]);
+
+		await fs.chmod(path.join(proxyDir, "bad.log"), 0o644);
+	});
+});
+
+describe("appendVsCodeLogs", () => {
+	let zipPath: string;
+	let originalZipBytes: Uint8Array;
+
+	beforeEach(async () => {
+		zipPath = path.join(tmpDir, "coder-support-123.zip");
+		originalZipBytes = zipSync({ "server/info.txt": strToU8("server data") });
+		await fs.writeFile(zipPath, originalZipBytes);
+	});
+
+	it("merges log files into the existing zip", async () => {
+		const logPath = path.join(tmpDir, "ssh.log");
+		await fs.writeFile(logPath, "ssh content");
+
+		await appendVsCodeLogs(zipPath, { remoteSshLogPath: logPath }, logger);
+
+		const zip = unzipSync(new Uint8Array(await fs.readFile(zipPath)));
+		expect(Buffer.from(zip["server/info.txt"]).toString()).toBe("server data");
+		expect(Buffer.from(zip["vscode-logs/remote-ssh/ssh.log"]).toString()).toBe(
+			"ssh content",
+		);
+	});
+
+	it("does not touch the zip when no logs are found", async () => {
+		await appendVsCodeLogs(zipPath, {}, logger);
+
+		const data = new Uint8Array(await fs.readFile(zipPath));
+		expect(Buffer.from(data)).toEqual(Buffer.from(originalZipBytes));
+	});
+
+	it("leaves the original zip intact when it is corrupted", async () => {
+		await fs.writeFile(zipPath, "not a zip");
+
+		const logPath = path.join(tmpDir, "ssh.log");
+		await fs.writeFile(logPath, "content");
+
+		await appendVsCodeLogs(zipPath, { remoteSshLogPath: logPath }, logger);
+
+		expect(await fs.readFile(zipPath, "utf-8")).toBe("not a zip");
+	});
+});


### PR DESCRIPTION
After the CLI generates the support bundle zip, this appends logs from three VS Code-side sources under a `vscode-logs/` directory:

- **Remote SSH extension log** — single file from `SshProcessMonitor.getLogFilePath()`
- **SSH proxy logs** — all files from `PathResolver.getProxyLogPath()`, filtered to the last 3 days by mtime
- **Extension output channel logs** — all files from `PathResolver.getCodeLogDir()`, filtered to the last 3 days by mtime

Each source is collected independently. If a source is unavailable or a file cannot be read, it is warned and skipped. If the zip read/merge/write fails, the original bundle is left untouched and any partial sibling is cleaned up. If the atomic rename step fails, the merged zip is left alongside the original as `<name>-vscode.zip` and that path is surfaced in a warning log so the user can still find their bundle.

Uses [fflate](https://github.com/101arrowz/fflate) (zero dependencies, 8kB minified, tree-shakeable) via its async `zip` / `unzip` callbacks wrapped with `node:util.promisify`. Memory is bounded by on-disk rotation: VS Code rotates extension logs per session, and `SshProcessMonitor` caps proxy logs at 20 files / 7 days, so the in-memory peak stays small.

<details>
<summary>Files changed</summary>

| File | Change |
|------|--------|
| `package.json` / `pnpm-lock.yaml` | Add `fflate` dependency |
| `src/core/supportBundleLogs.ts` | Log collection and zip append logic |
| `src/commands.ts` | Call `appendVsCodeLogs` after CLI produces the bundle |
| `test/unit/core/supportBundleLogs.test.ts` | 7 tests covering merge, empty sources, age filtering, unreadable files, rename failure, and corrupt zip |

</details>

Closes #889