### PR TITLE
fix: refresh CLI credentials before each invocation

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -930,7 +930,8 @@ export class Commands {
 		const configDir = this.pathResolver.getGlobalConfigDir(safeHost);
 		const configs = vscode.workspace.getConfiguration();
 		const auth = resolveCliAuth(configs, featureSet, baseUrl, configDir);
-		return { binary, configs, auth, featureSet };
+		const authEnv = { url: baseUrl, token: client.getSessionToken() ?? "" };
+		return { binary, configs, auth, authEnv, featureSet };
 	}
 
 	/**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -930,8 +930,11 @@ export class Commands {
 		const configDir = this.pathResolver.getGlobalConfigDir(safeHost);
 		const configs = vscode.workspace.getConfiguration();
 		const auth = resolveCliAuth(configs, featureSet, baseUrl, configDir);
-		const authEnv = { url: baseUrl, token: client.getSessionToken() ?? "" };
-		return { binary, configs, auth, authEnv, featureSet };
+		const childCredentials = {
+			url: baseUrl,
+			token: client.getSessionToken() ?? "",
+		};
+		return { binary, configs, auth, childCredentials, featureSet };
 	}
 
 	/**

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -930,11 +930,13 @@ export class Commands {
 		const configDir = this.pathResolver.getGlobalConfigDir(safeHost);
 		const configs = vscode.workspace.getConfiguration();
 		const auth = resolveCliAuth(configs, featureSet, baseUrl, configDir);
-		const childCredentials = {
-			url: baseUrl,
-			token: client.getSessionToken() ?? "",
-		};
-		return { binary, configs, auth, childCredentials, featureSet };
+		// Same threat model as the connection-time write in remote.ts: token
+		// goes to the file (or keyring on supported systems), never env, since
+		// child env is sibling-readable on most platforms.
+		await this.cliManager.configure(baseUrl, client.getSessionToken() ?? "", {
+			silent: true,
+		});
+		return { binary, configs, auth, featureSet };
 	}
 
 	/**

--- a/src/core/cliCredentialManager.ts
+++ b/src/core/cliCredentialManager.ts
@@ -56,16 +56,13 @@ export class CliCredentialManager {
 	 * setting is enabled and the CLI supports it; otherwise writes plaintext
 	 * files under --global-config.
 	 *
-	 * Keyring and files are mutually exclusive — never both.
-	 *
-	 * When `keyringOnly` is set, silently returns if the keyring is unavailable
-	 * instead of falling back to file storage.
+	 * Keyring and files are mutually exclusive, never both.
 	 */
 	public async storeToken(
 		url: string,
 		token: string,
 		configs: Pick<WorkspaceConfiguration, "get">,
-		options?: { signal?: AbortSignal; keyringOnly?: boolean },
+		options?: { signal?: AbortSignal },
 	): Promise<void> {
 		const binPath = await this.resolveKeyringBinary(
 			url,
@@ -73,9 +70,6 @@ export class CliCredentialManager {
 			"keyringAuth",
 		);
 		if (!binPath) {
-			if (options?.keyringOnly) {
-				return;
-			}
 			await this.writeCredentialFiles(url, token);
 			return;
 		}

--- a/src/core/cliExec.ts
+++ b/src/core/cliExec.ts
@@ -19,35 +19,6 @@ export interface CliEnv {
 	authEnv: { url: string; token: string };
 }
 
-const execFileAsync = promisify(execFile);
-
-function buildChildEnv(env: CliEnv): NodeJS.ProcessEnv {
-	return {
-		...process.env,
-		CODER_URL: env.authEnv.url,
-		CODER_SESSION_TOKEN: env.authEnv.token,
-	};
-}
-
-function isExecFileException(error: unknown): error is ExecFileException {
-	return error instanceof Error && "code" in error;
-}
-
-/** Prefer stderr over the default message which includes the full command line. */
-function cliError(error: unknown): Error {
-	// Pass aborts through; wrapping erases the AbortError name and would surface stale CLI warnings as the failure.
-	if (isAbortError(error)) {
-		return error;
-	}
-	if (isExecFileException(error)) {
-		const stderr = error.stderr?.trim();
-		if (stderr) {
-			return new Error(stderr, { cause: error });
-		}
-	}
-	return toError(error);
-}
-
 /**
  * Return the version from the binary.  Throw if unable to execute the binary or
  * find the version for any reason.
@@ -154,6 +125,61 @@ export function ping(env: CliEnv, workspaceName: string): vscode.Terminal {
 		banner: ["Press Ctrl+C (^C) to stop.", "─".repeat(40)],
 		env: buildChildEnv(env),
 	});
+}
+
+/**
+ * SSH into a workspace and run a command via `terminal.sendText`.
+ */
+export async function openAppStatusTerminal(
+	env: CliEnv,
+	app: {
+		name?: string;
+		command?: string;
+		workspace_name: string;
+	},
+): Promise<void> {
+	const globalFlags = getGlobalShellFlags(env.configs, env.auth);
+	const terminal = vscode.window.createTerminal({
+		name: app.name,
+		env: buildChildEnv(env),
+	});
+	terminal.sendText(
+		`${escapeCommandArg(env.binary)} ${globalFlags.join(" ")} ssh ${escapeCommandArg(app.workspace_name)}`,
+	);
+	await new Promise((resolve) => setTimeout(resolve, 5000));
+	terminal.sendText(app.command ?? "");
+	terminal.show(false);
+}
+
+// --- helpers ---
+
+const execFileAsync = promisify(execFile);
+
+function buildChildEnv(env: CliEnv): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		CODER_URL: env.authEnv.url,
+		CODER_SESSION_TOKEN: env.authEnv.token,
+	};
+}
+
+function isExecFileException(error: unknown): error is ExecFileException {
+	return error instanceof Error && "code" in error;
+}
+
+/** Prefer stderr over the default message which includes the full command line. */
+function cliError(error: unknown): Error {
+	// Pass aborts through; wrapping erases the AbortError name and would surface stale CLI warnings as the failure.
+	if (isAbortError(error)) {
+		return error;
+	}
+	if (isExecFileException(error)) {
+		const stderr = error.stderr?.trim();
+		if (stderr) {
+			return new Error(stderr, { cause: error });
+		}
+	}
+	return toError(error);
 }
 
 /**
@@ -284,28 +310,4 @@ function spawnCliInTerminal(options: {
 
 	terminal.show(false);
 	return terminal;
-}
-
-/**
- * SSH into a workspace and run a command via `terminal.sendText`.
- */
-export async function openAppStatusTerminal(
-	env: CliEnv,
-	app: {
-		name?: string;
-		command?: string;
-		workspace_name: string;
-	},
-): Promise<void> {
-	const globalFlags = getGlobalShellFlags(env.configs, env.auth);
-	const terminal = vscode.window.createTerminal({
-		name: app.name,
-		env: buildChildEnv(env),
-	});
-	terminal.sendText(
-		`${escapeCommandArg(env.binary)} ${globalFlags.join(" ")} ssh ${escapeCommandArg(app.workspace_name)}`,
-	);
-	await new Promise((resolve) => setTimeout(resolve, 5000));
-	terminal.sendText(app.command ?? "");
-	terminal.show(false);
 }

