### PR TITLE
fix: defer Workspace Build output channel creation until first write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
      from published versions since it shows up in the VS Code extension changelog
      tab and is confusing to users. Add it back between releases if needed. -->
 
+## Unreleased
+
+### Fixed
+
+- The **Coder: Workspace Build** output channel is no longer created when reconnecting to an
+  already-running workspace, so the Output panel doesn't pop open empty.
+
 ## [v1.14.4-pre](https://github.com/coder/vscode-coder/releases/tag/v1.14.4-pre) 2026-04-20
 
 ### Added

--- a/src/remote/terminalOutputChannel.ts
+++ b/src/remote/terminalOutputChannel.ts
@@ -1,20 +1,26 @@
 import stripAnsi from "strip-ansi";
 import * as vscode from "vscode";
 
-/** Adapts terminal-style output for a VS Code OutputChannel. Strips ANSI escape sequences and carriage returns. */
+/**
+ * Wraps a VS Code OutputChannel for terminal-style output, stripping ANSI
+ * escapes and carriage returns. The channel is created lazily on first write
+ * to avoid surfacing an empty pane in the Output dropdown when nothing is
+ * ever written.
+ */
 export class TerminalOutputChannel implements vscode.Disposable {
-	private readonly channel: vscode.OutputChannel;
+	private channel: vscode.OutputChannel | undefined;
 
-	constructor(name: string) {
-		this.channel = vscode.window.createOutputChannel(name);
-		this.channel.show(true);
-	}
+	constructor(private readonly name: string) {}
 
 	write(data: string): void {
+		if (!this.channel) {
+			this.channel = vscode.window.createOutputChannel(this.name);
+			this.channel.show(true);
+		}
 		this.channel.append(stripAnsi(data).replace(/\r/g, ""));
 	}
 
 	dispose(): void {
-		this.channel.dispose();
+		this.channel?.dispose();
 	}
 }

--- a/test/unit/remote/terminalOutputChannel.test.ts
+++ b/test/unit/remote/terminalOutputChannel.test.ts
@@ -27,4 +27,13 @@ describe("TerminalOutputChannel", () => {
 	])("%s", (_label, input, expected) => {
 		expect(setup(input).content.join("")).toBe(expected);
 	});
+
+	it("does not create the channel until first write", () => {
+		vi.mocked(vscode.window.createOutputChannel).mockClear();
+		const channel = new TerminalOutputChannel("test");
+		expect(vscode.window.createOutputChannel).not.toHaveBeenCalled();
+
+		channel.write("hello");
+		expect(vscode.window.createOutputChannel).toHaveBeenCalledOnce();
+	});
 });


### PR DESCRIPTION
- `TerminalOutputChannel`'s constructor previously called `createOutputChannel` and `show(true)` immediately, so the Output panel popped open every time we built a `WorkspaceStateMachine` — even on reconnects to an already-running workspace where no build logs would ever be written.
- The empty channel was disposed shortly afterward, but the Output panel itself stayed visible (VS Code's API has no way to programmatically close the Output panel).
- Defer both `createOutputChannel` and `show(true)` to the first `write()`. Reconnects to a running workspace never create the channel and never pop the panel; real builds behave exactly as before.