### PR TITLE
feat: enhance parseRemoteAuthority to handle domains containing "--"

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -61,14 +61,30 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 	// coder-vscode(--|.)<username>--<workspace>(--|.)<agent?>
 	// The agent can be omitted; the user will be prompted for it instead.
 	// Anything else is unrelated to Coder and can be ignored.
-	const parts = authorityParts[1].split("--");
+	const rawParts = authorityParts[1].split("--");
 	if (
-		parts.length <= 1 ||
-		(parts[0] !== AuthorityPrefix &&
-			!parts[0].startsWith(`${AuthorityPrefix}.`))
+		rawParts.length <= 1 ||
+		(rawParts[0] !== AuthorityPrefix &&
+			!rawParts[0].startsWith(`${AuthorityPrefix}.`))
 	) {
 		return null;
 	}
+
+	// DNS labels may legally contain "--" (Punycode labels like "xn--{encoded}"
+	// are a common example), which breaks a naive split.  Coder usernames and
+	// workspace names follow a slug pattern that never contains dots, so a
+	// dot-bearing segment after splitting on "--" must be a hostname fragment
+	// rather than a username.  We reassemble from the front: while the next
+	// segment contains a dot, merge it back into the accumulated prefix.
+	let reassemblingParts = rawParts;
+	while (reassemblingParts.length >= 2) {
+		if (reassemblingParts[1].includes(".")) {
+			reassemblingParts = [reassemblingParts.slice(0, 2).join("--"), ...reassemblingParts.slice(2)];
+		} else {
+			break;
+		}
+	}
+	const parts = reassemblingParts;
 
 	// It has the proper prefix, so this is probably a Coder host name.
 	// Validate the SSH host name.  Including the prefix, we expect at least

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -91,6 +91,17 @@ describe("parseRemoteAuthority", () => {
 			username: "foo",
 			workspace: "bar",
 		});
+		expect(
+			parseRemoteAuthority(
+				"vscode://ssh-remote+coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
+			),
+		).toStrictEqual({
+			agent: "",
+			sshHost: "coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
+			safeHostname: "dev.coder.xn--eckwd4c7cu47r2wf.jp",
+			username: "foo",
+			workspace: "bar",
+		});
 	});
 });
 


### PR DESCRIPTION
### Problem

As explained in [CONTRIBUTING.md](https://github.com/coder/vscode-coder/blob/98048f2ba65bed9762b00b47d989e1daf91d37f6/CONTRIBUTING.md), 

> The host name takes the format coder-vscode.<domain>--<username>--<workspace>.

The parser splits on "--" to extract each component, but domain labels may contain "--".
In practice, IDNA/Punycode-encoded domain labels use `xn--` as the ACE prefix.
So the naive split("--") misparses hostnames with such labels, and causes errors like the following image.

<img width="1202" height="666" alt="Screenshot 2026-04-23 02-50-34" src="https://github.com/user-attachments/assets/8ba3c0d3-720d-494e-96ed-f20f1f4c1f87" />
                                                                   
For example, a Coder deployment `coder.xn--eckwd4c7cu47r2wf.jp` would produce an SSH host of `coder-vscode.coder.xn--eckwd4c7cu47r2wf.jp--yourname--your-workspace`.
When split on "--", this yields `["coder-vscode.coder.xn", "eckwd4c7cu47r2wf.jp", "yourname", "your-workspace"]` but the parser expects the first element to be the full hostname, so vscode-coder would try to open a workspace `yourname` whose owner is `eckwd4c7cu47r2wf.jp` and fails.

### Solution

Added a reassembly step after the initial split("--").
The algorithm scans from the front of the split result:

- The first segment is always a part of a hostname.
- If the second segment contains a dot, that must be a fragmented part of a hostname. So merge those two segments back with "--". 
- Because more than one domain labels may contain "--", repeat this merging process until a dot does not appear in the second segment. 

This works because [Coder usernames never contain dots](https://github.com/coder/coder/blob/075face3cbf95e99f77c7081b49c28a436009ad6/codersdk/name.go#L14),
so any dot-bearing segment after the split must be a hostname fragment.

Note: a TLD containing "--" would not be handled correctly because such hostname would fragment into segments the last of which does not contain dot, but no such TLD exists today. 