--- a/src/core/cliExec.ts
+++ b/src/core/cliExec.ts
@@ -16,7 +16,7 @@ export interface CliEnv {
 	auth: CliAuth;
 	configs: Pick<vscode.WorkspaceConfiguration, "get">;
 	/** Forwarded to the child as `CODER_URL` / `CODER_SESSION_TOKEN`. Empty token is valid for mTLS. */
-	authEnv: { url: string; token: string };
+	childCredentials: { url: string; token: string };
 }
 
 /**
@@ -76,7 +76,7 @@ export async function speedtest(
 	try {
 		const result = await execFileAsync(env.binary, args, {
 			signal,
-			env: buildChildEnv(env),
+			env: execFileEnv(env),
 		});
 		return result.stdout;
 	} catch (error) {
@@ -106,7 +106,7 @@ export async function supportBundle(
 	try {
 		await execFileAsync(env.binary, args, {
 			signal,
-			env: buildChildEnv(env),
+			env: execFileEnv(env),
 		});
 	} catch (error) {
 		throw cliError(error);
@@ -123,7 +123,7 @@ export function ping(env: CliEnv, workspaceName: string): vscode.Terminal {
 		binary: env.binary,
 		args: [...globalFlags, "ping", escapeCommandArg(workspaceName)],
 		banner: ["Press Ctrl+C (^C) to stop.", "─".repeat(40)],
-		env: buildChildEnv(env),
+		env: execFileEnv(env),
 	});
 }
 
@@ -139,9 +139,10 @@ export async function openAppStatusTerminal(
 	},
 ): Promise<void> {
 	const globalFlags = getGlobalShellFlags(env.configs, env.auth);
+	// Pass only the delta; createTerminal merges it on top of the user's terminal env.
 	const terminal = vscode.window.createTerminal({
 		name: app.name,
-		env: buildChildEnv(env),
+		env: authEnv(env),
 	});
 	terminal.sendText(
 		`${escapeCommandArg(env.binary)} ${globalFlags.join(" ")} ssh ${escapeCommandArg(app.workspace_name)}`,
@@ -151,20 +152,22 @@ export async function openAppStatusTerminal(
 	terminal.show(false);
 }
 
-// --- helpers ---
-
 const execFileAsync = promisify(execFile);
 
-function buildChildEnv(env: CliEnv): NodeJS.ProcessEnv {
-	return {
-		...process.env,
-		CODER_URL: env.authEnv.url,
-		CODER_SESSION_TOKEN: env.authEnv.token,
-	};
+/**
+ * Full env for `execFile`/`spawn`, which replace the child env entirely:
+ * inherit `process.env` and overlay auth on top.
+ */
+function execFileEnv(env: CliEnv): NodeJS.ProcessEnv {
+	return { ...process.env, ...authEnv(env) };
 }
 
