### PR TITLE
feat: shared workspaces support

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,13 @@
 					"icon": "media/logo-white.svg"
 				},
 				{
+					"id": "sharedWorkspaces",
+					"name": "Shared Workspaces",
+					"visibility": "visible",
+					"icon": "media/logo-white.svg",
+					"when": "coder.authenticated"
+				},
+				{
 					"id": "allWorkspaces",
 					"name": "All Workspaces",
 					"visibility": "visible",
@@ -433,6 +440,12 @@
 				"icon": "$(search)"
 			},
 			{
+				"command": "coder.searchSharedWorkspaces",
+				"title": "Search",
+				"category": "Coder",
+				"icon": "$(search)"
+			},
+			{
 				"command": "coder.searchAllWorkspaces",
 				"title": "Search",
 				"category": "Coder",
@@ -561,6 +574,10 @@
 					"when": "false"
 				},
 				{
+					"command": "coder.searchSharedWorkspaces",
+					"when": "false"
+				},
+				{
 					"command": "coder.searchAllWorkspaces",
 					"when": "false"
 				},
@@ -605,6 +622,16 @@
 				{
 					"command": "coder.searchMyWorkspaces",
 					"when": "coder.authenticated && view == myWorkspaces",
+					"group": "navigation@3"
+				},
+				{
+					"command": "coder.refreshWorkspaces",
+					"when": "coder.authenticated && view == sharedWorkspaces",
+					"group": "navigation@2"
+				},
+				{
+					"command": "coder.searchSharedWorkspaces",
+					"when": "coder.authenticated && view == sharedWorkspaces",
 					"group": "navigation@3"
 				},
 				{

--- a/src/core/commandManager.ts
+++ b/src/core/commandManager.ts
@@ -21,6 +21,7 @@ export const CODER_COMMAND_IDS = [
 	"coder.refreshWorkspaces",
 	"coder.viewLogs",
 	"coder.searchMyWorkspaces",
+	"coder.searchSharedWorkspaces",
 	"coder.searchAllWorkspaces",
 	"coder.manageCredentials",
 	"coder.applyRecommendedSettings",

--- a/src/deployment/deploymentManager.ts
+++ b/src/deployment/deploymentManager.ts
@@ -37,6 +37,7 @@ export class DeploymentManager implements vscode.Disposable {
 	private readonly telemetryService: TelemetryService;
 
 	#deployment: Deployment | null = null;
+	#currentUserId: string | undefined;
 	#authListenerDisposable: vscode.Disposable | undefined;
 	#crossWindowSyncDisposable: vscode.Disposable | undefined;
 
@@ -84,6 +85,14 @@ export class DeploymentManager implements vscode.Disposable {
 	}
 
 	/**
+	 * Get the id of the currently authenticated user, if any. Used by the
+	 * Shared workspaces view to filter out the current user's workspaces.
+	 */
+	public getCurrentUserId(): string | undefined {
+		return this.#currentUserId;
+	}
+
+	/**
 	 * Attempt to change to a deployment after validating authentication.
 	 * Only changes deployment if authentication succeeds.
 	 * Returns true if deployment was changed, false otherwise.
@@ -127,6 +136,7 @@ export class DeploymentManager implements vscode.Disposable {
 			user: deployment.user.username,
 		});
 		this.#deployment = { ...deployment };
+		this.#currentUserId = deployment.user.id;
 		this.telemetryService.setDeploymentUrl(deployment.url);
 
 		// Updates client credentials
@@ -173,6 +183,7 @@ export class DeploymentManager implements vscode.Disposable {
 		this.client.setCredentials(undefined, undefined);
 		this.updateAuthContexts(undefined);
 		this.contextManager.set("coder.agentsEnabled", false);
+		this.#currentUserId = undefined;
 		this.clearWorkspaces();
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import {
 } from "./workspace/workspacesProvider";
 
 const MY_WORKSPACES_TREE_ID = "myWorkspaces";
+const SHARED_WORKSPACES_TREE_ID = "sharedWorkspaces";
 const ALL_WORKSPACES_TREE_ID = "allWorkspaces";
 
 export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
@@ -174,6 +175,19 @@ async function doActivate(
 	);
 	ctx.subscriptions.push(allWorkspacesProvider);
 
+	const sharedWorkspacesProvider = new WorkspaceProvider(
+		WorkspaceQuery.Shared,
+		client,
+		output,
+		isAuthenticated,
+		undefined,
+		// Filter out workspaces owned by the current user. The deployment
+		// manager is created below; we capture it via the closure and read it
+		// lazily, since the callback only fires when workspaces are fetched.
+		() => deploymentManager.getCurrentUserId(),
+	);
+	ctx.subscriptions.push(sharedWorkspacesProvider);
+
 	// createTreeView, unlike registerTreeDataProvider, gives us the tree view API
 	// (so we can see when it is visible) but otherwise they have the same effect.
 	const myWsTree = vscode.window.createTreeView(MY_WORKSPACES_TREE_ID, {
@@ -184,6 +198,19 @@ async function doActivate(
 	myWsTree.onDidChangeVisibility(
 		(event) => {
 			myWorkspacesProvider.setVisibility(event.visible);
+		},
+		undefined,
+		ctx.subscriptions,
+	);
+
+	const sharedWsTree = vscode.window.createTreeView(SHARED_WORKSPACES_TREE_ID, {
+		treeDataProvider: sharedWorkspacesProvider,
+	});
+	ctx.subscriptions.push(sharedWsTree);
+	sharedWorkspacesProvider.setVisibility(sharedWsTree.visible);
+	sharedWsTree.onDidChangeVisibility(
+		(event) => {
+			sharedWorkspacesProvider.setVisibility(event.visible);
 		},
 		undefined,
 		ctx.subscriptions,
@@ -207,7 +234,7 @@ async function doActivate(
 		serviceContainer,
 		client,
 		oauthSessionManager,
-		[myWorkspacesProvider, allWorkspacesProvider],
+		[myWorkspacesProvider, sharedWorkspacesProvider, allWorkspacesProvider],
 	);
 	ctx.subscriptions.push(deploymentManager);
 
@@ -313,11 +340,15 @@ async function doActivate(
 	);
 	commandManager.register("coder.refreshWorkspaces", () => {
 		void myWorkspacesProvider.fetchAndRefresh();
+		void sharedWorkspacesProvider.fetchAndRefresh();
 		void allWorkspacesProvider.fetchAndRefresh();
 	});
 	commandManager.register("coder.viewLogs", commands.viewLogs.bind(commands));
 	commandManager.register("coder.searchMyWorkspaces", async () =>
 		showTreeViewSearch(MY_WORKSPACES_TREE_ID),
+	);
+	commandManager.register("coder.searchSharedWorkspaces", async () =>
+		showTreeViewSearch(SHARED_WORKSPACES_TREE_ID),
 	);
 	commandManager.register("coder.searchAllWorkspaces", async () =>
 		showTreeViewSearch(ALL_WORKSPACES_TREE_ID),

--- a/src/workspace/workspacesProvider.ts
+++ b/src/workspace/workspacesProvider.ts
@@ -23,6 +23,11 @@ import { type Logger } from "../logging/logger";
 export enum WorkspaceQuery {
 	Mine = "owner:me",
 	All = "",
+	// Shared returns workspaces the user has access to via sharing but does not
+	// own. The server-side `shared:true` filter also includes workspaces the
+	// user owns and has shared out, so the provider filters those out
+	// client-side using the current user's id.
+	Shared = "shared:true",
 }
 
 /**
@@ -53,6 +58,10 @@ export class WorkspaceProvider
 		private readonly logger: Logger,
 		private readonly isAuthenticated: () => boolean,
 		private readonly timerSeconds?: number,
+		// Returns the id of the currently authenticated user. Used by the Shared
+		// query to filter out workspaces owned by the current user.
+		private readonly getCurrentUserId: () => string | undefined = () =>
+			undefined,
 	) {
 		// No initialization.
 	}
@@ -112,6 +121,18 @@ export class WorkspaceProvider
 			q: this.getWorkspacesQuery,
 		});
 
+		// `shared:true` also matches workspaces the current user shared out;
+		// keep only the ones owned by someone else.
+		let workspaces = resp.workspaces;
+		if (this.getWorkspacesQuery === WorkspaceQuery.Shared) {
+			const currentUserId = this.getCurrentUserId();
+			if (currentUserId) {
+				workspaces = workspaces.filter(
+					(workspace) => workspace.owner_id !== currentUserId,
+				);
+			}
+		}
+
 		// We could have logged out while waiting for the query, or logged into a
 		// different deployment.
 		const url2 = this.client.getAxiosInstance().defaults.baseURL;
@@ -133,7 +154,7 @@ export class WorkspaceProvider
 		// have this separate map held outside the tree.
 		const showMetadata = this.getWorkspacesQuery === WorkspaceQuery.Mine;
 		if (showMetadata) {
-			const agents = extractAllAgents(resp.workspaces);
+			const agents = extractAllAgents(workspaces);
 			for (const agent of agents) {
 				// If we have an existing watcher, re-use it.
 				const oldWatcher = this.agentWatchers.get(agent.id);
@@ -159,11 +180,15 @@ export class WorkspaceProvider
 			}
 		}
 
+		// Show the owner alongside the workspace name when the list may contain
+		// workspaces owned by other users.
+		const showOwner = this.getWorkspacesQuery !== WorkspaceQuery.Mine;
+
 		// Create tree items for each workspace
-		const workspaceTreeItems = resp.workspaces.map((workspace: Workspace) => {
+		const workspaceTreeItems = workspaces.map((workspace: Workspace) => {
 			const workspaceTreeItem = new WorkspaceTreeItem(
 				workspace,
-				this.getWorkspacesQuery === WorkspaceQuery.All,
+				showOwner,
 				showMetadata,
 			);
 


### PR DESCRIPTION
Adds a third tree view, **Shared Workspaces**, that lists workspaces the current user has access to but does not own. The view is visible to any authenticated user, sits between **My Workspaces** and **All Workspaces**, and reuses the existing context-menu actions and refresh/search affordances.

<details>
<summary>Implementation notes</summary>

- New `WorkspaceQuery.Shared = "shared:true"` value; the provider filters out workspaces owned by the current user client-side, because `shared:true` server-side also matches workspaces the current user shared out.
- `DeploymentManager` exposes `getCurrentUserId()` so the new provider can scope the filter to the active session; this is cleared on logout/suspend.
- `coder.refreshWorkspaces` now also refreshes the new view.

</details>

> Generated with Coder Agents on behalf of @aslilac.