### PR TITLE
fix: parse remote authority from right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@
 
 ### Fixed
 
-- Workspaces hosted on internationalized (IDN) domains can now be opened from
-  recent connections. The SSH authority parser was splitting Punycode (`xn--`)
-  domain labels across the field separator and rejecting the host as invalid.
+- Workspaces on hostnames containing `--`, such as internationalized (IDN)
+  domains with Punycode (`xn--`) labels, can now be opened from recent
+  connections. The SSH authority parser was splitting these names across the
+  field separator and rejecting the host as invalid.
 
 ## [v1.14.5](https://github.com/coder/vscode-coder/releases/tag/v1.14.5) 2026-04-30
 

--- a/src/core/cliManager.ts
+++ b/src/core/cliManager.ts
@@ -113,9 +113,8 @@ export class CliManager {
 	}
 
 	/**
-	 * Download and return the path to a working binary for the deployment with
-	 * the provided hostname using the provided client.  If the hostname is empty,
-	 * use the old deployment-unaware path instead.
+	 * Download and return the path to a working binary for the deployment using
+	 * the provided client.
 	 *
 	 * If there is already a working binary and it matches the server version,
 	 * return that, skipping the download.  If it does not match but downloads are

--- a/src/core/pathResolver.ts
+++ b/src/core/pathResolver.ts
@@ -13,21 +13,15 @@ export class PathResolver {
 	 * Return the directory for the deployment with the provided hostname to
 	 * where the global Coder configs are stored.
 	 *
-	 * If the hostname is empty, read the old deployment-unaware config instead.
-	 *
 	 * The caller must ensure this directory exists before use.
 	 */
 	public getGlobalConfigDir(safeHostname: string): string {
-		return safeHostname
-			? path.join(this.basePath, safeHostname)
-			: this.basePath;
+		return path.join(this.basePath, safeHostname);
 	}
 
 	/**
 	 * Return the directory for a deployment with the provided hostname to where
 	 * its binary is cached.
-	 *
-	 * If the hostname is empty, read the old deployment-unaware config instead.
 	 *
 	 * The caller must ensure this directory exists before use.
 	 */