-function isExecFileException(error: unknown): error is ExecFileException {
-	return error instanceof Error && "code" in error;
+/** Auth env vars to forward to a coder child process. */
+function authEnv(env: CliEnv): NodeJS.ProcessEnv {
+	return {
+		CODER_URL: env.childCredentials.url,
+		CODER_SESSION_TOKEN: env.childCredentials.token,
+	};
 }
 
 /** Prefer stderr over the default message which includes the full command line. */
@@ -180,6 +183,10 @@ function cliError(error: unknown): Error {
 		}
 	}
 	return toError(error);
+}
+
+function isExecFileException(error: unknown): error is ExecFileException {
+	return error instanceof Error && "code" in error;
 }
 
 /**
@@ -235,10 +242,8 @@ function spawnCliInTerminal(options: {
 			onDidWrite: writeEmitter.event,
 			onDidClose: closeEmitter.event,
 			open: () => {
-				if (options.banner) {
-					for (const line of options.banner) {
-						writeEmitter.fire(line + "\r\n");
-					}
+				for (const line of options.banner) {
+					writeEmitter.fire(line + "\r\n");
 				}
 			},
 			close: () => {

--- a/src/core/cliExec.ts
+++ b/src/core/cliExec.ts
@@ -2,7 +2,7 @@ import { type ExecFileException, execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import * as vscode from "vscode";
 
-import { toError } from "../error/errorUtils";
+import { isAbortError, toError } from "../error/errorUtils";
 import {
 	type CliAuth,
 	getGlobalFlags,
@@ -15,9 +15,19 @@ export interface CliEnv {
 	binary: string;
 	auth: CliAuth;
 	configs: Pick<vscode.WorkspaceConfiguration, "get">;
+	/** Forwarded to the child as `CODER_URL` / `CODER_SESSION_TOKEN`. Empty token is valid for mTLS. */
+	authEnv: { url: string; token: string };
 }
 
 const execFileAsync = promisify(execFile);
