### PR TITLE
ci: run tests on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,21 +28,19 @@ jobs:
       - run: pnpm build
 
   test-unit:
-    name: Unit Test (${{ matrix.os }}, Electron ${{ matrix.electron-version }})
+    name: Unit Test (${{ matrix.name }}, Electron ${{ matrix.electron-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # Minimum supported version: VS Code 1.106 (Oct 2025) -> Electron 37 -> Node 22
-        # See https://github.com/ewanharris/vscode-versions for version mapping
-        os: [ubuntu-24.04]
-        electron-version: ["37", "latest"]
-        # Smoke-test latest Electron on Windows + macOS; older Electron stays Linux-only.
+        # See https://github.com/ewanharris/vscode-versions for version mapping.
+        # Older Electron stays Linux-only; "latest" smoke-tests Windows + macOS too.
         include:
-          - os: windows-latest
-            electron-version: "latest"
-          - os: macos-latest
-            electron-version: "latest"
+          - { os: ubuntu-24.04, name: Linux, electron-version: "37" }
+          - { os: ubuntu-24.04, name: Linux, electron-version: "latest" }
+          - { os: windows-2025, name: Windows, electron-version: "latest" }
+          - { os: macos-15, name: macOS, electron-version: "latest" }
 
     steps:
       - uses: actions/checkout@v6
@@ -56,18 +54,16 @@ jobs:
           CI: true
 
   test-integration:
-    name: Integration Test (${{ matrix.os }}, VS Code ${{ matrix.vscode-version }})
+    name: Integration Test (${{ matrix.name }}, VS Code ${{ matrix.vscode-version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
-        vscode-version: ["1.106.0", "stable"]
         include:
-          - os: windows-latest
-            vscode-version: "stable"
-          - os: macos-latest
-            vscode-version: "stable"
+          - { os: ubuntu-24.04, name: Linux, vscode-version: "1.106.0" }
+          - { os: ubuntu-24.04, name: Linux, vscode-version: "stable" }
+          - { os: windows-2025, name: Windows, vscode-version: "stable" }
+          - { os: macos-15, name: macOS, vscode-version: "stable" }
 
     steps:
       - uses: actions/checkout@v6
@@ -76,13 +72,9 @@ jobs:
 
       - run: pnpm build
 
-      - name: Run integration tests on VS Code ${{ matrix.vscode-version }} (Linux)
-        if: runner.os == 'Linux'
-        run: xvfb-run -a pnpm test:integration --label "VS Code ${{ matrix.vscode-version }}"
-
-      - name: Run integration tests on VS Code ${{ matrix.vscode-version }} (Windows/macOS)
-        if: runner.os != 'Linux'
-        run: pnpm test:integration --label "VS Code ${{ matrix.vscode-version }}"
+      - name: Run integration tests on VS Code ${{ matrix.vscode-version }}
+        # xvfb only exists on Linux; on Windows/macOS the runner has a real display.
+        run: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }} pnpm test:integration --label "VS Code ${{ matrix.vscode-version }}"
         shell: bash
 
   package:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,14 +28,21 @@ jobs:
       - run: pnpm build
 
   test-unit:
-    name: Unit Test (Electron ${{ matrix.electron-version }})
-    runs-on: ubuntu-24.04
+    name: Unit Test (${{ matrix.os }}, Electron ${{ matrix.electron-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # Minimum supported version: VS Code 1.106 (Oct 2025) -> Electron 37 -> Node 22
         # See https://github.com/ewanharris/vscode-versions for version mapping
+        os: [ubuntu-24.04]
         electron-version: ["37", "latest"]
+        # Smoke-test latest Electron on Windows + macOS; older Electron stays Linux-only.
+        include:
+          - os: windows-latest
+            electron-version: "latest"
+          - os: macos-latest
+            electron-version: "latest"
 
     steps:
       - uses: actions/checkout@v6
@@ -44,16 +51,23 @@ jobs:
 
       - name: Run tests with Electron ${{ matrix.electron-version }}
         run: ./scripts/test-electron.sh ${{ matrix.electron-version }}
+        shell: bash
         env:
           CI: true
 
   test-integration:
-    name: Integration Test (VS Code ${{ matrix.vscode-version }})
-    runs-on: ubuntu-24.04
+    name: Integration Test (${{ matrix.os }}, VS Code ${{ matrix.vscode-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-24.04]
         vscode-version: ["1.106.0", "stable"]
+        include:
+          - os: windows-latest
+            vscode-version: "stable"
+          - os: macos-latest
+            vscode-version: "stable"
 
     steps:
       - uses: actions/checkout@v6
@@ -62,8 +76,14 @@ jobs:
 
       - run: pnpm build
 
-      - name: Run integration tests on VS Code ${{ matrix.vscode-version }}
+      - name: Run integration tests on VS Code ${{ matrix.vscode-version }} (Linux)
+        if: runner.os == 'Linux'
         run: xvfb-run -a pnpm test:integration --label "VS Code ${{ matrix.vscode-version }}"
+
+      - name: Run integration tests on VS Code ${{ matrix.vscode-version }} (Windows/macOS)
+        if: runner.os != 'Linux'
+        run: pnpm test:integration --label "VS Code ${{ matrix.vscode-version }}"
+        shell: bash
 
   package:
     name: Package


### PR DESCRIPTION
- Add Windows and macOS to the unit and integration test matrices to catch cross-platform regressions automatically (path separators, shell quoting, `.cmd` shim resolution, etc. — see #876 for prior offenders).
- Linux keeps the full matrix (Electron `37` + `latest`, VS Code `1.106.0` + `stable`); Windows and macOS each run a single `latest`/`stable` smoke job to keep the matrix tight (+4 jobs total, all parallel).
- `xvfb-run` is gated to Linux; Windows/macOS run `pnpm test:integration` directly since `@vscode/test-electron` handles platform-specific VS Code downloads.

Closes #882