@@ -85,8 +79,6 @@ export class PathResolver {
 	 * Return the directory for the deployment with the provided hostname to
 	 * where its session token is stored.
 	 *
-	 * If the hostname is empty, read the old deployment-unaware config instead.
-	 *
 	 * The caller must ensure this directory exists before use.
 	 */
 	public getSessionTokenPath(safeHostname: string): string {
@@ -97,8 +89,6 @@ export class PathResolver {
 	 * Return the directory for the deployment with the provided hostname to
 	 * where its session token was stored by older code.
 	 *
-	 * If the hostname is empty, read the old deployment-unaware config instead.
-	 *
 	 * The caller must ensure this directory exists before use.
 	 */
 	public getLegacySessionTokenPath(safeHostname: string): string {
@@ -108,8 +98,6 @@ export class PathResolver {
 	/**
 	 * Return the directory for the deployment with the provided hostname to
 	 * where its url is stored.
-	 *
-	 * If the hostname is empty, read the old deployment-unaware config instead.
 	 *
 	 * The caller must ensure this directory exists before use.
 	 */

--- a/src/core/secretsManager.ts
+++ b/src/core/secretsManager.ts
@@ -58,7 +58,7 @@ export class SecretsManager {
 	) {}
 
 	private buildKey(prefix: SecretKeyPrefix, safeHostname: string): string {
-		return `${prefix}${safeHostname || "<legacy>"}`;
+		return `${prefix}${safeHostname}`;
 	}
 
 	private async getSecret<T>(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,12 +134,9 @@ async function doActivate(
 	// This client tracks the current login and will be used through the life of
 	// the plugin to poll workspaces for the current login, as well as being used
 	// in commands that operate on the current login.
-	const sessionAuth = deployment
-		? await secretsManager.getSessionAuth(deployment.safeHostname)
-		: undefined;
 	const client = CoderApi.create(
 		deployment?.url || "",
-		sessionAuth?.token,
+		deploymentSessionAuth?.token,
 		output,
 		telemetryService,
 	);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,9 +134,12 @@ async function doActivate(
 	// This client tracks the current login and will be used through the life of
 	// the plugin to poll workspaces for the current login, as well as being used
 	// in commands that operate on the current login.
+	const sessionAuth = deployment
+		? await secretsManager.getSessionAuth(deployment.safeHostname)
+		: undefined;
 	const client = CoderApi.create(
 		deployment?.url || "",
-		deploymentSessionAuth?.token,
+		sessionAuth?.token,
 		output,
 		telemetryService,
 	);

--- a/src/remote/sshConfig.ts
+++ b/src/remote/sshConfig.ts
@@ -183,14 +183,10 @@ export class SshConfig {
 	private raw: string | undefined;
 
 	private startBlockComment(safeHostname: string): string {
-		return safeHostname
-			? `# --- START CODER VSCODE ${safeHostname} ---`
-			: `# --- START CODER VSCODE ---`;
+		return `# --- START CODER VSCODE ${safeHostname} ---`;
 	}
 	private endBlockComment(safeHostname: string): string {
-		return safeHostname
-			? `# --- END CODER VSCODE ${safeHostname} ---`
-			: `# --- END CODER VSCODE ---`;
+		return `# --- END CODER VSCODE ${safeHostname} ---`;
 	}
 
 	constructor(
@@ -248,13 +244,13 @@ export class SshConfig {
 		const endBlockCount = countSubstring(endBlock, raw);
 		if (startBlockCount !== endBlockCount) {
 			throw new SshConfigBadFormat(
-				`Malformed config: ${this.filePath} has an unterminated START CODER VSCODE ${safeHostname ? safeHostname + " " : ""}block. Each START block must have an END block.`,
+				`Malformed config: ${this.filePath} has an unterminated START CODER VSCODE ${safeHostname} block. Each START block must have an END block.`,
 			);
 		}
 
 		if (startBlockCount > 1 || endBlockCount > 1) {
 			throw new SshConfigBadFormat(
-				`Malformed config: ${this.filePath} has ${startBlockCount} START CODER VSCODE ${safeHostname ? safeHostname + " " : ""}sections. Please remove all but one.`,
+				`Malformed config: ${this.filePath} has ${startBlockCount} START CODER VSCODE ${safeHostname} sections. Please remove all but one.`,
 			);
 		}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -53,6 +53,10 @@ export function findPort(text: string): number | null {
 /**
  * Given an authority, parse into the expected parts.
  *
+ * The authority looks like `<scheme>://ssh-remote+<ssh host name>`, where the
+ * SSH host names created by this extension match the format:
+ *   coder-vscode.<safeHostname>--<username>--<workspace>(.<agent?>)
+ *
  * If this is not a Coder host, return null.
  *
  * Throw an error if the host is invalid.
@@ -69,18 +73,18 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 		return null;
 	}
 
-	if (parts.length < 3 || parts.some((p) => !p)) {
+	if (parts.length < 3) {
 		throw new Error(invalidAuthorityMessage);
 	}
 
 	// Parse from the right because safe hostnames can contain "--".
 	const hostPrefix = parts.slice(0, -2).join("--");
 	const safeHostname = hostPrefix.slice(authorityHostPrefix.length);
-	if (!safeHostname) {
-		throw new Error(invalidAuthorityMessage);
-	}
 	const username = parts[parts.length - 2];
 	const workspaceAndAgent = parts[parts.length - 1];
+	if (!safeHostname || !username || !workspaceAndAgent) {
+		throw new Error(invalidAuthorityMessage);
+	}
 
 	let workspace = workspaceAndAgent;
 	let agent = "";
@@ -95,11 +99,11 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 	}
 
 	return {
-		agent: agent,
-		sshHost: sshHost,
-		safeHostname: safeHostname,
-		username: username,
-		workspace: workspace,
+		agent,
+		sshHost,
+		safeHostname,
+		username,
+		workspace,
 	};
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -56,52 +56,43 @@ export function findPort(text: string): number | null {
 export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 	// The authority looks like: vscode://ssh-remote+<ssh host name>
 	const authorityParts = authority.split("+");
-
-	// We create SSH host names in a format matching:
-	// coder-vscode(--|.)<username>--<workspace>(--|.)<agent?>
-	// The agent can be omitted; the user will be prompted for it instead.
-	// Anything else is unrelated to Coder and can be ignored.
-	const parts = authorityParts[1].split("--");
-	if (
-		parts.length <= 1 ||
-		(parts[0] !== AuthorityPrefix &&
-			!parts[0].startsWith(`${AuthorityPrefix}.`))
-	) {
+	const sshHost = authorityParts[1];
+	if (!sshHost) {
 		return null;
 	}
 
-	// Reassemble Punycode labels (xn--...) the split broke apart: when the
-	// prefix ends in ".xn", the cut landed inside an "xn--..." label.
-	while (parts.length >= 2 && parts[0].endsWith(".xn")) {
-		parts.splice(0, 2, `${parts[0]}--${parts[1]}`);
+	const parts = sshHost.split("--");
+	if (!parts[0].startsWith(`${AuthorityPrefix}.`)) {
+		return null;
 	}
 
-	// It has the proper prefix, so this is probably a Coder host name.
-	// Validate the SSH host name.  Including the prefix, we expect at least
-	// three parts, or four if including the agent.
-	if ((parts.length !== 3 && parts.length !== 4) || parts.some((p) => !p)) {
-		throw new Error(
-			`Invalid Coder SSH authority. Must be: <username>--<workspace>(--|.)<agent?>`,
-		);
+	const invalidAuthorityMessage =
+		"Invalid Coder SSH authority. Must be: <hostname>--<username>--<workspace>(.<agent?>)";
+	if (parts.length < 3 || parts.some((p) => !p)) {
+		throw new Error(invalidAuthorityMessage);
 	}
 
-	let workspace = parts[2];
+	const hostPrefix = parts.slice(0, -2).join("--");
+	const safeHostname = hostPrefix.slice(`${AuthorityPrefix}.`.length);
+	if (!safeHostname) {
+		throw new Error(invalidAuthorityMessage);
+	}
+	const username = parts[parts.length - 2];
+	const workspaceAndAgent = parts[parts.length - 1];
+
+	let workspace = workspaceAndAgent;
 	let agent = "";
-	if (parts.length === 4) {
-		agent = parts[3];
-	} else if (parts.length === 3) {
-		const workspaceParts = parts[2].split(".");
-		if (workspaceParts.length === 2) {
-			workspace = workspaceParts[0];
-			agent = workspaceParts[1];
-		}
+	const workspaceParts = workspaceAndAgent.split(".");
+	if (workspaceParts.length === 2) {
+		workspace = workspaceParts[0];
+		agent = workspaceParts[1];
 	}
 
 	return {
 		agent: agent,
-		sshHost: authorityParts[1],
-		safeHostname: parts[0].replace(/^coder-vscode\.?/, ""),
-		username: parts[1],
+		sshHost: sshHost,
+		safeHostname: safeHostname,
+		username: username,
 		workspace: workspace,
 	};
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -58,7 +58,6 @@ export function findPort(text: string): number | null {
  * Throw an error if the host is invalid.
  */
 export function parseRemoteAuthority(authority: string): AuthorityParts | null {
-	// The authority looks like: vscode://ssh-remote+<ssh host name>
 	const authorityParts = authority.split("+");
 	const sshHost = authorityParts[1];
 	if (!sshHost) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -13,6 +13,10 @@ export interface AuthorityParts {
 // they should be handled by this extension.
 export const AuthorityPrefix = "coder-vscode";
 
+const authorityHostPrefix = `${AuthorityPrefix}.`;
+const invalidAuthorityMessage =
+	"Invalid Coder SSH authority. Must be: <hostname>--<username>--<workspace>(.<agent?>)";
+
 // Regex patterns to find the SSH port from Remote SSH extension logs.
 // `ms-vscode-remote.remote-ssh`: `-> socksPort <port> ->` or `between local port <port>`
 // `codeium.windsurf-remote-openssh`, `jeanp413.open-remote-ssh`, `google.antigravity-remote-openssh`: `=> <port>(socks) =>`
@@ -62,18 +66,17 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 	}
 
 	const parts = sshHost.split("--");
-	if (!parts[0].startsWith(`${AuthorityPrefix}.`)) {
+	if (!parts[0].startsWith(authorityHostPrefix)) {
 		return null;
 	}
 
-	const invalidAuthorityMessage =
-		"Invalid Coder SSH authority. Must be: <hostname>--<username>--<workspace>(.<agent?>)";
 	if (parts.length < 3 || parts.some((p) => !p)) {
 		throw new Error(invalidAuthorityMessage);
 	}
 
+	// Parse from the right because safe hostnames can contain "--".
 	const hostPrefix = parts.slice(0, -2).join("--");
-	const safeHostname = hostPrefix.slice(`${AuthorityPrefix}.`.length);
+	const safeHostname = hostPrefix.slice(authorityHostPrefix.length);
 	if (!safeHostname) {
 		throw new Error(invalidAuthorityMessage);
 	}
@@ -83,9 +86,13 @@ export function parseRemoteAuthority(authority: string): AuthorityParts | null {
 	let workspace = workspaceAndAgent;
 	let agent = "";
 	const workspaceParts = workspaceAndAgent.split(".");
+	// Multiple dots are ambiguous because workspace and agent share this separator.
 	if (workspaceParts.length === 2) {
 		workspace = workspaceParts[0];
 		agent = workspaceParts[1];
+		if (!workspace || !agent) {
+			throw new Error(invalidAuthorityMessage);
+		}
 	}
 
 	return {

--- a/test/unit/core/pathResolver.test.ts
+++ b/test/unit/core/pathResolver.test.ts
@@ -19,15 +19,6 @@ describe("PathResolver", () => {
 		mockConfig = new MockConfigurationProvider();
 	});
 
-	it("should use base path for empty labels", () => {
-		expectPathsEqual(pathResolver.getGlobalConfigDir(""), basePath);
-		expectPathsEqual(
-			pathResolver.getSessionTokenPath(""),
-			path.join(basePath, "session"),
-		);
-		expectPathsEqual(pathResolver.getUrlPath(""), path.join(basePath, "url"));
-	});
-
 	describe("getProxyLogPath", () => {
 		const defaultLogPath = path.join(basePath, "log");
 

--- a/test/unit/remote/sshConfig.test.ts
+++ b/test/unit/remote/sshConfig.test.ts
@@ -45,44 +45,6 @@ afterEach(() => {
 	vi.clearAllMocks();
 });
 
-it("creates a new file and adds config with empty label", async () => {
-	mockFileSystem.readFile.mockRejectedValueOnce("No file found");
-	mockFileSystem.stat.mockRejectedValueOnce({ code: "ENOENT" });
-
-	const sshConfig = new SshConfig(sshFilePath, mockLogger, mockFileSystem);
-	await sshConfig.load();
-	await sshConfig.update("", { ...BASE_SSH_VALUES, Host: "coder-vscode--*" });
-
-	const expectedOutput = `# --- START CODER VSCODE ---
-${managedHeader}
-Host coder-vscode--*
-  ConnectTimeout 0
-  LogLevel ERROR
-  ProxyCommand some-command-here
-  ServerAliveCountMax 3
-  ServerAliveInterval 10
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---`;
-
-	expect(mockFileSystem.readFile).toHaveBeenCalledWith(
-		sshFilePath,
-		expect.anything(),
-	);
-	expect(mockFileSystem.writeFile).toHaveBeenCalledWith(
-		expect.stringContaining(sshTempFilePrefix),
-		expectedOutput,
-		expect.objectContaining({
-			encoding: "utf-8",
-			mode: 0o600, // Default mode for new files.
-		}),
-	);
-	expect(mockFileSystem.rename).toHaveBeenCalledWith(
-		expect.stringContaining(sshTempFilePrefix),
-		sshFilePath,
-	);
-});
-
 it("creates a new file and adds the config", async () => {
 	mockFileSystem.readFile.mockRejectedValueOnce("No file found");
 	mockFileSystem.stat.mockRejectedValueOnce({ code: "ENOENT" });
@@ -404,48 +366,6 @@ Host afterconfig
 		sshConfig.update("dev.coder.com", BASE_SSH_VALUES),
 	).rejects.toThrow(
 		`Malformed config: ${sshFilePath} has an unterminated START CODER VSCODE dev.coder.com block. Each START block must have an END block.`,
-	);
-});
-
-it("throws an error if there is a mismatched start and end block count (without label)", async () => {
-	// As above, but without a label.
-	const existentSSHConfig = `Host beforeconfig
-  HostName before.config.tld
-  User before
-
-# --- START CODER VSCODE ---
-Host coder-vscode.dev.coder.com--*
-  ConnectTimeout 0
-  LogLevel ERROR
-  ProxyCommand some-command-here
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-# missing END CODER VSCODE ---
-
-Host donotdelete
-  HostName dont.delete.me
-  User please
-
-# --- START CODER VSCODE ---
-Host coder-vscode.dev.coder.com--*
-  ConnectTimeout 0
-  LogLevel ERROR
-  ProxyCommand some-command-here
-  StrictHostKeyChecking no
-  UserKnownHostsFile /dev/null
-# --- END CODER VSCODE ---
-
-Host afterconfig
-  HostName after.config.tld
-  User after`;
-
-	const sshConfig = new SshConfig(sshFilePath, mockLogger, mockFileSystem);
-	mockFileSystem.readFile.mockResolvedValueOnce(existentSSHConfig);
-	await sshConfig.load();
-
-	// When we try to update the config, it should throw an error.
-	await expect(sshConfig.update("", BASE_SSH_VALUES)).rejects.toThrow(
-		`Malformed config: ${sshFilePath} has an unterminated START CODER VSCODE block. Each START block must have an END block.`,
 	);
 });
 

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -118,6 +118,12 @@ describe("parseRemoteAuthority", () => {
 			agent: "baz",
 		},
 		{
+			label: "hostname with many consecutive dashes",
+			sshHost: "coder-vscode.foo---------------bar.com--foo--bar",
+			safeHostname: "foo---------------bar.com",
+			workspace: "bar",
+		},
+		{
 			label: "ambiguous workspace/agent separator",
 			sshHost: "coder-vscode.dev.coder.com--foo--bar.baz.qux",
 			safeHostname: "dev.coder.com",

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -14,158 +14,127 @@ import {
 } from "@/util";
 
 describe("parseRemoteAuthority", () => {
+	const remoteAuthority = (sshHost: string) => `vscode://ssh-remote+${sshHost}`;
+
 	it.each([
-		"vscode://ssh-remote+some-unrelated-host.com",
-		"vscode://ssh-remote+coder-vscode",
-		"vscode://ssh-remote+coder-vscode-test",
-		"vscode://ssh-remote+coder-vscode-test--foo--bar",
-		"vscode://ssh-remote+coder-vscode-foo--bar",
-		"vscode://ssh-remote+coder--foo--bar",
-		"vscode://ssh-remote+coder-vscode--foo",
-		"vscode://ssh-remote+coder-vscode--",
-		"vscode://ssh-remote+coder-vscode--foo--",
-		"vscode://ssh-remote+coder-vscode--foo--bar",
-		"vscode://ssh-remote+coder-vscode--foo--bar--",
-		"vscode://ssh-remote+coder-vscode--foo--bar--baz",
-	])("ignores unrelated authority: %s", (input) => {
+		{ label: "missing SSH host", input: "vscode://ssh-remote" },
+		{ label: "empty SSH host", input: "vscode://ssh-remote+" },
+		{
+			label: "non-Coder host",
+			input: remoteAuthority("some-unrelated-host.com"),
+		},
+		{
+			label: "prefix without safeHostname separator",
+			input: remoteAuthority("coder-vscode--foo--bar"),
+		},
+		{
+			label: "similar prefix",
+			input: remoteAuthority("coder-vscode-test--foo--bar"),
+		},
+		{ label: "wrong prefix", input: remoteAuthority("coder--foo--bar") },
+	])("ignores unrelated authority: $label", ({ input }) => {
 		expect(parseRemoteAuthority(input)).toBe(null);
 	});
 
 	it.each([
-		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo",
-		"vscode://ssh-remote+coder-vscode.dev.coder.com--",
-		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo--",
-		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar--",
-		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo----bar",
-		"vscode://ssh-remote+coder-vscode.--foo--bar",
-	])("rejects invalid authority: %s", (input) => {
-		expect(() => parseRemoteAuthority(input)).toThrow("Invalid");
+		{
+			label: "missing user and workspace",
+			sshHost: "coder-vscode.dev.coder.com",
+		},
+		{
+			label: "missing workspace",
+			sshHost: "coder-vscode.dev.coder.com--foo",
+		},
+		{
+			label: "empty username",
+			sshHost: "coder-vscode.dev.coder.com----bar",
+		},
+		{
+			label: "empty workspace",
+			sshHost: "coder-vscode.dev.coder.com--foo--",
+		},
+		{
+			label: "empty hostname",
+			sshHost: "coder-vscode.--foo--bar",
+		},
+		{
+			label: "empty trailing segment",
+			sshHost: "coder-vscode.dev.coder.com--foo--bar--",
+		},
+		{
+			label: "empty workspace before agent separator",
+			sshHost: "coder-vscode.dev.coder.com--foo--.agent",
+		},
+		{
+			label: "empty agent after separator",
+			sshHost: "coder-vscode.dev.coder.com--foo--bar.",
+		},
+	])("rejects invalid authority: $label", ({ sshHost }) => {
+		expect(() => parseRemoteAuthority(remoteAuthority(sshHost))).toThrow(
+			"Invalid Coder SSH authority",
+		);
 	});
 
 	interface ParseCase {
 		label: string;
-		input: string;
-		expected: AuthorityParts;
+		sshHost: string;
+		safeHostname: string;
+		workspace: string;
+		agent?: string;
+		username?: string;
 	}
 
 	it.each<ParseCase>([
 		{
-			label: "with hostname, no agent",
-			input: "vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.dev.coder.com--foo--bar",
-				safeHostname: "dev.coder.com",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "hostname without agent",
+			sshHost: "coder-vscode.dev.coder.com--foo--bar",
+			safeHostname: "dev.coder.com",
+			workspace: "bar",
 		},
 		{
-			label: "with hostname and . agent",
-			input: "vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar.baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode.dev.coder.com--foo--bar.baz",
-				safeHostname: "dev.coder.com",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "hostname with agent",
+			sshHost: "coder-vscode.dev.coder.com--foo--bar.baz",
+			safeHostname: "dev.coder.com",
+			workspace: "bar",
+			agent: "baz",
 		},
 		{
-			label: "hostname with double dash",
-			input: "vscode://ssh-remote+coder-vscode.test--domain.com--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.test--domain.com--foo--bar",
-				safeHostname: "test--domain.com",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "hostname containing delimiter",
+			sshHost: "coder-vscode.test--domain.com--foo--bar",
+			safeHostname: "test--domain.com",
+			workspace: "bar",
 		},
 		{
-			label: "Punycode hostname with triple dash",
-			input:
-				"vscode://ssh-remote+coder-vscode.xn--test---8o4.example--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.xn--test---8o4.example--foo--bar",
-				safeHostname: "xn--test---8o4.example",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "Punycode hostname containing delimiter",
+			sshHost: "coder-vscode.xn--test---8o4.example--foo--bar",
+			safeHostname: "xn--test---8o4.example",
+			workspace: "bar",
 		},
 		{
-			label: "hostname with multiple double dashes",
-			input:
-				"vscode://ssh-remote+coder-vscode.first--middle--last.example--foo--bar.baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode.first--middle--last.example--foo--bar.baz",
-				safeHostname: "first--middle--last.example",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "hostname with repeated delimiters and agent",
+			sshHost: "coder-vscode.first--middle--last.example--foo--bar.baz",
+			safeHostname: "first--middle--last.example",
+			workspace: "bar",
+			agent: "baz",
 		},
 		{
-			label: "Punycode label in hostname",
-			input:
-				"vscode://ssh-remote+coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
-				safeHostname: "dev.coder.xn--eckwd4c7cu47r2wf.jp",
-				username: "foo",
-				workspace: "bar",
-			},
+			label: "ambiguous workspace/agent separator",
+			sshHost: "coder-vscode.dev.coder.com--foo--bar.baz.qux",
+			safeHostname: "dev.coder.com",
+			workspace: "bar.baz.qux",
 		},
-		{
-			label: "Punycode hostname with . agent",
-			input:
-				"vscode://ssh-remote+coder-vscode.xn--eckwd4c7cu47r2wf.jp--foo--bar.baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode.xn--eckwd4c7cu47r2wf.jp--foo--bar.baz",
-				safeHostname: "xn--eckwd4c7cu47r2wf.jp",
-				username: "foo",
-				workspace: "bar",
-			},
+	])(
+		"parses $label",
+		({ sshHost, safeHostname, workspace, agent, username }) => {
+			expect(parseRemoteAuthority(remoteAuthority(sshHost))).toStrictEqual({
+				agent: agent ?? "",
+				sshHost,
+				safeHostname,
+				username: username ?? "foo",
+				workspace,
+			} satisfies AuthorityParts);
 		},
-		{
-			label: "multiple Punycode labels",
-			input: "vscode://ssh-remote+coder-vscode.xn--abc.xn--def.com--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.xn--abc.xn--def.com--foo--bar",
-				safeHostname: "xn--abc.xn--def.com",
-				username: "foo",
-				workspace: "bar",
-			},
-		},
-		{
-			label: "apex Punycode",
-			input: "vscode://ssh-remote+coder-vscode.xn--p1ai--owner--ws",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.xn--p1ai--owner--ws",
-				safeHostname: "xn--p1ai",
-				username: "owner",
-				workspace: "ws",
-			},
-		},
-		{
-			label: "consecutive apex Punycode labels",
-			input: "vscode://ssh-remote+coder-vscode.xn--p1ai.xn--abc--owner--ws",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode.xn--p1ai.xn--abc--owner--ws",
-				safeHostname: "xn--p1ai.xn--abc",
-				username: "owner",
-				workspace: "ws",
-			},
-		},
-	])("parses $label", ({ input, expected }) => {
-		expect(parseRemoteAuthority(input)).toStrictEqual(expected);
-	});
+	);
 });
 
 describe("toSafeHost", () => {

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -21,15 +21,23 @@ describe("parseRemoteAuthority", () => {
 		"vscode://ssh-remote+coder-vscode-test--foo--bar",
 		"vscode://ssh-remote+coder-vscode-foo--bar",
 		"vscode://ssh-remote+coder--foo--bar",
+		"vscode://ssh-remote+coder-vscode--foo",
+		"vscode://ssh-remote+coder-vscode--",
+		"vscode://ssh-remote+coder-vscode--foo--",
+		"vscode://ssh-remote+coder-vscode--foo--bar",
+		"vscode://ssh-remote+coder-vscode--foo--bar--",
+		"vscode://ssh-remote+coder-vscode--foo--bar--baz",
 	])("ignores unrelated authority: %s", (input) => {
 		expect(parseRemoteAuthority(input)).toBe(null);
 	});
 
 	it.each([
-		"vscode://ssh-remote+coder-vscode--foo",
-		"vscode://ssh-remote+coder-vscode--",
-		"vscode://ssh-remote+coder-vscode--foo--",
-		"vscode://ssh-remote+coder-vscode--foo--bar--",
+		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo",
+		"vscode://ssh-remote+coder-vscode.dev.coder.com--",
+		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo--",
+		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar--",
+		"vscode://ssh-remote+coder-vscode.dev.coder.com--foo----bar",
+		"vscode://ssh-remote+coder-vscode.--foo--bar",
 	])("rejects invalid authority: %s", (input) => {
 		expect(() => parseRemoteAuthority(input)).toThrow("Invalid");
 	});
@@ -42,44 +50,11 @@ describe("parseRemoteAuthority", () => {
 
 	it.each<ParseCase>([
 		{
-			label: "legacy form, no agent",
-			input: "vscode://ssh-remote+coder-vscode--foo--bar",
-			expected: {
-				agent: "",
-				sshHost: "coder-vscode--foo--bar",
-				safeHostname: "",
-				username: "foo",
-				workspace: "bar",
-			},
-		},
-		{
-			label: "legacy form with agent",
-			input: "vscode://ssh-remote+coder-vscode--foo--bar--baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode--foo--bar--baz",
-				safeHostname: "",
-				username: "foo",
-				workspace: "bar",
-			},
-		},
-		{
 			label: "with hostname, no agent",
 			input: "vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar",
 			expected: {
 				agent: "",
 				sshHost: "coder-vscode.dev.coder.com--foo--bar",
-				safeHostname: "dev.coder.com",
-				username: "foo",
-				workspace: "bar",
-			},
-		},
-		{
-			label: "with hostname and -- agent",
-			input: "vscode://ssh-remote+coder-vscode.dev.coder.com--foo--bar--baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode.dev.coder.com--foo--bar--baz",
 				safeHostname: "dev.coder.com",
 				username: "foo",
 				workspace: "bar",
@@ -97,6 +72,41 @@ describe("parseRemoteAuthority", () => {
 			},
 		},
 		{
+			label: "hostname with double dash",
+			input: "vscode://ssh-remote+coder-vscode.test--domain.com--foo--bar",
+			expected: {
+				agent: "",
+				sshHost: "coder-vscode.test--domain.com--foo--bar",
+				safeHostname: "test--domain.com",
+				username: "foo",
+				workspace: "bar",
+			},
+		},
+		{
+			label: "Punycode hostname with triple dash",
+			input:
+				"vscode://ssh-remote+coder-vscode.xn--test---8o4.example--foo--bar",
+			expected: {
+				agent: "",
+				sshHost: "coder-vscode.xn--test---8o4.example--foo--bar",
+				safeHostname: "xn--test---8o4.example",
+				username: "foo",
+				workspace: "bar",
+			},
+		},
+		{
+			label: "hostname with multiple double dashes",
+			input:
+				"vscode://ssh-remote+coder-vscode.first--middle--last.example--foo--bar.baz",
+			expected: {
+				agent: "baz",
+				sshHost: "coder-vscode.first--middle--last.example--foo--bar.baz",
+				safeHostname: "first--middle--last.example",
+				username: "foo",
+				workspace: "bar",
+			},
+		},
+		{
 			label: "Punycode label in hostname",
 			input:
 				"vscode://ssh-remote+coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
@@ -104,18 +114,6 @@ describe("parseRemoteAuthority", () => {
 				agent: "",
 				sshHost: "coder-vscode.dev.coder.xn--eckwd4c7cu47r2wf.jp--foo--bar",
 				safeHostname: "dev.coder.xn--eckwd4c7cu47r2wf.jp",
-				username: "foo",
-				workspace: "bar",
-			},
-		},
-		{
-			label: "Punycode hostname with -- agent",
-			input:
-				"vscode://ssh-remote+coder-vscode.xn--eckwd4c7cu47r2wf.jp--foo--bar--baz",
-			expected: {
-				agent: "baz",
-				sshHost: "coder-vscode.xn--eckwd4c7cu47r2wf.jp--foo--bar--baz",
-				safeHostname: "xn--eckwd4c7cu47r2wf.jp",
 				username: "foo",
 				workspace: "bar",
 			},


### PR DESCRIPTION
Closes #937.

## Summary
- Parse Coder remote authorities from the right, rejoining all safeHost segments before username/workspace extraction.
- Drop legacy empty-safeHost and `--agent` parser expectations; add double-dash/triple-dash safeHost regressions.
- Remove empty-hostname fallbacks in path/secrets/SSH config helpers and avoid session lookup when no deployment is selected.

## Tests
- `pnpm test:extension ./test/unit/util.test.ts ./test/unit/core/pathResolver.test.ts ./test/unit/remote/sshConfig.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:extension`
- `pnpm format:check`

<details>
<summary>Implementation notes (Coder Agents generated)</summary>

- `parseRemoteAuthority` now requires `coder-vscode.<safeHost>` and at least username/workspace fields.
- The parser treats the last `--` segment as workspace/agent, the previous segment as username, and rejoins earlier segments as safeHost.
- Tests cover Latin double-dash safeHost, triple-dash Punycode-like safeHost, and multiple embedded `--` segments.
- Legacy deployment-unaware helpers and tests were removed per issue scope.

</details>

Generated by Coder Agents.