+
+function buildChildEnv(env: CliEnv): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		CODER_URL: env.authEnv.url,
+		CODER_SESSION_TOKEN: env.authEnv.token,
+	};
+}
 
 function isExecFileException(error: unknown): error is ExecFileException {
 	return error instanceof Error && "code" in error;
@@ -25,6 +35,10 @@ function isExecFileException(error: unknown): error is ExecFileException {
 
 /** Prefer stderr over the default message which includes the full command line. */
 function cliError(error: unknown): Error {
+	// Pass aborts through; wrapping erases the AbortError name and would surface stale CLI warnings as the failure.
+	if (isAbortError(error)) {
+		return error;
+	}
 	if (isExecFileException(error)) {
 		const stderr = error.stderr?.trim();
 		if (stderr) {
@@ -89,7 +103,10 @@ export async function speedtest(
 		args.push("-t", duration);
 	}
 	try {
-		const result = await execFileAsync(env.binary, args, { signal });
+		const result = await execFileAsync(env.binary, args, {
+			signal,
+			env: buildChildEnv(env),
+		});
 		return result.stdout;
 	} catch (error) {
 		throw cliError(error);
@@ -116,7 +133,10 @@ export async function supportBundle(
 		"--yes",
 	];
 	try {
-		await execFileAsync(env.binary, args, { signal });
+		await execFileAsync(env.binary, args, {
+			signal,
+			env: buildChildEnv(env),
+		});
 	} catch (error) {
 		throw cliError(error);
 	}
@@ -132,6 +152,7 @@ export function ping(env: CliEnv, workspaceName: string): vscode.Terminal {
 		binary: env.binary,
 		args: [...globalFlags, "ping", escapeCommandArg(workspaceName)],
 		banner: ["Press Ctrl+C (^C) to stop.", "─".repeat(40)],
+		env: buildChildEnv(env),
 	});
 }
 
@@ -142,7 +163,8 @@ function spawnCliInTerminal(options: {
 	name: string;
 	binary: string;
 	args: string[];
-	banner?: string[];
+	banner: string[];
+	env: NodeJS.ProcessEnv;
 }): vscode.Terminal {
 	const writeEmitter = new vscode.EventEmitter<string>();
 	const closeEmitter = new vscode.EventEmitter<number | void>();
@@ -156,6 +178,7 @@ function spawnCliInTerminal(options: {
 	const proc = spawn(cmd, {
 		shell: true,
 		detached: useProcessGroup,
+		env: options.env,
 	});
 
 	let closed = false;
@@ -275,7 +298,10 @@ export async function openAppStatusTerminal(
 	},
 ): Promise<void> {
 	const globalFlags = getGlobalShellFlags(env.configs, env.auth);
-	const terminal = vscode.window.createTerminal(app.name);
+	const terminal = vscode.window.createTerminal({
+		name: app.name,
+		env: buildChildEnv(env),
+	});
 	terminal.sendText(
 		`${escapeCommandArg(env.binary)} ${globalFlags.join(" ")} ssh ${escapeCommandArg(app.workspace_name)}`,
 	);

--- a/src/core/cliExec.ts
+++ b/src/core/cliExec.ts
@@ -15,8 +15,6 @@ export interface CliEnv {
 	binary: string;
 	auth: CliAuth;
 	configs: Pick<vscode.WorkspaceConfiguration, "get">;
-	/** Forwarded to the child as `CODER_URL` / `CODER_SESSION_TOKEN`. Empty token is valid for mTLS. */
-	childCredentials: { url: string; token: string };
 }
 
 /**
@@ -74,10 +72,7 @@ export async function speedtest(
 		args.push("-t", duration);
 	}
 	try {
-		const result = await execFileAsync(env.binary, args, {
-			signal,
-			env: execFileEnv(env),
-		});
+		const result = await execFileAsync(env.binary, args, { signal });
 		return result.stdout;
 	} catch (error) {
 		throw cliError(error);
@@ -104,10 +99,7 @@ export async function supportBundle(
 		"--yes",
 	];
 	try {
-		await execFileAsync(env.binary, args, {
-			signal,
-			env: execFileEnv(env),
-		});
+		await execFileAsync(env.binary, args, { signal });
 	} catch (error) {
 		throw cliError(error);
 	}
@@ -123,7 +115,6 @@ export function ping(env: CliEnv, workspaceName: string): vscode.Terminal {
 		binary: env.binary,
 		args: [...globalFlags, "ping", escapeCommandArg(workspaceName)],
 		banner: ["Press Ctrl+C (^C) to stop.", "─".repeat(40)],
-		env: execFileEnv(env),
 	});
 }
 
@@ -139,11 +130,7 @@ export async function openAppStatusTerminal(
 	},
 ): Promise<void> {
 	const globalFlags = getGlobalShellFlags(env.configs, env.auth);
-	// Pass only the delta; createTerminal merges it on top of the user's terminal env.
-	const terminal = vscode.window.createTerminal({
-		name: app.name,
-		env: authEnv(env),
-	});
+	const terminal = vscode.window.createTerminal({ name: app.name });
 	terminal.sendText(
 		`${escapeCommandArg(env.binary)} ${globalFlags.join(" ")} ssh ${escapeCommandArg(app.workspace_name)}`,
 	);
@@ -153,22 +140,6 @@ export async function openAppStatusTerminal(
 }
 
 const execFileAsync = promisify(execFile);
-
-/**
- * Full env for `execFile`/`spawn`, which replace the child env entirely:
- * inherit `process.env` and overlay auth on top.
- */
-function execFileEnv(env: CliEnv): NodeJS.ProcessEnv {
-	return { ...process.env, ...authEnv(env) };
-}
-
-/** Auth env vars to forward to a coder child process. */
-function authEnv(env: CliEnv): NodeJS.ProcessEnv {
-	return {
-		CODER_URL: env.childCredentials.url,
-		CODER_SESSION_TOKEN: env.childCredentials.token,
-	};
-}
 
 /** Prefer stderr over the default message which includes the full command line. */
 function cliError(error: unknown): Error {
@@ -197,7 +168,6 @@ function spawnCliInTerminal(options: {
 	binary: string;
 	args: string[];
 	banner: string[];
-	env: NodeJS.ProcessEnv;
 }): vscode.Terminal {
 	const writeEmitter = new vscode.EventEmitter<string>();
 	const closeEmitter = new vscode.EventEmitter<number | void>();
@@ -211,7 +181,6 @@ function spawnCliInTerminal(options: {
 	const proc = spawn(cmd, {
 		shell: true,
 		detached: useProcessGroup,
-		env: options.env,
 	});
 
 	let closed = false;

--- a/src/core/cliManager.ts
+++ b/src/core/cliManager.ts
@@ -817,6 +817,9 @@ export class CliManager {
 	 *
 	 * Both URL and token are required. Empty tokens are allowed (e.g. mTLS
 	 * authentication) but the URL must be a non-empty string.
+	 *
+	 * @param options.silent Suppress the progress notification only; failures
+	 *   still surface via {@link handleStoreError} (logged + error toast).
 	 */
 	public async configure(
 		url: string,

--- a/src/error/errorUtils.ts
+++ b/src/error/errorUtils.ts
@@ -4,7 +4,7 @@ import util from "node:util";
 import { toError as baseToError } from "@repo/shared";
 
 /** Check whether an unknown thrown value is an AbortError (signal cancellation). */
-export function isAbortError(error: unknown): boolean {
+export function isAbortError(error: unknown): error is Error {
 	return error instanceof Error && error.name === "AbortError";
 }
 

--- a/src/login/loginCoordinator.ts
+++ b/src/login/loginCoordinator.ts
@@ -153,17 +153,11 @@ export class LoginCoordinator implements vscode.Disposable {
 			});
 			await this.mementoManager.addToUrlHistory(url);
 
-			// Fire-and-forget: sync token to OS keyring for the CLI.
 			if (result.token) {
 				this.cliCredentialManager
-					.storeToken(url, result.token, vscode.workspace.getConfiguration(), {
-						keyringOnly: true,
-					})
+					.storeToken(url, result.token, vscode.workspace.getConfiguration())
 					.catch((error) => {
-						this.logger.warn(
-							"Failed to store token in keyring at login:",
-							error,
-						);
+						this.logger.warn("Failed to store token at login:", error);
 					});
 			}
 		}

--- a/test/unit/core/cliCredentialManager.test.ts
+++ b/test/unit/core/cliCredentialManager.test.ts
@@ -269,42 +269,6 @@ describe("CliCredentialManager", () => {
 				}),
 			).rejects.toThrow("The operation was aborted");
 		});
-
-		it.each([
-			{ scenario: "keyring disabled", keyringEnabled: false },
-			{ scenario: "CLI version too old", keyringEnabled: true },
-		])(
-			"never writes files when keyringOnly and $scenario",
-			async ({ keyringEnabled }) => {
-				vi.mocked(isKeyringEnabled).mockReturnValue(keyringEnabled);
-				if (keyringEnabled) {
-					vi.mocked(cliExec.version).mockResolvedValueOnce("2.28.0");
-				}
-				const { manager } = setup();
-
-				await manager.storeToken(TEST_URL, "token", configs, {
-					keyringOnly: true,
-				});
-
-				expect(execFile).not.toHaveBeenCalled();
-				expect(memfs.existsSync(URL_FILE)).toBe(false);
-				expect(memfs.existsSync(SESSION_FILE)).toBe(false);
-			},
-		);
-
-		it("uses keyring without writing files when keyringOnly and keyring available", async () => {
-			vi.mocked(isKeyringEnabled).mockReturnValue(true);
-			stubExecFile({ stdout: "" });
-			const { manager } = setup();
-
-			await manager.storeToken(TEST_URL, "my-token", configs, {
-				keyringOnly: true,
-			});
-
-			expect(execFile).toHaveBeenCalled();
-			expect(memfs.existsSync(URL_FILE)).toBe(false);
-			expect(memfs.existsSync(SESSION_FILE)).toBe(false);
-		});
 	});
 
 	describe("readToken", () => {

--- a/test/unit/core/cliExec.test.ts
+++ b/test/unit/core/cliExec.test.ts
@@ -4,7 +4,13 @@ import path from "path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { MockConfigurationProvider } from "../../mocks/testHelpers";
-import { isWindows, quoteCommand, writeExecutable } from "../../utils/platform";
+import {
+	isWindows,
+	quoteCommand,
+	writeExecutable,
+	writeStderrJs,
+	writeStdoutJs,
+} from "../../utils/platform";
 
 import type { CliEnv } from "@/core/cliExec";
 
@@ -30,18 +36,13 @@ describe("cliExec", () => {
 
 	function setup(auth: CliEnv["auth"], binary = echoArgsBin) {
 		const configs = new MockConfigurationProvider();
-		const env: CliEnv = {
-			binary,
-			auth,
-			configs,
-			childCredentials: { url: "http://localhost:3000", token: "test-token" },
-		};
+		const env: CliEnv = { binary, auth, configs };
 		return { configs, env };
 	}
 
 	/** JS code for a fake CLI that writes a fixed string to stdout. */
 	function echoBin(output: string): string {
-		return `process.stdout.write(${JSON.stringify(output)});`;
+		return writeStdoutJs(output);
 	}
 
 	/**
@@ -51,10 +52,11 @@ describe("cliExec", () => {
 	function oldCliBin(stderr: string, stdout: string): string {
 		return [
 			`if (process.argv.includes("--output")) {`,
-			`  process.stderr.write(${JSON.stringify(stderr)});`,
-			`  process.exitCode = 1;`,
+			`  ${writeStderrJs(stderr)}`,
+			`  process.exit(1);`,
 			`} else {`,
-			`  process.stdout.write(${JSON.stringify(stdout)});`,
+			`  ${writeStdoutJs(stdout)}`,
+			`  process.exit(0);`,
 			`}`,
 		].join("\n");
 	}
@@ -164,34 +166,14 @@ describe("cliExec", () => {
 
 		it("surfaces stderr instead of full command line on failure", async () => {
 			const code = [
-				`process.stderr.write("invalid argument for -t flag\\n");`,
-				`process.exitCode = 1;`,
+				writeStderrJs("invalid argument for -t flag\n"),
+				`process.exit(1);`,
 			].join("\n");
 			const bin = await writeExecutable(tmp, "speedtest-err", code);
 			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
 			await expect(
 				cliExec.speedtest(env, "owner/workspace", "bad"),
 			).rejects.toThrow("invalid argument for -t flag");
-		});
-
-		it("forwards CODER_URL and CODER_SESSION_TOKEN to the child", async () => {
-			const code = [
-				`process.stdout.write(JSON.stringify({`,
-				`  url: process.env.CODER_URL || "",`,
-				`  token: process.env.CODER_SESSION_TOKEN || "",`,
-				`}));`,
-			].join("\n");
-			const bin = await writeExecutable(tmp, "speedtest-env", code);
-			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
-			env.childCredentials = {
-				url: "http://localhost:3000",
-				token: "secret-token",
-			};
-			const out = await cliExec.speedtest(env, "owner/workspace");
-			expect(JSON.parse(out)).toEqual({
-				url: "http://localhost:3000",
-				token: "secret-token",
-			});
 		});
 
 		it("preserves AbortError name when cancelled via signal", async () => {
@@ -204,23 +186,6 @@ describe("cliExec", () => {
 			await expect(
 				cliExec.speedtest(env, "owner/workspace", undefined, ac.signal),
 			).rejects.toMatchObject({ name: "AbortError" });
-		});
-
-		it("forwards an empty CODER_SESSION_TOKEN for mTLS", async () => {
-			const code = [
-				`process.stdout.write(JSON.stringify({`,
-				`  url: process.env.CODER_URL,`,
-				`  token: process.env.CODER_SESSION_TOKEN,`,
-				`}));`,
-			].join("\n");
-			const bin = await writeExecutable(tmp, "speedtest-env-mtls", code);
-			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
-			env.childCredentials = { url: "http://localhost:3000", token: "" };
-			const out = await cliExec.speedtest(env, "owner/workspace");
-			expect(JSON.parse(out)).toEqual({
-				url: "http://localhost:3000",
-				token: "",
-			});
 		});
 	});
 
@@ -258,8 +223,8 @@ describe("cliExec", () => {
 
 		it("surfaces stderr on failure", async () => {
 			const code = [
-				`process.stderr.write("workspace not found\\n");`,
-				`process.exitCode = 1;`,
+				writeStderrJs("workspace not found\n"),
+				`process.exit(1);`,
 			].join("\n");
 			const bin = await writeExecutable(tmp, "sb-err", code);
 			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);

--- a/test/unit/core/cliExec.test.ts
+++ b/test/unit/core/cliExec.test.ts
@@ -34,7 +34,7 @@ describe("cliExec", () => {
 			binary,
 			auth,
 			configs,
-			authEnv: { url: "http://localhost:3000", token: "test-token" },
+			childCredentials: { url: "http://localhost:3000", token: "test-token" },
 		};
 		return { configs, env };
 	}
@@ -183,12 +183,27 @@ describe("cliExec", () => {
 			].join("\n");
 			const bin = await writeExecutable(tmp, "speedtest-env", code);
 			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
-			env.authEnv = { url: "http://localhost:3000", token: "secret-token" };
+			env.childCredentials = {
+				url: "http://localhost:3000",
+				token: "secret-token",
+			};
 			const out = await cliExec.speedtest(env, "owner/workspace");
 			expect(JSON.parse(out)).toEqual({
 				url: "http://localhost:3000",
 				token: "secret-token",
 			});
+		});
+
+		it("preserves AbortError name when cancelled via signal", async () => {
+			// Hangs forever so the only way out is the abort signal.
+			const code = `setInterval(() => {}, 1000);`;
+			const bin = await writeExecutable(tmp, "speedtest-hang", code);
+			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
+			const ac = new AbortController();
+			ac.abort();
+			await expect(
+				cliExec.speedtest(env, "owner/workspace", undefined, ac.signal),
+			).rejects.toMatchObject({ name: "AbortError" });
 		});
 
 		it("forwards an empty CODER_SESSION_TOKEN for mTLS", async () => {
@@ -200,7 +215,7 @@ describe("cliExec", () => {
 			].join("\n");
 			const bin = await writeExecutable(tmp, "speedtest-env-mtls", code);
 			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
-			env.authEnv = { url: "http://localhost:3000", token: "" };
+			env.childCredentials = { url: "http://localhost:3000", token: "" };
 			const out = await cliExec.speedtest(env, "owner/workspace");
 			expect(JSON.parse(out)).toEqual({
 				url: "http://localhost:3000",

--- a/test/unit/core/cliExec.test.ts
+++ b/test/unit/core/cliExec.test.ts
@@ -30,7 +30,12 @@ describe("cliExec", () => {
 
 	function setup(auth: CliEnv["auth"], binary = echoArgsBin) {
 		const configs = new MockConfigurationProvider();
-		const env: CliEnv = { binary, auth, configs };
+		const env: CliEnv = {
+			binary,
+			auth,
+			configs,
+			authEnv: { url: "http://localhost:3000", token: "test-token" },
+		};
 		return { configs, env };
 	}
 
@@ -167,6 +172,40 @@ describe("cliExec", () => {
 			await expect(
 				cliExec.speedtest(env, "owner/workspace", "bad"),
 			).rejects.toThrow("invalid argument for -t flag");
+		});
+
+		it("forwards CODER_URL and CODER_SESSION_TOKEN to the child", async () => {
+			const code = [
+				`process.stdout.write(JSON.stringify({`,
+				`  url: process.env.CODER_URL || "",`,
+				`  token: process.env.CODER_SESSION_TOKEN || "",`,
+				`}));`,
+			].join("\n");
+			const bin = await writeExecutable(tmp, "speedtest-env", code);
+			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
+			env.authEnv = { url: "http://localhost:3000", token: "secret-token" };
+			const out = await cliExec.speedtest(env, "owner/workspace");
+			expect(JSON.parse(out)).toEqual({
+				url: "http://localhost:3000",
+				token: "secret-token",
+			});
+		});
+
+		it("forwards an empty CODER_SESSION_TOKEN for mTLS", async () => {
+			const code = [
+				`process.stdout.write(JSON.stringify({`,
+				`  url: process.env.CODER_URL,`,
+				`  token: process.env.CODER_SESSION_TOKEN,`,
+				`}));`,
+			].join("\n");
+			const bin = await writeExecutable(tmp, "speedtest-env-mtls", code);
+			const { env } = setup({ mode: "global-config", configDir: "/tmp" }, bin);
+			env.authEnv = { url: "http://localhost:3000", token: "" };
+			const out = await cliExec.speedtest(env, "owner/workspace");
+			expect(JSON.parse(out)).toEqual({
+				url: "http://localhost:3000",
+				token: "",
+			});
 		});
 	});
 

--- a/test/unit/error/errorUtils.test.ts
+++ b/test/unit/error/errorUtils.test.ts
@@ -1,6 +1,47 @@
 import { describe, it, expect } from "vitest";
 
-import { getErrorDetail, toError } from "@/error/errorUtils";
+import { getErrorDetail, isAbortError, toError } from "@/error/errorUtils";
+
+describe("isAbortError", () => {
+	it("returns true for an Error named AbortError", () => {
+		const err = new Error("aborted");
+		err.name = "AbortError";
+		expect(isAbortError(err)).toBe(true);
+	});
+
+	it("returns true for DOMException-style abort thrown by AbortController", () => {
+		const ac = new AbortController();
+		ac.abort();
+		// `signal.reason` is a DOMException with name "AbortError" in modern Node.
+		const reason = ac.signal.reason;
+		expect(isAbortError(reason)).toBe(true);
+	});
+
+	it("returns false for a plain Error", () => {
+		expect(isAbortError(new Error("nope"))).toBe(false);
+	});
+
+	it.each<[string, unknown]>([
+		["null", null],
+		["undefined", undefined],
+		["string", "AbortError"],
+		["object with name only", { name: "AbortError" }],
+	])("returns false for %s", (_name, input) => {
+		expect(isAbortError(input)).toBe(false);
+	});
+
+	it("narrows the type to Error", () => {
+		const err: unknown = Object.assign(new Error("aborted"), {
+			name: "AbortError",
+		});
+		if (isAbortError(err)) {
+			// Type-only assertion: this line must compile without a cast.
+			expect(err.message).toBe("aborted");
+		} else {
+			throw new Error("expected isAbortError to narrow");
+		}
+	});
+});
 
 describe("getErrorDetail", () => {
 	it("returns detail from API error", () => {

--- a/test/unit/login/loginCoordinator.test.ts
+++ b/test/unit/login/loginCoordinator.test.ts
@@ -500,7 +500,7 @@ describe("LoginCoordinator", () => {
 			return { ...ctx, user, login };
 		}
 
-		it("calls storeToken with keyringOnly after successful login", async () => {
+		it("calls storeToken after successful login", async () => {
 			const { mockCredentialManager, login } = await loginWithStoredToken();
 
 			await login();
@@ -509,7 +509,6 @@ describe("LoginCoordinator", () => {
 				TEST_URL,
 				"stored-token",
 				expect.anything(),
-				{ keyringOnly: true },
 			);
 		});
 

--- a/test/utils/platform.test.ts
+++ b/test/utils/platform.test.ts
@@ -13,6 +13,7 @@ import {
 	printEnvCommand,
 	shimExecFile,
 	writeExecutable,
+	writeStdoutJs,
 } from "./platform";
 
 describe("platform utils", () => {
@@ -123,11 +124,7 @@ describe("platform utils", () => {
 		});
 
 		it("runs .js files through node", async () => {
-			const script = await writeExecutable(
-				tmp,
-				"echo",
-				'process.stdout.write("ok");',
-			);
+			const script = await writeExecutable(tmp, "echo", writeStdoutJs("ok"));
 			const { stdout } = await execFileAsync(script);
 			expect(stdout).toBe("ok");
 		});
@@ -136,7 +133,7 @@ describe("platform utils", () => {
 			const script = await writeExecutable(
 				tmp,
 				"echo-args",
-				"process.stdout.write(process.argv.slice(2).join(','));",
+				`require("fs").writeSync(1, process.argv.slice(2).join(","));`,
 			);
 			const { stdout } = await execFileAsync(script, ["a", "b", "c"]);
 			expect(stdout).toBe("a,b,c");
@@ -149,11 +146,7 @@ describe("platform utils", () => {
 		});
 
 		it("preserves the callback form", async () => {
-			const script = await writeExecutable(
-				tmp,
-				"cb-echo",
-				'process.stdout.write("cb");',
-			);
+			const script = await writeExecutable(tmp, "cb-echo", writeStdoutJs("cb"));
 			const stdout = await new Promise<string>((resolve, reject) => {
 				mod.execFile(script, (err, out) =>
 					err ? reject(new Error(err.message)) : resolve(out),

--- a/test/utils/platform.ts
+++ b/test/utils/platform.ts
@@ -41,6 +41,20 @@ export function printEnvCommand(key: string, varName: string): string {
 }
 
 /**
+ * Generates a JS snippet that synchronously writes `data` to stdout. Use in
+ * fake CLI scripts so output isn't lost on exit (process.stdout.write is async
+ * on POSIX pipes; see https://nodejs.org/api/process.html#a-note-on-process-io).
+ */
+export function writeStdoutJs(data: string): string {
+	return `require("fs").writeSync(1, ${JSON.stringify(data)});`;
+}
+
+/** Same as {@link writeStdoutJs} but writes to stderr (fd 2). */
+export function writeStderrJs(data: string): string {
+	return `require("fs").writeSync(2, ${JSON.stringify(data)});`;
+}
+
+/**
  * Write a JS file that can be executed cross-platform.
  * Tests that use `execFile` on the returned path should apply
  * {@link shimExecFile} so `.js` files are run through `process.execPath`.


### PR DESCRIPTION
- Refresh the credential file (or keyring on supported systems) before each CLI call by awaiting `cliManager.configure` inside `commands.ts:resolveCliEnv`. The CLI reads the fresh token via the existing `--global-config` / `--url` flags. mTLS still works since the refresh accepts an empty token.
- Stop wrapping `AbortError` inside `cliError`. Previously, wrapping replaced the `AbortError` name with stale CLI stderr, so cancellations from `speedtest` and `support bundle` looked like real failures to `withCancellableProgress`.
- Tighten `isAbortError` to narrow to `Error` so callers can return the error directly.
- Drop the unused `keyringOnly` option from `storeToken`.
- Add `writeStdoutJs` / `writeStderrJs` test helpers that wrap `fs.writeSync`. Fixes a flaky version-fallback test caused by lost async pipe writes on exit (see https://nodejs.org/api/process.html#a-note-on-process-io).