### PR TITLE
Add `alternativeWebUrl` param

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,11 +134,11 @@
 					"default": "",
 					"scope": "application"
 				},
-				"coder.alternativeWebUrl": {
-					"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page). The connection URL is still used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
-					"type": "string",
-					"default": ""
-				},
+			"coder.alternativeWebUrl": {
+				"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page, OAuth authorization page). The connection URL is still used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
+				"type": "string",
+				"default": ""
+			},
 				"coder.autologin": {
 					"markdownDescription": "Automatically log into the default URL when the extension is activated. coder.defaultUrl is preferred, otherwise the CODER_URL environment variable will be used. This setting has no effect if neither is set.",
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
 				"coder.alternativeWebUrl": {
 					"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page, OAuth authorization page). When empty, the connection URL is used for the UI as well. The connection URL is always used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "application"
 				},
 				"coder.autologin": {
 					"markdownDescription": "Automatically log into the default URL when the extension is activated. coder.defaultUrl is preferred, otherwise the CODER_URL environment variable will be used. This setting has no effect if neither is set.",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 					"scope": "application"
 				},
 				"coder.alternativeWebUrl": {
-					"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page, OAuth authorization page). When empty, the connection URL is used for the UI as well. The connection URL is always used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
+					"markdownDescription": "Alternative URL for opening Coder pages in the browser (dashboard, workspace, and login pages). API, SSH, and CLI always use the connection URL; when this is empty, so does the browser. Useful when the API runs on a browser-restricted port (e.g. 7004) but the web UI is served on a standard port (e.g. 443).",
 					"type": "string",
 					"default": "",
 					"scope": "application"

--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
 					"default": "",
 					"scope": "application"
 				},
+				"coder.alternativeWebUrl": {
+					"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page). The connection URL is still used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
+					"type": "string",
+					"default": ""
+				},
 				"coder.autologin": {
 					"markdownDescription": "Automatically log into the default URL when the extension is activated. coder.defaultUrl is preferred, otherwise the CODER_URL environment variable will be used. This setting has no effect if neither is set.",
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -134,11 +134,11 @@
 					"default": "",
 					"scope": "application"
 				},
-			"coder.alternativeWebUrl": {
-				"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page, OAuth authorization page). The connection URL is still used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
-				"type": "string",
-				"default": ""
-			},
+				"coder.alternativeWebUrl": {
+					"markdownDescription": "An alternative URL to use when opening Coder pages in the browser. When set, this replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page, OAuth authorization page). When empty, the connection URL is used for the UI as well. The connection URL is always used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443).",
+					"type": "string",
+					"default": ""
+				},
 				"coder.autologin": {
 					"markdownDescription": "Automatically log into the default URL when the extension is activated. coder.defaultUrl is preferred, otherwise the CODER_URL environment variable will be used. This setting has no effect if neither is set.",
 					"type": "boolean",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,7 +27,7 @@ import {
 import { resolveCliAuth } from "./settings/cli";
 import { appendVsCodeLogs } from "./supportBundle/appendVsCodeLogs";
 import { runExportTelemetryCommand } from "./telemetry/export/command";
-import { resolveBrowserUrl, toRemoteAuthority, toSafeHost } from "./util";
+import { openInBrowser, toRemoteAuthority, toSafeHost } from "./util";
 import { vscodeProposed } from "./vscodeProposed";
 import { parseSpeedtestResult } from "./webviews/speedtest/types";
 import {
@@ -598,9 +598,7 @@ export class Commands {
 	 * Must only be called if currently logged in.
 	 */
 	public async createWorkspace(): Promise<void> {
-		const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
-		const uri = baseUrl + "/templates";
-		await vscode.commands.executeCommand("vscode.open", uri);
+		await openInBrowser(this.requireExtensionBaseUrl(), "/templates");
 	}
 
 	/**
@@ -613,14 +611,13 @@ export class Commands {
 	 */
 	public async navigateToWorkspace(item?: OpenableTreeItem) {
 		if (item) {
-			const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
 			const workspaceId = createWorkspaceIdentifier(item.workspace);
-			const uri = baseUrl + `/@${workspaceId}`;
-			await vscode.commands.executeCommand("vscode.open", uri);
+			await openInBrowser(this.requireExtensionBaseUrl(), `/@${workspaceId}`);
 		} else if (this.workspace && this.remoteWorkspaceClient) {
-			const baseUrl = resolveBrowserUrl(this.requireRemoteBaseUrl());
-			const uri = `${baseUrl}/@${createWorkspaceIdentifier(this.workspace)}`;
-			await vscode.commands.executeCommand("vscode.open", uri);
+			await openInBrowser(
+				this.requireRemoteBaseUrl(),
+				`/@${createWorkspaceIdentifier(this.workspace)}`,
+			);
 		} else {
 			vscode.window.showInformationMessage("No workspace found.");
 		}
@@ -636,14 +633,16 @@ export class Commands {
 	 */
 	public async navigateToWorkspaceSettings(item?: OpenableTreeItem) {
 		if (item) {
-			const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
 			const workspaceId = createWorkspaceIdentifier(item.workspace);
-			const uri = baseUrl + `/@${workspaceId}/settings`;
-			await vscode.commands.executeCommand("vscode.open", uri);
+			await openInBrowser(
+				this.requireExtensionBaseUrl(),
+				`/@${workspaceId}/settings`,
+			);
 		} else if (this.workspace && this.remoteWorkspaceClient) {
-			const baseUrl = resolveBrowserUrl(this.requireRemoteBaseUrl());
-			const uri = `${baseUrl}/@${createWorkspaceIdentifier(this.workspace)}/settings`;
-			await vscode.commands.executeCommand("vscode.open", uri);
+			await openInBrowser(
+				this.requireRemoteBaseUrl(),
+				`/@${createWorkspaceIdentifier(this.workspace)}/settings`,
+			);
 		} else {
 			vscode.window.showInformationMessage("No workspace found.");
 		}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -27,7 +27,7 @@ import {
 import { resolveCliAuth } from "./settings/cli";
 import { appendVsCodeLogs } from "./supportBundle/appendVsCodeLogs";
 import { runExportTelemetryCommand } from "./telemetry/export/command";
-import { toRemoteAuthority, toSafeHost } from "./util";
+import { resolveBrowserUrl, toRemoteAuthority, toSafeHost } from "./util";
 import { vscodeProposed } from "./vscodeProposed";
 import { parseSpeedtestResult } from "./webviews/speedtest/types";
 import {
@@ -118,6 +118,17 @@ export class Commands {
 		const url = this.extensionClient.getAxiosInstance().defaults.baseURL;
 		if (!url) {
 			throw new Error("You are not logged in");
+		}
+		return url;
+	}
+
+	/**
+	 * Get the remote workspace deployment URL, throwing if not connected.
+	 */
+	private requireRemoteBaseUrl(): string {
+		const url = this.remoteWorkspaceClient?.getAxiosInstance().defaults.baseURL;
+		if (!url) {
+			throw new Error("No remote workspace connection");
 		}
 		return url;
 	}
@@ -587,7 +598,7 @@ export class Commands {
 	 * Must only be called if currently logged in.
 	 */
 	public async createWorkspace(): Promise<void> {
-		const baseUrl = this.requireExtensionBaseUrl();
+		const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
 		const uri = baseUrl + "/templates";
 		await vscode.commands.executeCommand("vscode.open", uri);
 	}
@@ -602,13 +613,12 @@ export class Commands {
 	 */
 	public async navigateToWorkspace(item?: OpenableTreeItem) {
 		if (item) {
-			const baseUrl = this.requireExtensionBaseUrl();
+			const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
 			const workspaceId = createWorkspaceIdentifier(item.workspace);
 			const uri = baseUrl + `/@${workspaceId}`;
 			await vscode.commands.executeCommand("vscode.open", uri);
 		} else if (this.workspace && this.remoteWorkspaceClient) {
-			const baseUrl =
-				this.remoteWorkspaceClient.getAxiosInstance().defaults.baseURL;
+			const baseUrl = resolveBrowserUrl(this.requireRemoteBaseUrl());
 			const uri = `${baseUrl}/@${createWorkspaceIdentifier(this.workspace)}`;
 			await vscode.commands.executeCommand("vscode.open", uri);
 		} else {
@@ -626,13 +636,12 @@ export class Commands {
 	 */
 	public async navigateToWorkspaceSettings(item?: OpenableTreeItem) {
 		if (item) {
-			const baseUrl = this.requireExtensionBaseUrl();
+			const baseUrl = resolveBrowserUrl(this.requireExtensionBaseUrl());
 			const workspaceId = createWorkspaceIdentifier(item.workspace);
 			const uri = baseUrl + `/@${workspaceId}/settings`;
 			await vscode.commands.executeCommand("vscode.open", uri);
 		} else if (this.workspace && this.remoteWorkspaceClient) {
-			const baseUrl =
-				this.remoteWorkspaceClient.getAxiosInstance().defaults.baseURL;
+			const baseUrl = resolveBrowserUrl(this.requireRemoteBaseUrl());
 			const uri = `${baseUrl}/@${createWorkspaceIdentifier(this.workspace)}/settings`;
 			await vscode.commands.executeCommand("vscode.open", uri);
 		} else {

--- a/src/login/loginCoordinator.ts
+++ b/src/login/loginCoordinator.ts
@@ -10,7 +10,7 @@ import { buildOAuthTokenData } from "../oauth/utils";
 import { withOptionalProgress } from "../progress";
 import { maybeAskAuthMethod, maybeAskUrl } from "../promptUtils";
 import { isKeyringEnabled } from "../settings/cli";
-import { resolveBrowserUrl } from "../util";
+import { openInBrowser } from "../util";
 import { vscodeProposed } from "../vscodeProposed";
 
 import type { User } from "coder/site/src/api/typesGenerated";
@@ -399,9 +399,7 @@ export class LoginCoordinator implements vscode.Disposable {
 		}
 		// This prompt is for convenience; do not error if they close it since
 		// they may already have a token or already have the page opened.
-		await vscode.env.openExternal(
-			vscode.Uri.parse(`${resolveBrowserUrl(url)}/cli-auth`),
-		);
+		await openInBrowser(url, "/cli-auth");
 
 		// For token auth, start with the existing token in the prompt or the last
 		// used token.  Once submitted, if there is a failure we will keep asking

--- a/src/login/loginCoordinator.ts
+++ b/src/login/loginCoordinator.ts
@@ -10,6 +10,7 @@ import { buildOAuthTokenData } from "../oauth/utils";
 import { withOptionalProgress } from "../progress";
 import { maybeAskAuthMethod, maybeAskUrl } from "../promptUtils";
 import { isKeyringEnabled } from "../settings/cli";
+import { resolveBrowserUrl } from "../util";
 import { vscodeProposed } from "../vscodeProposed";
 
 import type { User } from "coder/site/src/api/typesGenerated";
@@ -398,7 +399,9 @@ export class LoginCoordinator implements vscode.Disposable {
 		}
 		// This prompt is for convenience; do not error if they close it since
 		// they may already have a token or already have the page opened.
-		await vscode.env.openExternal(vscode.Uri.parse(`${url}/cli-auth`));
+		await vscode.env.openExternal(
+			vscode.Uri.parse(`${resolveBrowserUrl(url)}/cli-auth`),
+		);
 
 		// For token auth, start with the existing token in the prompt or the last
 		// used token.  Once submitted, if there is a failure we will keep asking

--- a/src/oauth/authorizer.ts
+++ b/src/oauth/authorizer.ts
@@ -218,15 +218,27 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			code_challenge_method: PKCE_CHALLENGE_METHOD,
 		};
 
-		// Server is authoritative for the path; alternativeWebUrl can swap the origin.
+		// The server's endpoint path already includes the connection URL's path
+		// prefix (e.g. a sub-path deployment). alternativeWebUrl can swap the
+		// origin and path prefix (e.g. a reverse proxy) for browser use.
 		const endpoint = new URL(metadata.authorization_endpoint);
+		const connectionBase = new URL(connectionUrl);
 		const browserBase = new URL(resolveUiUrl(connectionUrl));
 		endpoint.protocol = browserBase.protocol;
 		endpoint.hostname = browserBase.hostname;
 		endpoint.port = browserBase.port;
-		// Preserve any path prefix on the alternative URL (e.g. reverse proxy).
-		const prefix = browserBase.pathname.replace(/\/$/, "");
-		endpoint.pathname = `${prefix}${endpoint.pathname}`;
+		// Swap the connection prefix for the browser prefix without doubling it.
+		const connectionPrefix = connectionBase.pathname.replace(/\/$/, "");
+		const browserPrefix = browserBase.pathname.replace(/\/$/, "");
+		let endpointPath = endpoint.pathname;
+		if (
+			connectionPrefix &&
+			(endpointPath === connectionPrefix ||
+				endpointPath.startsWith(`${connectionPrefix}/`))
+		) {
+			endpointPath = endpointPath.slice(connectionPrefix.length);
+		}
+		endpoint.pathname = `${browserPrefix}${endpointPath}`;
 		for (const [key, value] of Object.entries(params)) {
 			endpoint.searchParams.set(key, value);
 		}

--- a/src/oauth/authorizer.ts
+++ b/src/oauth/authorizer.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { CoderApi } from "../api/coderApi";
+import { resolveBrowserUrl } from "../util";
 
 import {
 	AUTH_GRANT_TYPE,
@@ -215,7 +216,13 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			code_challenge_method: PKCE_CHALLENGE_METHOD,
 		});
 
-		const url = `${metadata.authorization_endpoint}?${params.toString()}`;
+		// The server-advertised endpoint is authoritative for the path, but the
+		// origin may be unreachable from a browser (e.g. blocked port). When
+		// `coder.alternativeWebUrl` is set, swap the origin so the user lands on
+		// a reachable host while preserving the path the server told us to use.
+		const endpoint = new URL(metadata.authorization_endpoint);
+		const browserBase = resolveBrowserUrl(endpoint.origin);
+		const url = `${browserBase}${endpoint.pathname}?${params.toString()}`;
 
 		this.logger.debug("Built OAuth authorization URL:", {
 			client_id: clientId,

--- a/src/oauth/authorizer.ts
+++ b/src/oauth/authorizer.ts
@@ -208,7 +208,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			}
 		}
 
-		const params: Record<string, string> = {
+		const params = new URLSearchParams({
 			client_id: clientId,
 			response_type: RESPONSE_TYPE,
 			redirect_uri: this.getRedirectUri(),
@@ -216,30 +216,13 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			state,
 			code_challenge: challenge,
 			code_challenge_method: PKCE_CHALLENGE_METHOD,
-		};
+		});
 
-		// The server's endpoint path already includes the connection URL's path
-		// prefix (e.g. a sub-path deployment). alternativeWebUrl can swap the
-		// origin and path prefix (e.g. a reverse proxy) for browser use.
-		const endpoint = new URL(metadata.authorization_endpoint);
-		const connectionBase = new URL(connectionUrl);
-		const browserBase = new URL(resolveUiUrl(connectionUrl));
-		endpoint.protocol = browserBase.protocol;
-		endpoint.hostname = browserBase.hostname;
-		endpoint.port = browserBase.port;
-		// Swap the connection prefix for the browser prefix without doubling it.
-		const connectionPrefix = connectionBase.pathname.replace(/\/$/, "");
-		const browserPrefix = browserBase.pathname.replace(/\/$/, "");
-		let endpointPath = endpoint.pathname;
-		if (
-			connectionPrefix &&
-			(endpointPath === connectionPrefix ||
-				endpointPath.startsWith(`${connectionPrefix}/`))
-		) {
-			endpointPath = endpointPath.slice(connectionPrefix.length);
-		}
-		endpoint.pathname = `${browserPrefix}${endpointPath}`;
-		for (const [key, value] of Object.entries(params)) {
+		const endpoint = toBrowserAuthorizationUrl(
+			metadata.authorization_endpoint,
+			connectionUrl,
+		);
+		for (const [key, value] of params) {
 			endpoint.searchParams.set(key, value);
 		}
 
@@ -386,4 +369,32 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			this.pendingAuthReject = null;
 		}
 	}
+}
+
+/**
+ * Swap the server's authorization endpoint onto the browser-facing URL
+ * (`alternativeWebUrl`) when it lives under the connection URL, preserving any
+ * sub-path prefix. Endpoints on a different host are left untouched.
+ */
+function toBrowserAuthorizationUrl(
+	authorizationEndpoint: string,
+	connectionUrl: string,
+): URL {
+	const endpoint = new URL(authorizationEndpoint);
+	const connectionBase = new URL(connectionUrl);
+	const browserBase = new URL(resolveUiUrl(connectionUrl));
+	const connectionPrefix = connectionBase.pathname.replace(/\/$/, "");
+	const browserPrefix = browserBase.pathname.replace(/\/$/, "");
+	const underConnection =
+		endpoint.origin === connectionBase.origin &&
+		(connectionPrefix === "" ||
+			endpoint.pathname === connectionPrefix ||
+			endpoint.pathname.startsWith(`${connectionPrefix}/`));
+	if (underConnection) {
+		endpoint.protocol = browserBase.protocol;
+		endpoint.hostname = browserBase.hostname;
+		endpoint.port = browserBase.port;
+		endpoint.pathname = `${browserPrefix}${endpoint.pathname.slice(connectionPrefix.length)}`;
+	}
+	return endpoint;
 }

--- a/src/oauth/authorizer.ts
+++ b/src/oauth/authorizer.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 import { CoderApi } from "../api/coderApi";
-import { resolveBrowserUrl } from "../util";
+import { resolveUiUrl } from "../util";
 
 import {
 	AUTH_GRANT_TYPE,
@@ -99,6 +99,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 
 		reportProgress("waiting for authorization...", 30);
 		const { code, verifier } = await this.startAuthorization(
+			deployment.url,
 			metadata,
 			registration,
 			cancellationToken,
@@ -188,6 +189,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 	 * Build authorization URL with all required OAuth 2.1 parameters.
 	 */
 	private buildAuthorizationUrl(
+		connectionUrl: string,
 		metadata: OAuth2AuthorizationServerMetadata,
 		clientId: string,
 		state: string,
@@ -206,7 +208,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			}
 		}
 
-		const params = new URLSearchParams({
+		const params: Record<string, string> = {
 			client_id: clientId,
 			response_type: RESPONSE_TYPE,
 			redirect_uri: this.getRedirectUri(),
@@ -214,15 +216,20 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			state,
 			code_challenge: challenge,
 			code_challenge_method: PKCE_CHALLENGE_METHOD,
-		});
+		};
 
-		// The server-advertised endpoint is authoritative for the path, but the
-		// origin may be unreachable from a browser (e.g. blocked port). When
-		// `coder.alternativeWebUrl` is set, swap the origin so the user lands on
-		// a reachable host while preserving the path the server told us to use.
+		// Server is authoritative for the path; alternativeWebUrl can swap the origin.
 		const endpoint = new URL(metadata.authorization_endpoint);
-		const browserBase = resolveBrowserUrl(endpoint.origin);
-		const url = `${browserBase}${endpoint.pathname}?${params.toString()}`;
+		const browserBase = new URL(resolveUiUrl(connectionUrl));
+		endpoint.protocol = browserBase.protocol;
+		endpoint.hostname = browserBase.hostname;
+		endpoint.port = browserBase.port;
+		// Preserve any path prefix on the alternative URL (e.g. reverse proxy).
+		const prefix = browserBase.pathname.replace(/\/$/, "");
+		endpoint.pathname = `${prefix}${endpoint.pathname}`;
+		for (const [key, value] of Object.entries(params)) {
+			endpoint.searchParams.set(key, value);
+		}
 
 		this.logger.debug("Built OAuth authorization URL:", {
 			client_id: clientId,
@@ -230,7 +237,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 			scope: DEFAULT_OAUTH_SCOPES,
 		});
 
-		return url;
+		return endpoint.toString();
 	}
 
 	/**
@@ -239,6 +246,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 	 * Returns authorization code and PKCE verifier on success.
 	 */
 	private async startAuthorization(
+		connectionUrl: string,
 		metadata: OAuth2AuthorizationServerMetadata,
 		registration: OAuth2ClientRegistrationResponse,
 		cancellationToken: vscode.CancellationToken,
@@ -247,6 +255,7 @@ export class OAuthAuthorizer implements vscode.Disposable {
 		const { verifier, challenge } = generatePKCE();
 
 		const authUrl = this.buildAuthorizationUrl(
+			connectionUrl,
 			metadata,
 			registration.client_id,
 			state,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import url from "node:url";
+import * as vscode from "vscode";
 
 export interface AuthorityParts {
 	agent: string | undefined;
@@ -194,4 +195,18 @@ export function escapeShellArg(arg: string): string {
 		return `"${escaped}"`;
 	}
 	return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Return the URL for opening Coder pages in the browser.  Uses the
+ * `coder.alternativeWebUrl` setting when configured, otherwise returns
+ * the connection URL unchanged.
+ */
+export function resolveBrowserUrl(connectionUrl: string): string {
+	const alt = vscode.workspace
+		.getConfiguration("coder")
+		.get<string>("alternativeWebUrl")
+		?.trim()
+		.replace(/\/+$/, "");
+	return alt || connectionUrl;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -202,11 +202,24 @@ export function escapeShellArg(arg: string): string {
  * `coder.alternativeWebUrl` setting when configured, otherwise returns
  * the connection URL unchanged.
  */
-export function resolveBrowserUrl(connectionUrl: string): string {
+export function resolveUiUrl(connectionUrl: string): string {
 	const alt = vscode.workspace
 		.getConfiguration("coder")
 		.get<string>("alternativeWebUrl")
 		?.trim()
 		.replace(/\/+$/, "");
 	return alt || connectionUrl;
+}
+
+/**
+ * Open a path on the Coder deployment in the user's browser, applying
+ * `coder.alternativeWebUrl` when configured.
+ */
+export function openInBrowser(
+	connectionUrl: string,
+	path: string,
+): Thenable<boolean> {
+	const base = vscode.Uri.parse(resolveUiUrl(connectionUrl));
+	const segment = path.replace(/^\/+/, "");
+	return vscode.env.openExternal(vscode.Uri.joinPath(base, segment));
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -220,6 +220,5 @@ export function openInBrowser(
 	path: string,
 ): Thenable<boolean> {
 	const base = vscode.Uri.parse(resolveUiUrl(connectionUrl));
-	const segment = path.replace(/^\/+/, "");
-	return vscode.env.openExternal(vscode.Uri.joinPath(base, segment));
+	return vscode.env.openExternal(vscode.Uri.joinPath(base, path));
 }

--- a/src/webviews/tasks/tasksPanelProvider.ts
+++ b/src/webviews/tasks/tasksPanelProvider.ts
@@ -25,6 +25,7 @@ import {
 	streamBuildLogs,
 } from "../../api/workspace";
 import { type Logger } from "../../logging/logger";
+import { resolveBrowserUrl } from "../../util";
 import { vscodeProposed } from "../../vscodeProposed";
 import {
 	dispatchCommand,
@@ -308,9 +309,10 @@ export class TasksPanelProvider
 	}
 
 	private async handleViewInCoder(taskId: string): Promise<void> {
-		const baseUrl = this.client.getHost();
-		if (!baseUrl) return;
+		const connUrl = this.client.getHost();
+		if (!connUrl) return;
 
+		const baseUrl = resolveBrowserUrl(connUrl);
 		const task = await this.client.getTask("me", taskId);
 		vscode.env.openExternal(
 			vscode.Uri.parse(`${baseUrl}/tasks/${task.owner_name}/${task.id}`),
@@ -318,9 +320,10 @@ export class TasksPanelProvider
 	}
 
 	private async handleViewLogs(taskId: string): Promise<void> {
-		const baseUrl = this.client.getHost();
-		if (!baseUrl) return;
+		const connUrl = this.client.getHost();
+		if (!connUrl) return;
 
+		const baseUrl = resolveBrowserUrl(connUrl);
 		const task = await this.client.getTask("me", taskId);
 		vscode.env.openExternal(vscode.Uri.parse(getTaskBuildUrl(baseUrl, task)));
 	}

--- a/src/webviews/tasks/tasksPanelProvider.ts
+++ b/src/webviews/tasks/tasksPanelProvider.ts
@@ -25,7 +25,7 @@ import {
 	streamBuildLogs,
 } from "../../api/workspace";
 import { type Logger } from "../../logging/logger";
-import { resolveBrowserUrl } from "../../util";
+import { openInBrowser } from "../../util";
 import { vscodeProposed } from "../../vscodeProposed";
 import {
 	dispatchCommand,
@@ -44,12 +44,12 @@ import type {
 	WorkspaceAgentLog,
 } from "coder/site/src/api/typesGenerated";
 
-/** Build URL to view task build logs in Coder dashboard */
-function getTaskBuildUrl(baseUrl: string, task: Task): string {
+/** Build the dashboard path for a task's build logs. */
+function getTaskBuildPath(task: Task): string {
 	if (task.workspace_name && task.workspace_build_number) {
-		return `${baseUrl}/@${task.owner_name}/${task.workspace_name}/builds/${task.workspace_build_number}`;
+		return `/@${task.owner_name}/${task.workspace_name}/builds/${task.workspace_build_number}`;
 	}
-	return `${baseUrl}/tasks/${task.owner_name}/${task.id}`;
+	return `/tasks/${task.owner_name}/${task.id}`;
 }
 
 export class TasksPanelProvider
@@ -312,20 +312,16 @@ export class TasksPanelProvider
 		const connUrl = this.client.getHost();
 		if (!connUrl) return;
 
-		const baseUrl = resolveBrowserUrl(connUrl);
 		const task = await this.client.getTask("me", taskId);
-		vscode.env.openExternal(
-			vscode.Uri.parse(`${baseUrl}/tasks/${task.owner_name}/${task.id}`),
-		);
+		await openInBrowser(connUrl, `/tasks/${task.owner_name}/${task.id}`);
 	}
 
 	private async handleViewLogs(taskId: string): Promise<void> {
 		const connUrl = this.client.getHost();
 		if (!connUrl) return;
 
-		const baseUrl = resolveBrowserUrl(connUrl);
 		const task = await this.client.getTask("me", taskId);
-		vscode.env.openExternal(vscode.Uri.parse(getTaskBuildUrl(baseUrl, task)));
+		await openInBrowser(connUrl, getTaskBuildPath(task));
 	}
 
 	private async handleDownloadLogs(taskId: string): Promise<void> {

--- a/test/mocks/vscode.runtime.ts
+++ b/test/mocks/vscode.runtime.ts
@@ -89,8 +89,14 @@ export class Uri {
 			: `${this.scheme}:${this.path}`;
 	}
 	static joinPath(base: Uri, ...paths: string[]) {
-		const sep = base.path.endsWith("/") ? "" : "/";
-		return new Uri(base.scheme, base.path + sep + paths.join("/"));
+		// Mirror vscode-uri: collapse slashes at the seams while preserving the
+		// leading "//" that separates the authority from the path.
+		const head = base.path.replace(/\/+$/, "");
+		const tail = paths
+			.map((p) => p.replace(/^\/+|\/+$/g, ""))
+			.filter(Boolean)
+			.join("/");
+		return new Uri(base.scheme, tail ? `${head}/${tail}` : head);
 	}
 }
 

--- a/test/unit/oauth/authorizer.test.ts
+++ b/test/unit/oauth/authorizer.test.ts
@@ -260,6 +260,34 @@ describe("OAuthAuthorizer", () => {
 				"fetching user...",
 			]);
 		});
+
+		it("rewrites authorization endpoint origin when alternativeWebUrl is set", async () => {
+			const {
+				mockAdapter,
+				configurationProvider,
+				startLogin,
+				completeLogin,
+			} = createTestContext();
+			configurationProvider.set(
+				"coder.alternativeWebUrl",
+				"https://web.example.com",
+			);
+			setupAxiosMockRoutes(mockAdapter, {
+				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
+					"https://coder.example.com:7004",
+				),
+				"/oauth2/register": createMockClientRegistration(),
+				"/oauth2/token": createMockTokenResponse(),
+				"/api/v2/users/me": { username: "test-user" },
+			});
+
+			const { loginPromise, authUrl, state } = await startLogin();
+			expect(authUrl.origin).toBe("https://web.example.com");
+			expect(authUrl.pathname).toBe("/oauth2/authorize");
+
+			await completeLogin(state);
+			await loginPromise;
+		});
 	});
 
 	describe("callback handling", () => {

--- a/test/unit/oauth/authorizer.test.ts
+++ b/test/unit/oauth/authorizer.test.ts
@@ -20,6 +20,7 @@ import {
 	TEST_URL,
 } from "./testUtils";
 
+import type { Deployment } from "@/deployment/types";
 import type { CreateAxiosDefaults } from "axios";
 
 vi.mock("axios", async () => {
@@ -70,11 +71,12 @@ function createTestContext() {
 	const startLogin = async (options?: {
 		progress?: MockProgress;
 		token?: MockCancellationToken;
+		deployment?: Deployment;
 	}) => {
 		const progress = options?.progress ?? new MockProgress();
 		const token = options?.token ?? new MockCancellationToken();
 		const loginPromise = authorizer.login(
-			createTestDeployment(),
+			options?.deployment ?? createTestDeployment(),
 			progress,
 			token,
 		);
@@ -304,6 +306,59 @@ describe("OAuthAuthorizer", () => {
 			const { loginPromise, authUrl, state } = await startLogin();
 			expect(authUrl.origin).toBe("https://proxy.example.com");
 			expect(authUrl.pathname).toBe("/coder/oauth2/authorize");
+
+			await completeLogin(state);
+			await loginPromise;
+		});
+
+		it("does not double the path prefix on sub-path deployments", async () => {
+			const { mockAdapter, startLogin, completeLogin } = createTestContext();
+			setupAxiosMockRoutes(mockAdapter, {
+				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
+					"https://example.com/coder",
+				),
+				"/oauth2/register": createMockClientRegistration(),
+				"/oauth2/token": createMockTokenResponse(),
+				"/api/v2/users/me": { username: "test-user" },
+			});
+
+			const { loginPromise, authUrl, state } = await startLogin({
+				deployment: {
+					url: "https://example.com/coder",
+					safeHostname: "example.com",
+				},
+			});
+			expect(authUrl.origin).toBe("https://example.com");
+			expect(authUrl.pathname).toBe("/coder/oauth2/authorize");
+
+			await completeLogin(state);
+			await loginPromise;
+		});
+
+		it("swaps the sub-path prefix for the alternativeWebUrl prefix", async () => {
+			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
+				createTestContext();
+			configurationProvider.set(
+				"coder.alternativeWebUrl",
+				"https://proxy.example.com/proxy",
+			);
+			setupAxiosMockRoutes(mockAdapter, {
+				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
+					"https://example.com/coder",
+				),
+				"/oauth2/register": createMockClientRegistration(),
+				"/oauth2/token": createMockTokenResponse(),
+				"/api/v2/users/me": { username: "test-user" },
+			});
+
+			const { loginPromise, authUrl, state } = await startLogin({
+				deployment: {
+					url: "https://example.com/coder",
+					safeHostname: "example.com",
+				},
+			});
+			expect(authUrl.origin).toBe("https://proxy.example.com");
+			expect(authUrl.pathname).toBe("/proxy/oauth2/authorize");
 
 			await completeLogin(state);
 			await loginPromise;

--- a/test/unit/oauth/authorizer.test.ts
+++ b/test/unit/oauth/authorizer.test.ts
@@ -262,12 +262,8 @@ describe("OAuthAuthorizer", () => {
 		});
 
 		it("rewrites authorization endpoint origin when alternativeWebUrl is set", async () => {
-			const {
-				mockAdapter,
-				configurationProvider,
-				startLogin,
-				completeLogin,
-			} = createTestContext();
+			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
+				createTestContext();
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
 				"https://web.example.com",
@@ -284,6 +280,52 @@ describe("OAuthAuthorizer", () => {
 			const { loginPromise, authUrl, state } = await startLogin();
 			expect(authUrl.origin).toBe("https://web.example.com");
 			expect(authUrl.pathname).toBe("/oauth2/authorize");
+
+			await completeLogin(state);
+			await loginPromise;
+		});
+
+		it("preserves path prefix on alternativeWebUrl", async () => {
+			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
+				createTestContext();
+			configurationProvider.set(
+				"coder.alternativeWebUrl",
+				"https://proxy.example.com/coder",
+			);
+			setupAxiosMockRoutes(mockAdapter, {
+				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
+					"https://coder.example.com:7004",
+				),
+				"/oauth2/register": createMockClientRegistration(),
+				"/oauth2/token": createMockTokenResponse(),
+				"/api/v2/users/me": { username: "test-user" },
+			});
+
+			const { loginPromise, authUrl, state } = await startLogin();
+			expect(authUrl.origin).toBe("https://proxy.example.com");
+			expect(authUrl.pathname).toBe("/coder/oauth2/authorize");
+
+			await completeLogin(state);
+			await loginPromise;
+		});
+
+		it("preserves query params already on the authorization endpoint", async () => {
+			const { mockAdapter, startLogin, completeLogin } = createTestContext();
+			setupAxiosMockRoutes(mockAdapter, {
+				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
+					TEST_URL,
+					{
+						authorization_endpoint: `${TEST_URL}/oauth2/authorize?audience=workspace`,
+					},
+				),
+				"/oauth2/register": createMockClientRegistration(),
+				"/oauth2/token": createMockTokenResponse(),
+				"/api/v2/users/me": { username: "test-user" },
+			});
+
+			const { loginPromise, authUrl, state } = await startLogin();
+			expect(authUrl.searchParams.get("audience")).toBe("workspace");
+			expect(authUrl.searchParams.get("client_id")).toBeTruthy();
 
 			await completeLogin(state);
 			await loginPromise;

--- a/test/unit/oauth/authorizer.test.ts
+++ b/test/unit/oauth/authorizer.test.ts
@@ -20,8 +20,9 @@ import {
 	TEST_URL,
 } from "./testUtils";
 
-import type { Deployment } from "@/deployment/types";
 import type { CreateAxiosDefaults } from "axios";
+
+import type { Deployment } from "@/deployment/types";
 
 vi.mock("axios", async () => {
 	const actual = await vi.importActual<typeof import("axios")>("axios");
@@ -263,47 +264,55 @@ describe("OAuthAuthorizer", () => {
 			]);
 		});
 
-		it("rewrites authorization endpoint origin when alternativeWebUrl is set", async () => {
-			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
-				createTestContext();
+		it("rewrites the endpoint origin when alternativeWebUrl is set", async () => {
+			const {
+				configurationProvider,
+				setupOAuthRoutes,
+				startLogin,
+				completeLogin,
+			} = createTestContext();
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
-				"https://web.example.com",
+				"https://coder.example.com",
 			);
-			setupAxiosMockRoutes(mockAdapter, {
-				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
-					"https://coder.example.com:7004",
-				),
-				"/oauth2/register": createMockClientRegistration(),
-				"/oauth2/token": createMockTokenResponse(),
-				"/api/v2/users/me": { username: "test-user" },
-			});
+			setupOAuthRoutes(
+				createMockOAuthMetadata("https://coder.example.com:7004"),
+			);
 
-			const { loginPromise, authUrl, state } = await startLogin();
-			expect(authUrl.origin).toBe("https://web.example.com");
+			const { loginPromise, authUrl, state } = await startLogin({
+				deployment: {
+					url: "https://coder.example.com:7004",
+					safeHostname: "coder.example.com",
+				},
+			});
+			expect(authUrl.origin).toBe("https://coder.example.com");
 			expect(authUrl.pathname).toBe("/oauth2/authorize");
 
 			await completeLogin(state);
 			await loginPromise;
 		});
 
-		it("preserves path prefix on alternativeWebUrl", async () => {
-			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
-				createTestContext();
+		it("preserves a path prefix on alternativeWebUrl", async () => {
+			const {
+				configurationProvider,
+				setupOAuthRoutes,
+				startLogin,
+				completeLogin,
+			} = createTestContext();
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
 				"https://proxy.example.com/coder",
 			);
-			setupAxiosMockRoutes(mockAdapter, {
-				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
-					"https://coder.example.com:7004",
-				),
-				"/oauth2/register": createMockClientRegistration(),
-				"/oauth2/token": createMockTokenResponse(),
-				"/api/v2/users/me": { username: "test-user" },
-			});
+			setupOAuthRoutes(
+				createMockOAuthMetadata("https://coder.example.com:7004"),
+			);
 
-			const { loginPromise, authUrl, state } = await startLogin();
+			const { loginPromise, authUrl, state } = await startLogin({
+				deployment: {
+					url: "https://coder.example.com:7004",
+					safeHostname: "coder.example.com",
+				},
+			});
 			expect(authUrl.origin).toBe("https://proxy.example.com");
 			expect(authUrl.pathname).toBe("/coder/oauth2/authorize");
 
@@ -312,15 +321,9 @@ describe("OAuthAuthorizer", () => {
 		});
 
 		it("does not double the path prefix on sub-path deployments", async () => {
-			const { mockAdapter, startLogin, completeLogin } = createTestContext();
-			setupAxiosMockRoutes(mockAdapter, {
-				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
-					"https://example.com/coder",
-				),
-				"/oauth2/register": createMockClientRegistration(),
-				"/oauth2/token": createMockTokenResponse(),
-				"/api/v2/users/me": { username: "test-user" },
-			});
+			const { setupOAuthRoutes, startLogin, completeLogin } =
+				createTestContext();
+			setupOAuthRoutes(createMockOAuthMetadata("https://example.com/coder"));
 
 			const { loginPromise, authUrl, state } = await startLogin({
 				deployment: {
@@ -336,20 +339,17 @@ describe("OAuthAuthorizer", () => {
 		});
 
 		it("swaps the sub-path prefix for the alternativeWebUrl prefix", async () => {
-			const { mockAdapter, configurationProvider, startLogin, completeLogin } =
-				createTestContext();
+			const {
+				configurationProvider,
+				setupOAuthRoutes,
+				startLogin,
+				completeLogin,
+			} = createTestContext();
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
 				"https://proxy.example.com/proxy",
 			);
-			setupAxiosMockRoutes(mockAdapter, {
-				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
-					"https://example.com/coder",
-				),
-				"/oauth2/register": createMockClientRegistration(),
-				"/oauth2/token": createMockTokenResponse(),
-				"/api/v2/users/me": { username: "test-user" },
-			});
+			setupOAuthRoutes(createMockOAuthMetadata("https://example.com/coder"));
 
 			const { loginPromise, authUrl, state } = await startLogin({
 				deployment: {
@@ -365,18 +365,13 @@ describe("OAuthAuthorizer", () => {
 		});
 
 		it("preserves query params already on the authorization endpoint", async () => {
-			const { mockAdapter, startLogin, completeLogin } = createTestContext();
-			setupAxiosMockRoutes(mockAdapter, {
-				"/.well-known/oauth-authorization-server": createMockOAuthMetadata(
-					TEST_URL,
-					{
-						authorization_endpoint: `${TEST_URL}/oauth2/authorize?audience=workspace`,
-					},
-				),
-				"/oauth2/register": createMockClientRegistration(),
-				"/oauth2/token": createMockTokenResponse(),
-				"/api/v2/users/me": { username: "test-user" },
-			});
+			const { setupOAuthRoutes, startLogin, completeLogin } =
+				createTestContext();
+			setupOAuthRoutes(
+				createMockOAuthMetadata(TEST_URL, {
+					authorization_endpoint: `${TEST_URL}/oauth2/authorize?audience=workspace`,
+				}),
+			);
 
 			const { loginPromise, authUrl, state } = await startLogin();
 			expect(authUrl.searchParams.get("audience")).toBe("workspace");

--- a/test/unit/oauth/testUtils.ts
+++ b/test/unit/oauth/testUtils.ts
@@ -131,11 +131,14 @@ export function createBaseTestContext() {
 	const secretsManager = new SecretsManager(secretStorage, memento, logger);
 	const oauthCallback = new OAuthCallback(secretStorage, logger);
 
-	/** Sets up default OAuth routes - use explicit routes when asserting on values */
-	const setupOAuthRoutes = () => {
+	/** Sets up OAuth routes, defaulting to metadata for TEST_URL. */
+	const setupOAuthRoutes = (
+		metadata: OAuth2AuthorizationServerMetadata = createMockOAuthMetadata(
+			TEST_URL,
+		),
+	) => {
 		setupAxiosMockRoutes(mockAdapter, {
-			"/.well-known/oauth-authorization-server":
-				createMockOAuthMetadata(TEST_URL),
+			"/.well-known/oauth-authorization-server": metadata,
 			"/oauth2/register": createMockClientRegistration(),
 			"/oauth2/token": createMockTokenResponse(),
 			"/api/v2/users/me": { username: "test-user" },

--- a/test/unit/oauth/testUtils.ts
+++ b/test/unit/oauth/testUtils.ts
@@ -123,7 +123,7 @@ export function createBaseTestContext() {
 	vi.mocked(getHeaders).mockResolvedValue({});
 
 	// Constructor sets up vscode.workspace mock
-	const _configurationProvider = new MockConfigurationProvider();
+	const configurationProvider = new MockConfigurationProvider();
 
 	const secretStorage = new InMemorySecretStorage();
 	const memento = new InMemoryMemento();
@@ -148,5 +148,6 @@ export function createBaseTestContext() {
 		oauthCallback,
 		logger,
 		setupOAuthRoutes,
+		configurationProvider,
 	};
 }

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -410,65 +410,38 @@ describe("resolveUiUrl", () => {
 		configurationProvider = new MockConfigurationProvider();
 	});
 
-	afterEach(() => {
-		vi.mocked(vscode.workspace.getConfiguration).mockReset();
-	});
-
-	it("returns connection URL when setting is not configured", () => {
+	it("returns the connection URL when no alternative is configured", () => {
 		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com:7004",
 		);
 	});
 
-	it("returns connection URL when setting is empty", () => {
-		configurationProvider.set("coder.alternativeWebUrl", "");
-		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
-			"https://coder.example.com:7004",
-		);
-	});
+	it.each([
+		{ name: "empty", value: "" },
+		{ name: "whitespace", value: "   " },
+	])(
+		"returns the connection URL when the alternative is $name",
+		({ value }) => {
+			configurationProvider.set("coder.alternativeWebUrl", value);
+			expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
+				"https://coder.example.com:7004",
+			);
+		},
+	);
 
-	it("returns connection URL when setting is whitespace", () => {
-		configurationProvider.set("coder.alternativeWebUrl", "   ");
-		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
-			"https://coder.example.com:7004",
-		);
-	});
-
-	it("returns alternative URL when configured", () => {
-		configurationProvider.set(
-			"coder.alternativeWebUrl",
-			"https://coder.example.com",
-		);
-		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
-			"https://coder.example.com",
-		);
-	});
-
-	it("strips trailing slashes from alternative URL", () => {
-		configurationProvider.set(
-			"coder.alternativeWebUrl",
-			"https://coder.example.com/",
-		);
-		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
-			"https://coder.example.com",
-		);
-	});
-
-	it("strips multiple trailing slashes from alternative URL", () => {
-		configurationProvider.set(
-			"coder.alternativeWebUrl",
-			"https://coder.example.com///",
-		);
-		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
-			"https://coder.example.com",
-		);
-	});
-
-	it("trims whitespace from alternative URL", () => {
-		configurationProvider.set(
-			"coder.alternativeWebUrl",
-			"  https://coder.example.com  ",
-		);
+	it.each([
+		{
+			name: "uses the alternative URL when configured",
+			value: "https://coder.example.com",
+		},
+		{ name: "strips trailing slashes", value: "https://coder.example.com/" },
+		{
+			name: "strips multiple trailing slashes",
+			value: "https://coder.example.com///",
+		},
+		{ name: "trims whitespace", value: "  https://coder.example.com  " },
+	])("$name", ({ value }) => {
+		configurationProvider.set("coder.alternativeWebUrl", value);
 		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com",
 		);
@@ -483,11 +456,7 @@ describe("openInBrowser", () => {
 		vi.mocked(vscode.env.openExternal).mockClear();
 	});
 
-	afterEach(() => {
-		vi.mocked(vscode.workspace.getConfiguration).mockReset();
-	});
-
-	it("opens the connection URL with the given path when no alt URL set", () => {
+	it("opens the connection URL joined with the path when no alt URL is set", () => {
 		openInBrowser("https://coder.example.com:7004", "/templates");
 		expect(vscode.env.openExternal).toHaveBeenCalledWith(
 			vscode.Uri.parse("https://coder.example.com:7004/templates"),
@@ -516,7 +485,7 @@ describe("openInBrowser", () => {
 		);
 	});
 
-	it("handles paths without a leading slash", () => {
+	it("joins paths without a leading slash", () => {
 		openInBrowser("https://coder.example.com", "templates");
 		expect(vscode.env.openExternal).toHaveBeenCalledWith(
 			vscode.Uri.parse("https://coder.example.com/templates"),

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
+import * as vscode from "vscode";
 
 import {
 	type AuthorityParts,
@@ -9,6 +10,7 @@ import {
 	expandPath,
 	findPort,
 	parseRemoteAuthority,
+	resolveBrowserUrl,
 	toSafeHost,
 } from "@/util";
 
@@ -395,5 +397,66 @@ describe("findPort", () => {
 [10:30:10] Final connection Socks port: 3333 established
 		`;
 		expect(findPort(log)).toBe(3333);
+	});
+});
+
+describe("resolveBrowserUrl", () => {
+	function mockAlternativeWebUrl(value: string | undefined): void {
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn().mockReturnValue(value),
+		} as unknown as vscode.WorkspaceConfiguration);
+	}
+
+	afterEach(() => {
+		vi.mocked(vscode.workspace.getConfiguration).mockReset();
+	});
+
+	it("returns connection URL when setting is not configured", () => {
+		mockAlternativeWebUrl(undefined);
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com:7004",
+		);
+	});
+
+	it("returns connection URL when setting is empty", () => {
+		mockAlternativeWebUrl("");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com:7004",
+		);
+	});
+
+	it("returns connection URL when setting is whitespace", () => {
+		mockAlternativeWebUrl("   ");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com:7004",
+		);
+	});
+
+	it("returns alternative URL when configured", () => {
+		mockAlternativeWebUrl("https://coder.example.com");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com",
+		);
+	});
+
+	it("strips trailing slashes from alternative URL", () => {
+		mockAlternativeWebUrl("https://coder.example.com/");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com",
+		);
+	});
+
+	it("strips multiple trailing slashes from alternative URL", () => {
+		mockAlternativeWebUrl("https://coder.example.com///");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com",
+		);
+	});
+
+	it("trims whitespace from alternative URL", () => {
+		mockAlternativeWebUrl("  https://coder.example.com  ");
+		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+			"https://coder.example.com",
+		);
 	});
 });

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -9,10 +9,13 @@ import {
 	escapeShellArg,
 	expandPath,
 	findPort,
+	openInBrowser,
 	parseRemoteAuthority,
-	resolveBrowserUrl,
+	resolveUiUrl,
 	toSafeHost,
 } from "@/util";
+
+import { MockConfigurationProvider } from "../mocks/testHelpers";
 
 describe("parseRemoteAuthority", () => {
 	const remoteAuthority = (sshHost: string) => `vscode://ssh-remote+${sshHost}`;
@@ -400,63 +403,123 @@ describe("findPort", () => {
 	});
 });
 
-describe("resolveBrowserUrl", () => {
-	function mockAlternativeWebUrl(value: string | undefined): void {
-		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-			get: vi.fn().mockReturnValue(value),
-		} as unknown as vscode.WorkspaceConfiguration);
-	}
+describe("resolveUiUrl", () => {
+	let configurationProvider: MockConfigurationProvider;
+
+	beforeEach(() => {
+		configurationProvider = new MockConfigurationProvider();
+	});
 
 	afterEach(() => {
 		vi.mocked(vscode.workspace.getConfiguration).mockReset();
 	});
 
 	it("returns connection URL when setting is not configured", () => {
-		mockAlternativeWebUrl(undefined);
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com:7004",
 		);
 	});
 
 	it("returns connection URL when setting is empty", () => {
-		mockAlternativeWebUrl("");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set("coder.alternativeWebUrl", "");
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com:7004",
 		);
 	});
 
 	it("returns connection URL when setting is whitespace", () => {
-		mockAlternativeWebUrl("   ");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set("coder.alternativeWebUrl", "   ");
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com:7004",
 		);
 	});
 
 	it("returns alternative URL when configured", () => {
-		mockAlternativeWebUrl("https://coder.example.com");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"https://coder.example.com",
+		);
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com",
 		);
 	});
 
 	it("strips trailing slashes from alternative URL", () => {
-		mockAlternativeWebUrl("https://coder.example.com/");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"https://coder.example.com/",
+		);
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com",
 		);
 	});
 
 	it("strips multiple trailing slashes from alternative URL", () => {
-		mockAlternativeWebUrl("https://coder.example.com///");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"https://coder.example.com///",
+		);
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com",
 		);
 	});
 
 	it("trims whitespace from alternative URL", () => {
-		mockAlternativeWebUrl("  https://coder.example.com  ");
-		expect(resolveBrowserUrl("https://coder.example.com:7004")).toBe(
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"  https://coder.example.com  ",
+		);
+		expect(resolveUiUrl("https://coder.example.com:7004")).toBe(
 			"https://coder.example.com",
+		);
+	});
+});
+
+describe("openInBrowser", () => {
+	let configurationProvider: MockConfigurationProvider;
+
+	beforeEach(() => {
+		configurationProvider = new MockConfigurationProvider();
+		vi.mocked(vscode.env.openExternal).mockClear();
+	});
+
+	afterEach(() => {
+		vi.mocked(vscode.workspace.getConfiguration).mockReset();
+	});
+
+	it("opens the connection URL with the given path when no alt URL set", () => {
+		openInBrowser("https://coder.example.com:7004", "/templates");
+		expect(vscode.env.openExternal).toHaveBeenCalledWith(
+			vscode.Uri.parse("https://coder.example.com:7004/templates"),
+		);
+	});
+
+	it("opens the alternative URL when configured", () => {
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"https://coder.example.com",
+		);
+		openInBrowser("https://coder.example.com:7004", "/templates");
+		expect(vscode.env.openExternal).toHaveBeenCalledWith(
+			vscode.Uri.parse("https://coder.example.com/templates"),
+		);
+	});
+
+	it("preserves a path prefix on the alternative URL", () => {
+		configurationProvider.set(
+			"coder.alternativeWebUrl",
+			"https://proxy.example.com/coder",
+		);
+		openInBrowser("https://coder.example.com:7004", "/templates");
+		expect(vscode.env.openExternal).toHaveBeenCalledWith(
+			vscode.Uri.parse("https://proxy.example.com/coder/templates"),
+		);
+	});
+
+	it("handles paths without a leading slash", () => {
+		openInBrowser("https://coder.example.com", "templates");
+		expect(vscode.env.openExternal).toHaveBeenCalledWith(
+			vscode.Uri.parse("https://coder.example.com/templates"),
 		);
 	});
 });

--- a/test/unit/webviews/tasks/tasksPanelProvider.test.ts
+++ b/test/unit/webviews/tasks/tasksPanelProvider.test.ts
@@ -23,6 +23,7 @@ import {
 import {
 	createAxiosError,
 	createMockLogger,
+	MockConfigurationProvider,
 	MockUserInteraction,
 } from "../../../mocks/testHelpers";
 
@@ -200,16 +201,13 @@ function createHarness(): Harness {
 }
 
 describe("TasksPanelProvider", () => {
+	let configurationProvider: MockConfigurationProvider;
+
 	beforeEach(() => {
 		// Reset shared vscode mocks between tests
 		vi.resetAllMocks();
 
-		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-			get: vi.fn(),
-			has: vi.fn().mockReturnValue(false),
-			inspect: vi.fn(),
-			update: vi.fn().mockResolvedValue(undefined),
-		} as unknown as vscode.WorkspaceConfiguration);
+		configurationProvider = new MockConfigurationProvider();
 	});
 
 	describe("getTasks", () => {
@@ -687,9 +685,10 @@ describe("TasksPanelProvider", () => {
 		});
 
 		it("viewInCoder uses alternative web URL when configured", async () => {
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-				get: vi.fn().mockReturnValue("https://coder.example.com:443"),
-			} as unknown as vscode.WorkspaceConfiguration);
+			configurationProvider.set(
+				"coder.alternativeWebUrl",
+				"https://coder.example.com:443",
+			);
 
 			const h = createHarness();
 			h.client.getTask.mockResolvedValue(
@@ -704,9 +703,10 @@ describe("TasksPanelProvider", () => {
 		});
 
 		it("viewLogs uses alternative web URL when configured", async () => {
-			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
-				get: vi.fn().mockReturnValue("https://coder.example.com:443"),
-			} as unknown as vscode.WorkspaceConfiguration);
+			configurationProvider.set(
+				"coder.alternativeWebUrl",
+				"https://coder.example.com:443",
+			);
 
 			const h = createHarness();
 			h.client.getTask.mockResolvedValue(

--- a/test/unit/webviews/tasks/tasksPanelProvider.test.ts
+++ b/test/unit/webviews/tasks/tasksPanelProvider.test.ts
@@ -203,6 +203,13 @@ describe("TasksPanelProvider", () => {
 	beforeEach(() => {
 		// Reset shared vscode mocks between tests
 		vi.resetAllMocks();
+
+		vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+			get: vi.fn(),
+			has: vi.fn().mockReturnValue(false),
+			inspect: vi.fn(),
+			update: vi.fn().mockResolvedValue(undefined),
+		} as unknown as vscode.WorkspaceConfiguration);
 	});
 
 	describe("getTasks", () => {
@@ -677,6 +684,46 @@ describe("TasksPanelProvider", () => {
 			await h.command(TasksApi.viewInCoder, { taskId: "task-123" });
 
 			expect(vscode.env.openExternal).not.toHaveBeenCalled();
+		});
+
+		it("viewInCoder uses alternative web URL when configured", async () => {
+			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+				get: vi.fn().mockReturnValue("https://coder.example.com:443"),
+			} as unknown as vscode.WorkspaceConfiguration);
+
+			const h = createHarness();
+			h.client.getTask.mockResolvedValue(
+				task({ id: "task-1", owner_name: "alice" }),
+			);
+
+			await h.command(TasksApi.viewInCoder, { taskId: "task-1" });
+
+			expect(vscode.env.openExternal).toHaveBeenCalledWith(
+				vscode.Uri.parse("https://coder.example.com:443/tasks/alice/task-1"),
+			);
+		});
+
+		it("viewLogs uses alternative web URL when configured", async () => {
+			vi.mocked(vscode.workspace.getConfiguration).mockReturnValue({
+				get: vi.fn().mockReturnValue("https://coder.example.com:443"),
+			} as unknown as vscode.WorkspaceConfiguration);
+
+			const h = createHarness();
+			h.client.getTask.mockResolvedValue(
+				task({
+					owner_name: "alice",
+					workspace_name: "my-ws",
+					workspace_build_number: 42,
+				}),
+			);
+
+			await h.command(TasksApi.viewLogs, { taskId: "task-1" });
+
+			expect(vscode.env.openExternal).toHaveBeenCalledWith(
+				vscode.Uri.parse(
+					"https://coder.example.com:443/@alice/my-ws/builds/42",
+				),
+			);
 		});
 	});
 

--- a/test/unit/webviews/tasks/tasksPanelProvider.test.ts
+++ b/test/unit/webviews/tasks/tasksPanelProvider.test.ts
@@ -684,12 +684,11 @@ describe("TasksPanelProvider", () => {
 			expect(vscode.env.openExternal).not.toHaveBeenCalled();
 		});
 
-		it("viewInCoder uses alternative web URL when configured", async () => {
+		it("viewInCoder uses the alternative web URL when configured", async () => {
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
 				"https://coder.example.com:443",
 			);
-
 			const h = createHarness();
 			h.client.getTask.mockResolvedValue(
 				task({ id: "task-1", owner_name: "alice" }),
@@ -702,12 +701,11 @@ describe("TasksPanelProvider", () => {
 			);
 		});
 
-		it("viewLogs uses alternative web URL when configured", async () => {
+		it("viewLogs uses the alternative web URL when configured", async () => {
 			configurationProvider.set(
 				"coder.alternativeWebUrl",
 				"https://coder.example.com:443",
 			);
-
 			const h = createHarness();
 			h.client.getTask.mockResolvedValue(
 				task({


### PR DESCRIPTION
This PR adds a new parameter for specifying an alternative URL to use when opening Coder pages in the browser. When set, it replaces the connection URL for browser links only (dashboard, workspace pages, token authentication page). The connection URL is still used for API calls, SSH, and CLI operations. Useful when the Coder API runs on a port that browsers restrict (e.g., 7004) but the web UI is accessible on a standard port (e.g., 443)."