### PR TITLE
feat(telemetry): instrument auth recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,18 @@
   machine only and never sent anywhere. Configure via the new
   `coder.telemetry.level` setting (`local` by default, `off` to disable);
   see `coder.telemetry.local` for tunables.
-- Every `coder.*` command now records a `command.invoked` telemetry event with
-  its duration and outcome, so command latency and failures are captured
-  alongside other local telemetry.
-- Extension activation, remote workspace setup phases (auth retrieval,
-  workspace lookup, workspace and agent readiness, SSH config write), and CLI
-  binary download/verify now emit local telemetry events with their duration
-  and outcome, so startup latency and failures are captured alongside other
-  local telemetry.
+- Local telemetry now records `command.invoked` for each `coder.*` command
+  with duration and outcome.
+- Local telemetry now records extension activation, remote workspace setup
+  phases (auth retrieval, workspace lookup, workspace and agent readiness,
+  SSH config write), and CLI binary download/verify with their durations
+  and outcomes.
 - Local telemetry now records `http.requests` rollups for per-route HTTP
-  health without emitting one event per request.
-- Connection lifecycle now records local telemetry: SSH process
+  health, without emitting one event per request.
+- Local telemetry now records connection lifecycle: SSH process
   discovery/loss/recovery with sampled network info, and reconnecting
-  WebSocket open, drop, reconnect, and state transitions, so connection
-  stability is captured alongside other local telemetry.
+  WebSocket open/drop/reconnect/state transitions.
+- Local telemetry now records authentication refresh and recovery prompts.
 
 ### Fixed
 

--- a/src/api/authInterceptor.ts
+++ b/src/api/authInterceptor.ts
@@ -1,10 +1,12 @@
 import { type AxiosError, isAxiosError } from "axios";
 
+import { AuthTelemetry } from "../instrumentation/auth";
 import { OAuthError } from "../oauth/errors";
 import { toSafeHost } from "../util";
 
 import type * as vscode from "vscode";
 
+import type { ServiceContainer } from "../core/container";
 import type { SecretsManager } from "../core/secretsManager";
 import type { Logger } from "../logging/logger";
 import type { RequestConfigWithMeta } from "../logging/types";
@@ -28,15 +30,20 @@ export type AuthRequiredHandler = (hostname: string) => Promise<boolean>;
  */
 export class AuthInterceptor implements vscode.Disposable {
 	private readonly interceptorId: number;
+	private readonly authTelemetry: AuthTelemetry;
+	private readonly logger: Logger;
+	private readonly secretsManager: SecretsManager;
 	private authRequiredPromise: Promise<boolean> | null = null;
 
 	constructor(
 		private readonly client: CoderApi,
-		private readonly logger: Logger,
 		private readonly oauthSessionManager: OAuthSessionManager,
-		private readonly secretsManager: SecretsManager,
+		container: ServiceContainer,
 		private readonly onAuthRequired?: AuthRequiredHandler,
 	) {
+		this.logger = container.getLogger();
+		this.secretsManager = container.getSecretsManager();
+		this.authTelemetry = new AuthTelemetry(container.getTelemetryService());
 		this.interceptorId = this.client
 			.getAxiosInstance()
 			.interceptors.response.use(
@@ -68,47 +75,58 @@ export class AuthInterceptor implements vscode.Disposable {
 		}
 		const hostname = toSafeHost(baseUrl);
 
-		return this.handle401Error(error, hostname);
+		return this.recoverFromUnauthorized(error, hostname);
 	}
 
-	private async handle401Error(
+	private recoverFromUnauthorized(
 		error: AxiosError,
 		hostname: string,
 	): Promise<unknown> {
 		this.logger.debug("Received 401 response, attempting recovery");
-
-		if (await this.oauthSessionManager.isLoggedInWithOAuth(hostname)) {
-			try {
-				const newTokens = await this.oauthSessionManager.refreshToken();
-				this.client.setSessionToken(newTokens.access_token);
-				this.logger.debug("Token refresh successful, retrying request");
-				return this.retryRequest(error, newTokens.access_token);
-			} catch (refreshError) {
-				if (refreshError instanceof OAuthError) {
-					const msg = `Token refresh failed: ${refreshError.message}`;
-					if (refreshError.requiresReAuth) {
-						this.logger.warn(msg);
-					} else {
-						this.logger.error(msg);
-					}
-				} else {
-					this.logger.error("Token refresh failed:", refreshError);
-				}
-			}
-		}
-
-		if (this.onAuthRequired) {
-			const success = await this.executeAuthRequired(hostname);
-			if (success) {
-				const auth = await this.secretsManager.getSessionAuth(hostname);
+		// TODO(#925): emit a correlated received-log here once Span.log() lands.
+		return this.authTelemetry.traceAuthRecovery(async (recorder) => {
+			const isOAuth =
+				await this.oauthSessionManager.isLoggedInWithOAuth(hostname);
+			recorder.setRefreshAttempted(isOAuth);
+			const newToken = isOAuth ? await this.tryOAuthRefresh() : undefined;
+			if (newToken) {
+				recorder.setRecovery("refresh_success");
+				return this.retryRequest(error, newToken);
+			} else if (this.onAuthRequired) {
+				recorder.setRecovery("login_required");
+				const success = await this.executeAuthRequired(hostname);
+				const auth = success
+					? await this.secretsManager.getSessionAuth(hostname)
+					: undefined;
 				if (auth) {
 					this.logger.debug("Re-authentication successful, retrying request");
 					return this.retryRequest(error, auth.token);
 				}
+				throw error;
+			} else {
+				recorder.setRecovery("none");
+				throw error;
 			}
-		}
+		});
+	}
 
-		throw error;
+	/** Returns the new access token on success, or undefined when refresh fails. */
+	private async tryOAuthRefresh(): Promise<string | undefined> {
+		try {
+			const newTokens = await this.oauthSessionManager.refreshToken();
+			this.client.setSessionToken(newTokens.access_token);
+			this.logger.debug("Token refresh successful");
+			return newTokens.access_token;
+		} catch (refreshError) {
+			if (!(refreshError instanceof OAuthError)) {
+				this.logger.error("Token refresh failed:", refreshError);
+			} else if (refreshError.requiresReAuth) {
+				this.logger.warn(`Token refresh failed: ${refreshError.message}`);
+			} else {
+				this.logger.error(`Token refresh failed: ${refreshError.message}`);
+			}
+			return undefined;
+		}
 	}
 
 	/**

--- a/src/api/authInterceptor.ts
+++ b/src/api/authInterceptor.ts
@@ -85,28 +85,33 @@ export class AuthInterceptor implements vscode.Disposable {
 		this.logger.debug("Received 401 response, attempting recovery");
 		// TODO(#925): emit a correlated received-log here once Span.log() lands.
 		return this.authTelemetry.traceAuthRecovery(async (recorder) => {
+			// 1) OAuth refresh path.
 			const isOAuth =
 				await this.oauthSessionManager.isLoggedInWithOAuth(hostname);
 			recorder.setRefreshAttempted(isOAuth);
-			const newToken = isOAuth ? await this.tryOAuthRefresh() : undefined;
-			if (newToken) {
-				recorder.setRecovery("refresh_success");
-				return this.retryRequest(error, newToken);
-			} else if (this.onAuthRequired) {
-				recorder.setRecovery("login_required");
-				const success = await this.executeAuthRequired(hostname);
-				const auth = success
-					? await this.secretsManager.getSessionAuth(hostname)
-					: undefined;
-				if (auth) {
-					this.logger.debug("Re-authentication successful, retrying request");
-					return this.retryRequest(error, auth.token);
+			if (isOAuth) {
+				const newToken = await this.tryOAuthRefresh();
+				if (newToken) {
+					recorder.setRecovery("refresh_success");
+					return this.retryRequest(error, newToken);
 				}
-				throw error;
-			} else {
+			}
+
+			// 2) Interactive re-auth fallback.
+			if (!this.onAuthRequired) {
 				recorder.setRecovery("none");
 				throw error;
 			}
+			recorder.setRecovery("login_required");
+			const success = await this.executeAuthRequired(hostname);
+			const auth = success
+				? await this.secretsManager.getSessionAuth(hostname)
+				: undefined;
+			if (!auth) {
+				throw error;
+			}
+			this.logger.debug("Re-authentication successful, retrying request");
+			return this.retryRequest(error, auth.token);
 		});
 	}
 

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 
 import { CoderApi } from "../api/coderApi";
+import { AuthTelemetry } from "../instrumentation/auth";
 import { LoginCoordinator } from "../login/loginCoordinator";
 import { OAuthCallback } from "../oauth/oauthCallback";
 import { buildSession, extractExtensionVersion } from "../telemetry/event";
@@ -99,7 +100,11 @@ export class ServiceContainer implements vscode.Disposable {
 		this.contextManager = new ContextManager(context);
 		this.oauthCallback = new OAuthCallback(context.secrets, this.logger);
 		this.loginCoordinator = new LoginCoordinator(
-			this,
+			this.secretsManager,
+			this.mementoManager,
+			this.logger,
+			this.cliCredentialManager,
+			new AuthTelemetry(this.telemetryService),
 			this.oauthCallback,
 			context.extension.id,
 		);

--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -99,10 +99,7 @@ export class ServiceContainer implements vscode.Disposable {
 		this.contextManager = new ContextManager(context);
 		this.oauthCallback = new OAuthCallback(context.secrets, this.logger);
 		this.loginCoordinator = new LoginCoordinator(
-			this.secretsManager,
-			this.mementoManager,
-			this.logger,
-			this.cliCredentialManager,
+			this,
 			this.oauthCallback,
 			context.extension.id,
 		);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -145,9 +145,8 @@ async function doActivate(
 	// Handles 401 responses (OAuth and otherwise)
 	const authInterceptor = new AuthInterceptor(
 		client,
-		output,
 		oauthSessionManager,
-		secretsManager,
+		serviceContainer,
 		async () => {
 			await handleAuthFailure();
 			return false;

--- a/src/instrumentation/auth.ts
+++ b/src/instrumentation/auth.ts
@@ -4,10 +4,6 @@ export type AuthTokenRefreshTrigger = "background" | "reactive";
 export type AuthRecoveryAction = "refresh_success" | "login_required" | "none";
 export type AuthLoginPromptTrigger = "auth_required" | "missing_session";
 
-/**
- * Why a login prompt ended without a session. `auth_failed` indicates
- * authentication itself failed; the others are user-driven aborts.
- */
 export type LoginPromptReason =
 	| "user_dismissed"
 	| "no_url_provided"
@@ -17,7 +13,6 @@ export type LoginPromptOutcome =
 	| { success: true }
 	| { success: false; reason: LoginPromptReason };
 
-/** Span annotator for the auth-recovery flow. Defaults to safe values. */
 interface AuthRecoveryRecorder {
 	setRecovery(recovery: AuthRecoveryAction): void;
 	setRefreshAttempted(attempted: boolean): void;
@@ -34,7 +29,7 @@ export class AuthTelemetry {
 	}
 
 	/** Logged when a refresh call joins an in-flight refresh and emits no span of its own. */
-	public tokenRefreshDeduped(trigger: AuthTokenRefreshTrigger): void {
+	public logTokenRefreshDeduped(trigger: AuthTokenRefreshTrigger): void {
 		this.telemetry.log("auth.token_refresh.deduped", { trigger });
 	}
 

--- a/src/instrumentation/auth.ts
+++ b/src/instrumentation/auth.ts
@@ -1,0 +1,86 @@
+import type { TelemetryReporter } from "../telemetry/reporter";
+
+export type AuthTokenRefreshTrigger = "background" | "reactive";
+export type AuthRecoveryAction = "refresh_success" | "login_required" | "none";
+export type AuthLoginPromptTrigger = "auth_required" | "missing_session";
+
+/**
+ * Why a login prompt ended without a session. `auth_failed` indicates
+ * authentication itself failed; the others are user-driven aborts.
+ */
+export type LoginPromptReason =
+	| "user_dismissed"
+	| "no_url_provided"
+	| "auth_failed";
+
+export type LoginPromptOutcome =
+	| { success: true }
+	| { success: false; reason: LoginPromptReason };
+
+/** Span annotator for the auth-recovery flow. Defaults to safe values. */
+interface AuthRecoveryRecorder {
+	setRecovery(recovery: AuthRecoveryAction): void;
+	setRefreshAttempted(attempted: boolean): void;
+}
+
+export class AuthTelemetry {
+	public constructor(private readonly telemetry: TelemetryReporter) {}
+
+	public traceTokenRefresh<T>(
+		trigger: AuthTokenRefreshTrigger,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		return this.telemetry.trace("auth.token_refreshed", fn, { trigger });
+	}
+
+	/** Logged when a refresh call joins an in-flight refresh and emits no span of its own. */
+	public tokenRefreshDeduped(trigger: AuthTokenRefreshTrigger): void {
+		this.telemetry.log("auth.token_refresh.deduped", { trigger });
+	}
+
+	/**
+	 * Wraps the auth-recovery path triggered by a 401. Initial properties
+	 * cover the throw-before-callback case.
+	 */
+	public traceAuthRecovery<T>(
+		fn: (recorder: AuthRecoveryRecorder) => Promise<T>,
+	): Promise<T> {
+		return this.telemetry.trace(
+			"auth.unauthorized_intercepted",
+			(span) =>
+				fn({
+					setRecovery: (recovery) => span.setProperty("recovery", recovery),
+					setRefreshAttempted: (attempted) =>
+						span.setProperty("refreshAttempted", attempted),
+				}),
+			{ recovery: "none", refreshAttempted: false },
+		);
+	}
+
+	/**
+	 * Records `auth.login_prompted`. `auth_failed` marks the span as failure;
+	 * other non-success reasons mark it as aborted. The reason is copied to the
+	 * span's `reason` property on failure/abort only.
+	 */
+	public traceLoginPrompt<T extends LoginPromptOutcome>(
+		trigger: AuthLoginPromptTrigger,
+		fn: () => Promise<T>,
+	): Promise<T> {
+		return this.telemetry.trace(
+			"auth.login_prompted",
+			async (span) => {
+				const result = await fn();
+				if (!result.success) {
+					span.setProperty("reason", result.reason);
+					if (result.reason === "auth_failed") {
+						span.markFailure();
+					} else {
+						span.markAborted();
+					}
+				}
+				return result;
+			},
+			{ trigger },
+		);
+	}
+}

--- a/src/instrumentation/ssh.ts
+++ b/src/instrumentation/ssh.ts
@@ -34,7 +34,7 @@ export class SshTelemetry {
 	): Promise<number | undefined> {
 		return this.#telemetry.trace("ssh.process.discovered", async (span) => {
 			const { pid, attempts } = await fn();
-			span.setProperty("found", String(pid !== undefined));
+			span.setProperty("found", pid !== undefined);
 			span.setMeasurement("attempts", attempts);
 			return pid;
 		});
@@ -79,7 +79,6 @@ export class SshTelemetry {
 	public processReplaced(): void {
 		const now = performance.now();
 		if (this.#processStartedAtMs !== undefined) {
-			const wasLost = this.#processLostAtMs !== undefined;
 			const measurements: Record<string, number> = {
 				previousUptimeMs: now - this.#processStartedAtMs,
 			};
@@ -88,7 +87,7 @@ export class SshTelemetry {
 			}
 			this.#telemetry.log(
 				"ssh.process.replaced",
-				{ wasLost: String(wasLost) },
+				{ wasLost: this.#processLostAtMs !== undefined },
 				measurements,
 			);
 		}
@@ -104,10 +103,9 @@ export class SshTelemetry {
 			return;
 		}
 		const now = performance.now();
-		const wasLost = this.#processLostAtMs !== undefined;
 		this.#telemetry.log(
 			"ssh.process.disposed",
-			{ wasLost: String(wasLost) },
+			{ wasLost: this.#processLostAtMs !== undefined },
 			{ uptimeMs: now - this.#processStartedAtMs },
 		);
 		this.#processStartedAtMs = undefined;
@@ -131,7 +129,7 @@ export class SshTelemetry {
 		this.#telemetry.log(
 			"ssh.network.sampled",
 			{
-				p2p: String(network.p2p),
+				p2p: network.p2p,
 				preferredDerp: network.preferred_derp,
 			},
 			{

--- a/src/instrumentation/websocket.ts
+++ b/src/instrumentation/websocket.ts
@@ -49,7 +49,6 @@ export class WebSocketTelemetry {
 	readonly #telemetry: TelemetryReporter;
 	#connectStartedAtMs: number | undefined;
 	#connectionOpenedAtMs: number | undefined;
-	#connectionDropEmitted = false;
 	#reconnectCycle: ReconnectCycle | undefined;
 
 	public constructor(telemetry: TelemetryReporter) {
@@ -80,7 +79,6 @@ export class WebSocketTelemetry {
 		const now = performance.now();
 		const start = this.#connectStartedAtMs ?? now;
 		this.#connectionOpenedAtMs = now;
-		this.#connectionDropEmitted = false;
 		this.#connectStartedAtMs = undefined;
 		this.#telemetry.log(
 			"connection.opened",
@@ -95,19 +93,19 @@ export class WebSocketTelemetry {
 		closeCode?: number,
 		error?: unknown,
 	): void {
-		if (
-			this.#connectionOpenedAtMs === undefined ||
-			this.#connectionDropEmitted
-		) {
+		// Capture-and-clear up-front so a throw, future await, or re-entry can't re-emit.
+		const openedAtMs = this.#connectionOpenedAtMs;
+		if (openedAtMs === undefined) {
 			return;
 		}
+		this.#connectionOpenedAtMs = undefined;
 
 		const properties: CallerProperties = { cause };
 		if (closeCode !== undefined) {
-			properties.closeCode = String(closeCode);
+			properties.closeCode = closeCode;
 		}
 		const measurements = {
-			connectionDurationMs: performance.now() - this.#connectionOpenedAtMs,
+			connectionDurationMs: performance.now() - openedAtMs,
 		};
 		if (error === undefined) {
 			this.#telemetry.log("connection.dropped", properties, measurements);
@@ -119,13 +117,11 @@ export class WebSocketTelemetry {
 				measurements,
 			);
 		}
-		this.#connectionDropEmitted = true;
 	}
 
 	public reset(): void {
 		this.#connectStartedAtMs = undefined;
 		this.#connectionOpenedAtMs = undefined;
-		this.#connectionDropEmitted = false;
 		this.#reconnectCycle = undefined;
 	}
 

--- a/src/login/loginCoordinator.ts
+++ b/src/login/loginCoordinator.ts
@@ -5,6 +5,11 @@ import * as vscode from "vscode";
 import { CoderApi } from "../api/coderApi";
 import { needToken } from "../api/utils";
 import { CertificateError } from "../error/certificateError";
+import {
+	AuthTelemetry,
+	type AuthLoginPromptTrigger,
+	type LoginPromptReason,
+} from "../instrumentation/auth";
 import { OAuthAuthorizer } from "../oauth/authorizer";
 import { buildOAuthTokenData } from "../oauth/utils";
 import { withOptionalProgress } from "../progress";
@@ -15,6 +20,7 @@ import { vscodeProposed } from "../vscodeProposed";
 import type { User } from "coder/site/src/api/typesGenerated";
 
 import type { CliCredentialManager } from "../core/cliCredentialManager";
+import type { ServiceContainer } from "../core/container";
 import type { MementoManager } from "../core/mementoManager";
 import type { OAuthTokenData, SecretsManager } from "../core/secretsManager";
 import type { Deployment } from "../deployment/types";
@@ -22,7 +28,7 @@ import type { Logger } from "../logging/logger";
 import type { OAuthCallback } from "../oauth/oauthCallback";
 
 type LoginResult =
-	| { success: false }
+	| { success: false; reason: LoginPromptReason }
 	| { success: true; user: User; token: string; oauth?: OAuthTokenData };
 
 export interface LoginOptions {
@@ -38,19 +44,26 @@ export interface LoginOptions {
 export class LoginCoordinator implements vscode.Disposable {
 	private loginQueue: Promise<unknown> = Promise.resolve();
 	private readonly oauthAuthorizer: OAuthAuthorizer;
+	private readonly authTelemetry: AuthTelemetry;
+	private readonly secretsManager: SecretsManager;
+	private readonly mementoManager: MementoManager;
+	private readonly logger: Logger;
+	private readonly cliCredentialManager: CliCredentialManager;
 
 	constructor(
-		private readonly secretsManager: SecretsManager,
-		private readonly mementoManager: MementoManager,
-		private readonly logger: Logger,
-		private readonly cliCredentialManager: CliCredentialManager,
+		container: ServiceContainer,
 		oauthCallback: OAuthCallback,
 		extensionId: string,
 	) {
+		this.secretsManager = container.getSecretsManager();
+		this.mementoManager = container.getMementoManager();
+		this.logger = container.getLogger();
+		this.cliCredentialManager = container.getCliCredentialManager();
+		this.authTelemetry = new AuthTelemetry(container.getTelemetryService());
 		this.oauthAuthorizer = new OAuthAuthorizer(
-			secretsManager,
+			this.secretsManager,
 			oauthCallback,
-			logger,
+			this.logger,
 			extensionId,
 		);
 	}
@@ -79,7 +92,19 @@ export class LoginCoordinator implements vscode.Disposable {
 	/**
 	 * Shows dialog then login - for system-initiated auth (remote, OAuth refresh).
 	 */
-	public async ensureLoggedInWithDialog(
+	public ensureLoggedInWithDialog(
+		options: LoginOptions & {
+			message?: string;
+			detailPrefix?: string;
+			trigger: AuthLoginPromptTrigger;
+		},
+	): Promise<LoginResult> {
+		return this.authTelemetry.traceLoginPrompt(options.trigger, () =>
+			this.performLoginDialog(options),
+		);
+	}
+
+	private async performLoginDialog(
 		options: LoginOptions & { message?: string; detailPrefix?: string },
 	): Promise<LoginResult> {
 		const { safeHostname, url, detailPrefix, message } = options;
@@ -97,7 +122,7 @@ export class LoginCoordinator implements vscode.Disposable {
 					},
 					"Login",
 				)
-				.then(async (action) => {
+				.then(async (action): Promise<LoginResult> => {
 					if (action === "Login") {
 						// Proceed with the login flow, handling logging in from another window
 						const storedAuth =
@@ -108,7 +133,7 @@ export class LoginCoordinator implements vscode.Disposable {
 							storedAuth?.url,
 						);
 						if (!newUrl) {
-							throw new Error("URL must be provided");
+							return { success: false, reason: "no_url_provided" };
 						}
 
 						const result = await this.attemptLogin(
@@ -120,10 +145,9 @@ export class LoginCoordinator implements vscode.Disposable {
 						await this.persistSessionAuth(result, safeHostname, newUrl);
 
 						return result;
-					} else {
-						// User cancelled
-						return { success: false } as const;
 					}
+					// User cancelled
+					return { success: false, reason: "user_dismissed" };
 				});
 
 			// Race between user clicking login and cross-window detection
@@ -290,7 +314,7 @@ export class LoginCoordinator implements vscode.Disposable {
 			case "legacy":
 				return this.loginWithToken(client);
 			case undefined:
-				return { success: false }; // User aborted
+				return { success: false, reason: "user_dismissed" };
 		}
 	}
 
@@ -303,7 +327,7 @@ export class LoginCoordinator implements vscode.Disposable {
 			return { success: true, token: "", user };
 		} catch (err) {
 			this.showAuthError(err, isAutoLogin);
-			return { success: false };
+			return { success: false, reason: "auth_failed" };
 		}
 	}
 
@@ -324,7 +348,7 @@ export class LoginCoordinator implements vscode.Disposable {
 				return "unauthorized";
 			}
 			this.showAuthError(err, isAutoLogin);
-			return { success: false };
+			return { success: false, reason: "auth_failed" };
 		}
 	}
 
@@ -406,7 +430,7 @@ export class LoginCoordinator implements vscode.Disposable {
 			return { success: true, user, token: validatedToken ?? "" };
 		}
 
-		return { success: false };
+		return { success: false, reason: "user_dismissed" };
 	}
 
 	/**
@@ -446,7 +470,7 @@ export class LoginCoordinator implements vscode.Disposable {
 					`${title}: ${getErrorMessage(error, "Unknown error")}`,
 				);
 			}
-			return { success: false };
+			return { success: false, reason: "auth_failed" };
 		}
 	}
 

--- a/src/login/loginCoordinator.ts
+++ b/src/login/loginCoordinator.ts
@@ -5,11 +5,6 @@ import * as vscode from "vscode";
 import { CoderApi } from "../api/coderApi";
 import { needToken } from "../api/utils";
 import { CertificateError } from "../error/certificateError";
-import {
-	AuthTelemetry,
-	type AuthLoginPromptTrigger,
-	type LoginPromptReason,
-} from "../instrumentation/auth";
 import { OAuthAuthorizer } from "../oauth/authorizer";
 import { buildOAuthTokenData } from "../oauth/utils";
 import { withOptionalProgress } from "../progress";
@@ -20,10 +15,14 @@ import { vscodeProposed } from "../vscodeProposed";
 import type { User } from "coder/site/src/api/typesGenerated";
 
 import type { CliCredentialManager } from "../core/cliCredentialManager";
-import type { ServiceContainer } from "../core/container";
 import type { MementoManager } from "../core/mementoManager";
 import type { OAuthTokenData, SecretsManager } from "../core/secretsManager";
 import type { Deployment } from "../deployment/types";
+import type {
+	AuthLoginPromptTrigger,
+	AuthTelemetry,
+	LoginPromptReason,
+} from "../instrumentation/auth";
 import type { Logger } from "../logging/logger";
 import type { OAuthCallback } from "../oauth/oauthCallback";
 
@@ -44,26 +43,20 @@ export interface LoginOptions {
 export class LoginCoordinator implements vscode.Disposable {
 	private loginQueue: Promise<unknown> = Promise.resolve();
 	private readonly oauthAuthorizer: OAuthAuthorizer;
-	private readonly authTelemetry: AuthTelemetry;
-	private readonly secretsManager: SecretsManager;
-	private readonly mementoManager: MementoManager;
-	private readonly logger: Logger;
-	private readonly cliCredentialManager: CliCredentialManager;
 
 	constructor(
-		container: ServiceContainer,
+		private readonly secretsManager: SecretsManager,
+		private readonly mementoManager: MementoManager,
+		private readonly logger: Logger,
+		private readonly cliCredentialManager: CliCredentialManager,
+		private readonly authTelemetry: AuthTelemetry,
 		oauthCallback: OAuthCallback,
 		extensionId: string,
 	) {
-		this.secretsManager = container.getSecretsManager();
-		this.mementoManager = container.getMementoManager();
-		this.logger = container.getLogger();
-		this.cliCredentialManager = container.getCliCredentialManager();
-		this.authTelemetry = new AuthTelemetry(container.getTelemetryService());
 		this.oauthAuthorizer = new OAuthAuthorizer(
-			this.secretsManager,
+			secretsManager,
 			oauthCallback,
-			this.logger,
+			logger,
 			extensionId,
 		);
 	}

--- a/src/oauth/sessionManager.ts
+++ b/src/oauth/sessionManager.ts
@@ -355,7 +355,7 @@ export class OAuthSessionManager implements vscode.Disposable {
 			this.logger.debug(
 				"Token refresh already in progress, waiting for result",
 			);
-			this.authTelemetry.tokenRefreshDeduped(trigger);
+			this.authTelemetry.logTokenRefreshDeduped(trigger);
 			return this.refreshPromise;
 		}
 

--- a/src/oauth/sessionManager.ts
+++ b/src/oauth/sessionManager.ts
@@ -1,4 +1,8 @@
 import { CoderApi } from "../api/coderApi";
+import {
+	AuthTelemetry,
+	type AuthTokenRefreshTrigger,
+} from "../instrumentation/auth";
 
 import { DEFAULT_OAUTH_SCOPES, REFRESH_GRANT_TYPE } from "./constants";
 import { OAuthError, parseOAuthError } from "./errors";
@@ -64,6 +68,7 @@ export class OAuthSessionManager implements vscode.Disposable {
 			container.getSecretsManager(),
 			container.getLogger(),
 			onAuthRequired,
+			new AuthTelemetry(container.getTelemetryService()),
 		);
 		manager.setupTokenListener();
 		manager.scheduleNextRefresh();
@@ -75,6 +80,7 @@ export class OAuthSessionManager implements vscode.Disposable {
 		private readonly secretsManager: SecretsManager,
 		private readonly logger: Logger,
 		private readonly onAuthRequired: () => Promise<void>,
+		private readonly authTelemetry: AuthTelemetry,
 	) {}
 
 	/**
@@ -218,7 +224,7 @@ export class OAuthSessionManager implements vscode.Disposable {
 
 		this.refreshTimer = undefined;
 
-		this.refreshToken()
+		this.refreshToken("background")
 			.then(() => {
 				this.logger.debug("Background token refresh succeeded");
 			})
@@ -342,17 +348,22 @@ export class OAuthSessionManager implements vscode.Disposable {
 	 * Refresh the access token using the stored refresh token.
 	 * Uses a shared promise to handle concurrent refresh attempts.
 	 */
-	public async refreshToken(): Promise<OAuth2TokenResponse> {
+	public async refreshToken(
+		trigger: AuthTokenRefreshTrigger = "reactive",
+	): Promise<OAuth2TokenResponse> {
 		if (this.refreshPromise) {
 			this.logger.debug(
 				"Token refresh already in progress, waiting for result",
 			);
+			this.authTelemetry.tokenRefreshDeduped(trigger);
 			return this.refreshPromise;
 		}
 
 		const deployment = this.requireDeployment();
 		// Assign synchronously before any async work to prevent race conditions
-		this.refreshPromise = this.executeTokenRefresh(deployment);
+		this.refreshPromise = this.authTelemetry.traceTokenRefresh(trigger, () =>
+			this.executeTokenRefresh(deployment),
+		);
 		return this.refreshPromise;
 	}
 

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -223,9 +223,8 @@ export class Remote {
 			// Create 401 interceptor - handles auth failures with re-login dialog
 			const authInterceptor = new AuthInterceptor(
 				workspaceClient,
-				this.logger,
 				remoteOAuthManager,
-				this.secretsManager,
+				this.serviceContainer,
 				async () => {
 					const result = await this.showSessionExpiredDialog(context);
 					return result.success;
@@ -642,6 +641,7 @@ export class Remote {
 			url: context.baseUrl,
 			message: "Your session expired...",
 			detailPrefix: `You must log in to access ${context.workspaceName}.`,
+			trigger: "auth_required",
 		});
 	}
 
@@ -655,6 +655,7 @@ export class Remote {
 			url,
 			message,
 			detailPrefix: `You must log in to access ${context.workspaceName}.`,
+			trigger: "missing_session",
 		});
 
 		// Dispose before retrying since setup will create new disposables.

--- a/src/telemetry/event.ts
+++ b/src/telemetry/event.ts
@@ -6,8 +6,13 @@ import { toError } from "../error/errorUtils";
 /** Telemetry level, mirrors `coder.telemetry.level`. Ordered: off < local. */
 export type TelemetryLevel = "off" | "local";
 
+/** Value types accepted from callers; the framework stringifies at the wire boundary. */
+export type CallerPropertyValue = string | number | boolean;
+
 /** Caller properties. `result` is framework-managed on traced events. */
-export type CallerProperties = Record<string, string> & { result?: never };
+export type CallerProperties = Record<string, CallerPropertyValue> & {
+	result?: never;
+};
 
 /** Caller measurements. `durationMs` is framework-managed on traced events. */
 export type CallerMeasurements = Record<string, number> & {

--- a/src/telemetry/service.ts
+++ b/src/telemetry/service.ts
@@ -11,13 +11,14 @@ import {
 	buildErrorBlock,
 	type CallerMeasurements,
 	type CallerProperties,
+	type CallerPropertyValue,
 	type SessionContext,
 	type TelemetryEvent,
 	type TelemetryLevel,
 	type TelemetrySink,
 } from "./event";
 import { newSpanId, newTraceId } from "./ids";
-import { NOOP_SPAN, type Span } from "./span";
+import { NOOP_SPAN, type Span, type SpanResult } from "./span";
 
 import type { TelemetryReporter } from "./reporter";
 
@@ -28,6 +29,16 @@ const LEVEL_ORDER: Readonly<Record<TelemetryLevel, number>> = {
 
 const readLevel = (): TelemetryLevel =>
 	readTelemetryLevel(vscode.workspace.getConfiguration());
+
+const normalizeProps = (
+	props: Record<string, CallerPropertyValue>,
+): Record<string, string> => {
+	const out: Record<string, string> = {};
+	for (const [k, v] of Object.entries(props)) {
+		out[k] = typeof v === "string" ? v : String(v);
+	}
+	return out;
+};
 
 /** Trace context shared by all events in one trace. */
 interface SpanOptions {
@@ -88,7 +99,12 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		if (this.#level === "off") {
 			return;
 		}
-		this.#safeEmit(newSpanId(), eventName, properties, measurements);
+		this.#safeEmit(
+			newSpanId(),
+			eventName,
+			normalizeProps(properties),
+			measurements,
+		);
 	}
 
 	public logError(
@@ -100,9 +116,13 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		if (this.#level === "off") {
 			return;
 		}
-		this.#safeEmit(newSpanId(), eventName, properties, measurements, {
-			error,
-		});
+		this.#safeEmit(
+			newSpanId(),
+			eventName,
+			normalizeProps(properties),
+			measurements,
+			{ error },
+		);
 	}
 
 	/**
@@ -120,10 +140,16 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		if (this.#level === "off") {
 			return fn(NOOP_SPAN);
 		}
-		return this.#startSpan(eventName, fn, properties, measurements, {
-			traceId: newTraceId(),
-			traceLevel: this.#level,
-		});
+		return this.#startSpan(
+			eventName,
+			fn,
+			normalizeProps(properties),
+			measurements,
+			{
+				traceId: newTraceId(),
+				traceLevel: this.#level,
+			},
+		);
 	}
 
 	public async dispose(): Promise<void> {
@@ -148,7 +174,8 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		const spanMeasurements = { ...measurements };
 		const { traceId, traceLevel } = spanOpts;
 		let completed = false;
-		let aborted = false;
+		// `markFailure` wins over `markAborted` regardless of call order.
+		let mark: "aborted" | "error" | undefined;
 		const warnPostEmit = (op: string, name: string): void => {
 			this.logger.warn(
 				`Telemetry span '${eventName}' ${op}('${name}') called after emit; mutation dropped`,
@@ -161,24 +188,25 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 			phase: <U>(
 				phaseName: string,
 				phaseFn: (childSpan: Span) => Promise<U>,
-				phaseProps: Record<string, string> = {},
+				phaseProps: CallerProperties = {},
 				phaseMeasurements: Record<string, number> = {},
 			): Promise<U> => {
 				const safeName = this.#sanitizePhaseName(phaseName);
 				return this.#startSpan(
 					`${eventName}.${safeName}`,
 					phaseFn,
-					phaseProps,
+					normalizeProps(phaseProps),
 					phaseMeasurements,
 					{ traceId, parentEventId: eventId, traceLevel },
 				);
 			},
-			setProperty(name: string, value: string): void {
+			setProperty(name: string, value: CallerPropertyValue): void {
 				if (completed) {
 					warnPostEmit("setProperty", name);
 					return;
 				}
-				spanProperties[name] = value;
+				spanProperties[name] =
+					typeof value === "string" ? value : String(value);
 			},
 			setMeasurement(name: string, value: number): void {
 				if (completed) {
@@ -192,7 +220,14 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 					warnPostEmit("markAborted", "");
 					return;
 				}
-				aborted = true;
+				mark ??= "aborted";
+			},
+			markFailure(): void {
+				if (completed) {
+					warnPostEmit("markFailure", "");
+					return;
+				}
+				mark = "error";
 			},
 		};
 		return this.#emitTimed(
@@ -202,7 +237,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 			spanProperties,
 			spanMeasurements,
 			spanOpts,
-			() => aborted,
+			() => mark ?? "success",
 		).finally(() => {
 			completed = true;
 		});
@@ -226,13 +261,10 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		properties: Record<string, string>,
 		measurements: Record<string, number>,
 		spanOpts: SpanOptions,
-		isAborted: () => boolean,
+		resolveResult: () => SpanResult,
 	): Promise<T> {
 		const start = performance.now();
-		const send = (
-			result: "success" | "error" | "aborted",
-			error?: unknown,
-		): void =>
+		const send = (result: SpanResult, error?: unknown): void =>
 			this.#safeEmit(
 				eventId,
 				eventName,
@@ -242,7 +274,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 			);
 		try {
 			const value = await fn();
-			send(isAborted() ? "aborted" : "success");
+			send(resolveResult());
 			return value;
 		} catch (err) {
 			send("error", err);

--- a/src/telemetry/service.ts
+++ b/src/telemetry/service.ts
@@ -30,7 +30,7 @@ const LEVEL_ORDER: Readonly<Record<TelemetryLevel, number>> = {
 const readLevel = (): TelemetryLevel =>
 	readTelemetryLevel(vscode.workspace.getConfiguration());
 
-const normalizeProps = (
+const stringifyProps = (
 	props: Record<string, CallerPropertyValue>,
 ): Record<string, string> => {
 	const out: Record<string, string> = {};
@@ -102,7 +102,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		this.#safeEmit(
 			newSpanId(),
 			eventName,
-			normalizeProps(properties),
+			stringifyProps(properties),
 			measurements,
 		);
 	}
@@ -119,7 +119,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		this.#safeEmit(
 			newSpanId(),
 			eventName,
-			normalizeProps(properties),
+			stringifyProps(properties),
 			measurements,
 			{ error },
 		);
@@ -143,7 +143,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 		return this.#startSpan(
 			eventName,
 			fn,
-			normalizeProps(properties),
+			stringifyProps(properties),
 			measurements,
 			{
 				traceId: newTraceId(),
@@ -195,7 +195,7 @@ export class TelemetryService implements vscode.Disposable, TelemetryReporter {
 				return this.#startSpan(
 					`${eventName}.${safeName}`,
 					phaseFn,
-					normalizeProps(phaseProps),
+					stringifyProps(phaseProps),
 					phaseMeasurements,
 					{ traceId, parentEventId: eventId, traceLevel },
 				);

--- a/src/telemetry/span.ts
+++ b/src/telemetry/span.ts
@@ -4,14 +4,6 @@ import type {
 	CallerPropertyValue,
 } from "./event";
 
-/**
- * Final disposition recorded on a traced event's `result` property.
- * - `success`: ran to completion as intended.
- * - `aborted`: ended early by a user-initiated cancel.
- * - `error`:   the operation failed. Thrown exceptions populate the event's
- *              `error` block; `markFailure()` does not. This matches
- *              OpenTelemetry's "Status: Error + optional exception event".
- */
 export type SpanResult = "success" | "aborted" | "error";
 
 /**

--- a/src/telemetry/span.ts
+++ b/src/telemetry/span.ts
@@ -1,4 +1,18 @@
-import type { CallerMeasurements, CallerProperties } from "./event";
+import type {
+	CallerMeasurements,
+	CallerProperties,
+	CallerPropertyValue,
+} from "./event";
+
+/**
+ * Final disposition recorded on a traced event's `result` property.
+ * - `success`: ran to completion as intended.
+ * - `aborted`: ended early by a user-initiated cancel.
+ * - `error`:   the operation failed. Thrown exceptions populate the event's
+ *              `error` block; `markFailure()` does not. This matches
+ *              OpenTelemetry's "Status: Error + optional exception event".
+ */
+export type SpanResult = "success" | "aborted" | "error";
 
 /**
  * Parent span handle. Children's `eventName` composes as `${parent.eventName}.${phaseName}`.
@@ -17,11 +31,13 @@ export interface Span {
 		measurements?: CallerMeasurements,
 	): Promise<T>;
 	/** Add or replace a property on the event emitted for this span. */
-	setProperty(name: string, value: string): void;
+	setProperty(name: string, value: CallerPropertyValue): void;
 	/** Add or replace a measurement on the event emitted for this span. */
 	setMeasurement(name: string, value: number): void;
 	/** Flip this span's `result` from `success` to `aborted` on normal return. */
 	markAborted(): void;
+	/** Flip `result` to `error` for a failure captured in the return value. See `SpanResult`. */
+	markFailure(): void;
 }
 
 /** No-op `Span` used when telemetry is off. Runs phase fns but emits nothing. */
@@ -33,6 +49,7 @@ export const NOOP_SPAN: Span = {
 		return fn(NOOP_SPAN);
 	},
 	markAborted: () => undefined,
+	markFailure: () => undefined,
 	setProperty: () => undefined,
 	setMeasurement: () => undefined,
 };

--- a/test/mocks/telemetry.ts
+++ b/test/mocks/telemetry.ts
@@ -8,7 +8,7 @@ import {
 } from "@/telemetry/event";
 import { TelemetryService } from "@/telemetry/service";
 
-import { createMockLogger } from "./testHelpers";
+import { createMockLogger, MockConfigurationProvider } from "./testHelpers";
 
 /**
  * In-memory `TelemetrySink` for tests. Captures every written event and
@@ -33,6 +33,17 @@ export class TestSink implements TelemetrySink {
 	eventsNamed(name: string): TelemetryEvent[] {
 		return this.events.filter((e) => e.eventName === name);
 	}
+
+	/** Returns the single event with `name`, throwing if not exactly one. */
+	expectOne(name: string): TelemetryEvent {
+		const matches = this.eventsNamed(name);
+		if (matches.length !== 1) {
+			throw new Error(
+				`Expected exactly 1 '${name}' event, got ${matches.length}`,
+			);
+		}
+		return matches[0];
+	}
 }
 
 export function createTestTelemetryService(
@@ -43,4 +54,19 @@ export function createTestTelemetryService(
 		[sink],
 		createMockLogger(),
 	);
+}
+
+/** Sets `coder.telemetry.level=local` so emissions reach the sink. */
+export function enableLocalTelemetry(): void {
+	new MockConfigurationProvider().set("coder.telemetry.level", "local");
+}
+
+/** Bundles `enableLocalTelemetry` + a fresh sink + service. */
+export function createTelemetryHarness(): {
+	sink: TestSink;
+	service: TelemetryService;
+} {
+	enableLocalTelemetry();
+	const sink = new TestSink();
+	return { sink, service: createTestTelemetryService(sink) };
 }

--- a/test/mocks/testHelpers.ts
+++ b/test/mocks/testHelpers.ts
@@ -8,6 +8,7 @@ import axios, {
 import { vi } from "vitest";
 import * as vscode from "vscode";
 
+import { createTestTelemetryService } from "./telemetry";
 import { window as vscodeWindow } from "./vscode.runtime";
 
 import type { Experiment, User } from "coder/site/src/api/typesGenerated";
@@ -16,14 +17,30 @@ import type { IncomingMessage } from "node:http";
 
 import type { CoderApi } from "@/api/coderApi";
 import type { CliCredentialManager } from "@/core/cliCredentialManager";
+import type { ServiceContainer } from "@/core/container";
+import type { ContextManager } from "@/core/contextManager";
+import type { MementoManager } from "@/core/mementoManager";
+import type { SecretsManager } from "@/core/secretsManager";
 import type { Logger } from "@/logging/logger";
 import type { NetworkInfo } from "@/remote/sshProcess";
+import type { TelemetryService } from "@/telemetry/service";
 import type {
 	EventHandler,
 	EventPayloadMap,
 	ParsedMessageEvent,
 	UnidirectionalStream,
 } from "@/websocket/eventStreamConnection";
+
+/**
+ * Subset of `ContextManager`'s public API that mocks (e.g. `MockContextManager`)
+ * implement. Used by `createMockServiceContainer` so tests can pass either the
+ * real class or a mock without resorting to `unknown`.
+ */
+interface ContextManagerLike {
+	set(key: string, value: boolean): void;
+	get(key: string): boolean;
+	dispose(): void;
+}
 
 export function makeNetworkInfo(
 	overrides: Partial<NetworkInfo> = {},
@@ -441,6 +458,43 @@ export function createMockLogger(): Logger {
 		error: vi.fn(),
 		show: vi.fn(),
 	};
+}
+
+/**
+ * Minimal `ServiceContainer` stub for tests. Pass only the services the unit
+ * under test reads; unset services throw on access so a missing dependency
+ * surfaces as a clear error rather than a downstream `undefined` deref.
+ */
+export function createMockServiceContainer(
+	overrides: {
+		telemetry?: TelemetryService;
+		logger?: Logger;
+		secretsManager?: SecretsManager;
+		mementoManager?: MementoManager;
+		cliCredentialManager?: CliCredentialManager;
+		contextManager?: ContextManagerLike;
+	} = {},
+): ServiceContainer {
+	const telemetry = overrides.telemetry ?? createTestTelemetryService();
+	const logger = overrides.logger ?? createMockLogger();
+	const require = <T>(name: string, value: T | undefined): T => {
+		if (value === undefined) {
+			throw new Error(`createMockServiceContainer: '${name}' was not provided`);
+		}
+		return value;
+	};
+	return {
+		getTelemetryService: () => telemetry,
+		getLogger: () => logger,
+		getSecretsManager: () =>
+			require("secretsManager", overrides.secretsManager),
+		getMementoManager: () =>
+			require("mementoManager", overrides.mementoManager),
+		getCliCredentialManager: () =>
+			require("cliCredentialManager", overrides.cliCredentialManager),
+		getContextManager: () =>
+			require("contextManager", overrides.contextManager) as ContextManager,
+	} as ServiceContainer;
 }
 
 /** Update the mocked active color theme and fire onDidChangeActiveColorTheme. */

--- a/test/unit/api/authInterceptor.test.ts
+++ b/test/unit/api/authInterceptor.test.ts
@@ -8,8 +8,14 @@ import {
 import { SecretsManager } from "@/core/secretsManager";
 
 import {
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
+import {
 	createAxiosError,
 	createMockLogger,
+	createMockServiceContainer,
 	InMemoryMemento,
 	InMemorySecretStorage,
 	MockOAuthSessionManager,
@@ -21,7 +27,9 @@ import {
 } from "../oauth/testUtils";
 
 import type { CoderApi } from "@/api/coderApi";
+import type { AuthRecoveryAction } from "@/instrumentation/auth";
 import type { OAuthSessionManager } from "@/oauth/sessionManager";
+import type { TelemetryService } from "@/telemetry/service";
 
 /**
  * Creates a mock axios instance with controllable interceptors.
@@ -84,6 +92,7 @@ const ONE_HOUR_MS = 60 * 60 * 1000;
 
 function createTestContext() {
 	vi.resetAllMocks();
+	enableLocalTelemetry();
 
 	const secretStorage = new InMemorySecretStorage();
 	const memento = new InMemoryMemento();
@@ -136,12 +145,14 @@ function createTestContext() {
 	};
 
 	/** Creates interceptor with optional callback */
-	const createInterceptor = (onAuthRequired?: AuthRequiredHandler) =>
+	const createInterceptor = (
+		onAuthRequired?: AuthRequiredHandler,
+		telemetry?: TelemetryService,
+	) =>
 		new AuthInterceptor(
 			mockCoderApi,
-			logger,
 			mockOAuthManager as unknown as OAuthSessionManager,
-			secretsManager,
+			createMockServiceContainer({ telemetry, logger, secretsManager }),
 			onAuthRequired,
 		);
 
@@ -182,7 +193,7 @@ describe("AuthInterceptor", () => {
 	});
 
 	describe("401 handling with OAuth", () => {
-		it("refreshes token and retries request", async () => {
+		it("refreshes token and retries the request", async () => {
 			const {
 				mockCoderApi,
 				mockOAuthManager,
@@ -422,6 +433,134 @@ describe("AuthInterceptor", () => {
 			interceptor.dispose();
 
 			expect(axiosInstance.getInterceptorCount()).toBe(0);
+		});
+	});
+
+	describe("telemetry", () => {
+		interface RecoveryCase {
+			name: string;
+			arrange: (ctx: ReturnType<typeof createTestContext>) => Promise<void>;
+			withCallback: boolean;
+			callbackResult?: boolean;
+			expectThrow: boolean;
+			expected: {
+				recovery: AuthRecoveryAction;
+				refreshAttempted: "true" | "false";
+				result: "success" | "error";
+			};
+		}
+
+		it.each<RecoveryCase>([
+			{
+				name: "OAuth refresh succeeds: recovery=refresh_success",
+				arrange: async (ctx) => {
+					await ctx.setupOAuthTokens();
+					ctx.mockOAuthManager.refreshToken.mockResolvedValue(
+						createMockTokenResponse({ access_token: "new" }),
+					);
+					vi.spyOn(ctx.axiosInstance, "request").mockResolvedValue({
+						status: 200,
+					});
+				},
+				withCallback: false,
+				expectThrow: false,
+				expected: {
+					recovery: "refresh_success",
+					refreshAttempted: "true",
+					result: "success",
+				},
+			},
+			{
+				name: "no OAuth + callback declines: recovery=login_required",
+				arrange: () => Promise.resolve(),
+				withCallback: true,
+				callbackResult: false,
+				expectThrow: true,
+				expected: {
+					recovery: "login_required",
+					refreshAttempted: "false",
+					result: "error",
+				},
+			},
+			{
+				name: "no OAuth + no callback: recovery=none",
+				arrange: () => Promise.resolve(),
+				withCallback: false,
+				expectThrow: true,
+				expected: {
+					recovery: "none",
+					refreshAttempted: "false",
+					result: "error",
+				},
+			},
+			{
+				name: "OAuth refresh fails + callback declines: refreshAttempted=true, recovery=login_required",
+				arrange: async (ctx) => {
+					await ctx.setupOAuthTokens();
+					ctx.mockOAuthManager.refreshToken.mockRejectedValue(
+						new Error("refresh failed"),
+					);
+				},
+				withCallback: true,
+				callbackResult: false,
+				expectThrow: true,
+				expected: {
+					recovery: "login_required",
+					refreshAttempted: "true",
+					result: "error",
+				},
+			},
+		])(
+			"$name",
+			async ({
+				arrange,
+				withCallback,
+				callbackResult,
+				expectThrow,
+				expected,
+			}) => {
+				const sink = new TestSink();
+				const ctx = createTestContext();
+				await arrange(ctx);
+				const onAuthRequired = withCallback
+					? vi.fn().mockResolvedValue(callbackResult)
+					: undefined;
+				ctx.createInterceptor(onAuthRequired, createTestTelemetryService(sink));
+
+				const trigger = ctx.axiosInstance.triggerResponseError(
+					createAxiosError(401, "Unauthorized"),
+				);
+				if (expectThrow) {
+					await expect(trigger).rejects.toThrow();
+				} else {
+					await trigger;
+				}
+
+				expect(
+					sink.expectOne("auth.unauthorized_intercepted").properties,
+				).toMatchObject(expected);
+			},
+		);
+
+		it("includes durationMs on the recovery span", async () => {
+			const sink = new TestSink();
+			const ctx = createTestContext();
+			await ctx.setupOAuthTokens();
+			ctx.mockOAuthManager.refreshToken.mockResolvedValue(
+				createMockTokenResponse({ access_token: "new" }),
+			);
+			vi.spyOn(ctx.axiosInstance, "request").mockResolvedValue({
+				status: 200,
+			});
+			ctx.createInterceptor(undefined, createTestTelemetryService(sink));
+
+			await ctx.axiosInstance.triggerResponseError(
+				createAxiosError(401, "Unauthorized"),
+			);
+
+			expect(
+				sink.expectOne("auth.unauthorized_intercepted").measurements.durationMs,
+			).toEqual(expect.any(Number));
 		});
 	});
 });

--- a/test/unit/deployment/deploymentManager.test.ts
+++ b/test/unit/deployment/deploymentManager.test.ts
@@ -7,6 +7,7 @@ import { DeploymentManager } from "@/deployment/deploymentManager";
 
 import {
 	createMockLogger,
+	createMockServiceContainer,
 	createMockUser,
 	InMemoryMemento,
 	InMemorySecretStorage,
@@ -15,9 +16,8 @@ import {
 	MockOAuthSessionManager,
 } from "../../mocks/testHelpers";
 
-import type { ServiceContainer } from "@/core/container";
-import type { ContextManager } from "@/core/contextManager";
 import type { OAuthSessionManager } from "@/oauth/sessionManager";
+import type { TelemetryService } from "@/telemetry/service";
 import type { WorkspaceProvider } from "@/workspace/workspacesProvider";
 
 // Mock CoderApi.create to return our mock client for validation
@@ -70,16 +70,14 @@ function createTestContext() {
 		setDeploymentUrl: vi.fn(),
 	};
 
-	const container = {
-		getSecretsManager: () => secretsManager,
-		getMementoManager: () => mementoManager,
-		getContextManager: () => contextManager as unknown as ContextManager,
-		getLogger: () => logger,
-		getTelemetryService: () => telemetryService,
-	};
-
 	const manager = DeploymentManager.create(
-		container as unknown as ServiceContainer,
+		createMockServiceContainer({
+			telemetry: telemetryService as unknown as TelemetryService,
+			logger,
+			secretsManager,
+			mementoManager,
+			contextManager,
+		}),
 		mockClient as unknown as CoderApi,
 		mockOAuthSessionManager as unknown as OAuthSessionManager,
 		[mockWorkspaceProvider as unknown as WorkspaceProvider],

--- a/test/unit/deployment/deploymentManager.test.ts
+++ b/test/unit/deployment/deploymentManager.test.ts
@@ -5,6 +5,7 @@ import { MementoManager } from "@/core/mementoManager";
 import { SecretsManager } from "@/core/secretsManager";
 import { DeploymentManager } from "@/deployment/deploymentManager";
 
+import { createTestTelemetryService } from "../../mocks/telemetry";
 import {
 	createMockLogger,
 	createMockServiceContainer,
@@ -12,12 +13,12 @@ import {
 	InMemoryMemento,
 	InMemorySecretStorage,
 	MockCoderApi,
+	MockConfigurationProvider,
 	MockContextManager,
 	MockOAuthSessionManager,
 } from "../../mocks/testHelpers";
 
 import type { OAuthSessionManager } from "@/oauth/sessionManager";
-import type { TelemetryService } from "@/telemetry/service";
 import type { WorkspaceProvider } from "@/workspace/workspacesProvider";
 
 // Mock CoderApi.create to return our mock client for validation
@@ -48,6 +49,7 @@ const TEST_HOSTNAME = "coder.example.com";
  */
 function createTestContext() {
 	vi.resetAllMocks();
+	new MockConfigurationProvider();
 
 	const mockClient = new MockCoderApi();
 	// For setDeploymentIfValid, we use a separate mock for validation
@@ -66,13 +68,12 @@ function createTestContext() {
 		validationMockClient as unknown as CoderApi,
 	);
 
-	const telemetryService = {
-		setDeploymentUrl: vi.fn(),
-	};
+	const telemetryService = createTestTelemetryService();
+	const setDeploymentUrlSpy = vi.spyOn(telemetryService, "setDeploymentUrl");
 
 	const manager = DeploymentManager.create(
 		createMockServiceContainer({
-			telemetry: telemetryService as unknown as TelemetryService,
+			telemetry: telemetryService,
 			logger,
 			secretsManager,
 			mementoManager,
@@ -91,6 +92,7 @@ function createTestContext() {
 		mockOAuthSessionManager,
 		mockWorkspaceProvider,
 		telemetryService,
+		setDeploymentUrlSpy,
 		manager,
 	};
 }
@@ -163,7 +165,7 @@ describe("DeploymentManager", () => {
 		});
 
 		it("notifies telemetry of the deployment URL", async () => {
-			const { telemetryService, manager } = createTestContext();
+			const { setDeploymentUrlSpy, manager } = createTestContext();
 
 			await manager.setDeployment({
 				url: TEST_URL,
@@ -172,7 +174,7 @@ describe("DeploymentManager", () => {
 				user: createMockUser(),
 			});
 
-			expect(telemetryService.setDeploymentUrl).toHaveBeenCalledWith(TEST_URL);
+			expect(setDeploymentUrlSpy).toHaveBeenCalledWith(TEST_URL);
 		});
 
 		it("sets isOwner context when user has owner role", async () => {
@@ -403,7 +405,7 @@ describe("DeploymentManager", () => {
 		});
 
 		it("resets the telemetry deployment URL on clearDeployment", async () => {
-			const { telemetryService, manager } = createTestContext();
+			const { setDeploymentUrlSpy, manager } = createTestContext();
 
 			await manager.setDeployment({
 				url: TEST_URL,
@@ -413,7 +415,7 @@ describe("DeploymentManager", () => {
 			});
 			await manager.clearDeployment();
 
-			expect(telemetryService.setDeploymentUrl).toHaveBeenLastCalledWith("");
+			expect(setDeploymentUrlSpy).toHaveBeenLastCalledWith("");
 		});
 	});
 

--- a/test/unit/instrumentation/ssh.test.ts
+++ b/test/unit/instrumentation/ssh.test.ts
@@ -2,25 +2,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SshTelemetry } from "@/instrumentation/ssh";
 
-import { createTestTelemetryService, TestSink } from "../../mocks/telemetry";
-import {
-	makeNetworkInfo,
-	MockConfigurationProvider,
-} from "../../mocks/testHelpers";
+import { createTelemetryHarness } from "../../mocks/telemetry";
+import { makeNetworkInfo } from "../../mocks/testHelpers";
 
 function setup() {
-	new MockConfigurationProvider().set("coder.telemetry.level", "local");
-	const sink = new TestSink();
-	return { ssh: new SshTelemetry(createTestTelemetryService(sink)), sink };
+	const { sink, service } = createTelemetryHarness();
+	return { ssh: new SshTelemetry(service), sink };
+}
+
+interface DiscoveryCase {
+	pid: number | undefined;
+	attempts: number;
+	found: string;
+}
+
+interface DisposedCase {
+	name: string;
+	lose: boolean;
+	wasLost: string;
 }
 
 describe("SshTelemetry", () => {
 	describe("traceProcessDiscovery", () => {
-		interface DiscoveryCase {
-			pid: number | undefined;
-			attempts: number;
-			found: string;
-		}
 		it.each<DiscoveryCase>([
 			{ pid: 123, attempts: 2, found: "true" },
 			{ pid: undefined, attempts: 5, found: "false" },
@@ -148,11 +151,6 @@ describe("SshTelemetry", () => {
 			expect(sink.events).toHaveLength(0);
 		});
 
-		interface DisposedCase {
-			name: string;
-			lose: boolean;
-			wasLost: string;
-		}
 		it.each<DisposedCase>([
 			{ name: "from a healthy state", lose: false, wasLost: "false" },
 			{ name: "after the process was lost", lose: true, wasLost: "true" },

--- a/test/unit/instrumentation/websocket.test.ts
+++ b/test/unit/instrumentation/websocket.test.ts
@@ -3,13 +3,11 @@ import { describe, expect, it } from "vitest";
 import { WebSocketTelemetry } from "@/instrumentation/websocket";
 import { ConnectionState } from "@/websocket/reconnectingWebSocket";
 
-import { createTestTelemetryService, TestSink } from "../../mocks/telemetry";
-import { MockConfigurationProvider } from "../../mocks/testHelpers";
+import { createTelemetryHarness } from "../../mocks/telemetry";
 
 function setup() {
-	new MockConfigurationProvider().set("coder.telemetry.level", "local");
-	const sink = new TestSink();
-	return { ws: new WebSocketTelemetry(createTestTelemetryService(sink)), sink };
+	const { sink, service } = createTelemetryHarness();
+	return { ws: new WebSocketTelemetry(service), sink };
 }
 
 describe("WebSocketTelemetry", () => {

--- a/test/unit/login/loginCoordinator.test.ts
+++ b/test/unit/login/loginCoordinator.test.ts
@@ -7,12 +7,14 @@ import { SecretsManager } from "@/core/secretsManager";
 import { getHeaders } from "@/headers";
 import { LoginCoordinator } from "@/login/loginCoordinator";
 import { OAuthCallback } from "@/oauth/oauthCallback";
-import { maybeAskAuthMethod } from "@/promptUtils";
+import { maybeAskAuthMethod, maybeAskUrl } from "@/promptUtils";
 
+import { createTestTelemetryService, TestSink } from "../../mocks/telemetry";
 import {
 	createAxiosError,
 	createMockCliCredentialManager,
 	createMockLogger,
+	createMockServiceContainer,
 	createMockUser,
 	InMemoryMemento,
 	InMemorySecretStorage,
@@ -20,6 +22,8 @@ import {
 	MockProgressReporter,
 	MockUserInteraction,
 } from "../../mocks/testHelpers";
+
+import type { TelemetryService } from "@/telemetry/service";
 
 // Hoisted mock adapter implementation
 const mockAxiosAdapterImpl = vi.hoisted(
@@ -98,7 +102,7 @@ const TEST_HOSTNAME = "coder.example.com";
 /**
  * Creates a fresh test context with all dependencies.
  */
-function createTestContext() {
+function createTestContext(telemetry?: TelemetryService) {
 	vi.resetAllMocks();
 
 	const mockAdapter = (axios as MockedAxios).__mockAdapter;
@@ -121,10 +125,13 @@ function createTestContext() {
 
 	const mockCredentialManager = createMockCliCredentialManager();
 	const coordinator = new LoginCoordinator(
-		secretsManager,
-		mementoManager,
-		logger,
-		mockCredentialManager,
+		createMockServiceContainer({
+			telemetry,
+			logger,
+			secretsManager,
+			mementoManager,
+			cliCredentialManager: mockCredentialManager,
+		}),
 		oauthCallback,
 		"coder.coder-remote",
 	);
@@ -153,6 +160,7 @@ function createTestContext() {
 		mockGetAuthenticatedUser,
 		mockConfig,
 		userInteraction,
+		logger,
 		secretsManager,
 		oauthCallback,
 		mementoManager,
@@ -306,26 +314,10 @@ describe("LoginCoordinator", () => {
 		});
 
 		it("logs warning instead of showing dialog for autoLogin", async () => {
-			const {
-				mockConfig,
-				secretsManager,
-				oauthCallback,
-				mementoManager,
-				mockAuthFailure,
-			} = createTestContext();
+			const { mockConfig, logger, coordinator, mockAuthFailure } =
+				createTestContext();
 			mockConfig.set("coder.tlsCertFile", "/path/to/cert.pem");
 			mockConfig.set("coder.tlsKeyFile", "/path/to/key.pem");
-
-			const logger = createMockLogger();
-			const coordinator = new LoginCoordinator(
-				secretsManager,
-				mementoManager,
-				logger,
-				createMockCliCredentialManager(),
-				oauthCallback,
-				"coder.coder-remote",
-			);
-
 			mockAuthFailure("Certificate error");
 
 			const result = await coordinator.ensureLoggedIn({
@@ -353,6 +345,7 @@ describe("LoginCoordinator", () => {
 			const result = await coordinator.ensureLoggedInWithDialog({
 				url: TEST_URL,
 				safeHostname: TEST_HOSTNAME,
+				trigger: "auth_required",
 			});
 
 			expect(result.success).toBe(false);
@@ -542,6 +535,100 @@ describe("LoginCoordinator", () => {
 			const result = await login();
 
 			expect(result).toEqual({ success: true, user, token: "stored-token" });
+		});
+	});
+
+	describe("telemetry", () => {
+		const dialogOptions = (trigger: "auth_required" | "missing_session") => ({
+			url: TEST_URL,
+			safeHostname: TEST_HOSTNAME,
+			trigger,
+		});
+
+		const enableMTLS = (mockConfig: MockConfigurationProvider) => {
+			mockConfig.set("coder.tlsCertFile", "/path/to/cert.pem");
+			mockConfig.set("coder.tlsKeyFile", "/path/to/key.pem");
+		};
+
+		interface PromptCase {
+			name: string;
+			arrange: (ctx: ReturnType<typeof createTestContext>) => void;
+			trigger: "auth_required" | "missing_session";
+			expected: {
+				result: "success" | "aborted" | "error";
+				reason?: "user_dismissed" | "no_url_provided" | "auth_failed";
+			};
+		}
+
+		it.each<PromptCase>([
+			{
+				name: "user dismisses the dialog: aborted + user_dismissed",
+				arrange: (ctx) =>
+					ctx.userInteraction.setResponse("Authentication Required", undefined),
+				trigger: "missing_session",
+				expected: { result: "aborted", reason: "user_dismissed" },
+			},
+			{
+				name: "authentication fails: error + auth_failed",
+				arrange: (ctx) => {
+					enableMTLS(ctx.mockConfig);
+					ctx.mockAuthFailure("Certificate error");
+					vi.mocked(maybeAskUrl).mockResolvedValue(TEST_URL);
+					ctx.userInteraction.setResponse("Authentication Required", "Login");
+				},
+				trigger: "auth_required",
+				expected: { result: "error", reason: "auth_failed" },
+			},
+			{
+				name: "user cancels URL prompt: aborted + no_url_provided",
+				arrange: (ctx) => {
+					enableMTLS(ctx.mockConfig);
+					vi.mocked(maybeAskUrl).mockResolvedValue(undefined);
+					ctx.userInteraction.setResponse("Authentication Required", "Login");
+				},
+				trigger: "auth_required",
+				expected: { result: "aborted", reason: "no_url_provided" },
+			},
+			{
+				name: "happy path: success and no reason",
+				arrange: (ctx) => {
+					enableMTLS(ctx.mockConfig);
+					ctx.mockSuccessfulAuth();
+					vi.mocked(maybeAskUrl).mockResolvedValue(TEST_URL);
+					ctx.userInteraction.setResponse("Authentication Required", "Login");
+				},
+				trigger: "auth_required",
+				expected: { result: "success" },
+			},
+		])("$name", async ({ arrange, trigger, expected }) => {
+			const sink = new TestSink();
+			const ctx = createTestContext(createTestTelemetryService(sink));
+			arrange(ctx);
+
+			await ctx.coordinator.ensureLoggedInWithDialog(dialogOptions(trigger));
+
+			const event = sink.expectOne("auth.login_prompted");
+			expect(event.properties).toMatchObject({ trigger, ...expected });
+			if (expected.reason === undefined) {
+				expect(event.properties.reason).toBeUndefined();
+			}
+			expect(event.error).toBeUndefined();
+		});
+
+		it("includes durationMs on the prompt span", async () => {
+			const sink = new TestSink();
+			const { userInteraction, coordinator } = createTestContext(
+				createTestTelemetryService(sink),
+			);
+			userInteraction.setResponse("Authentication Required", undefined);
+
+			await coordinator.ensureLoggedInWithDialog(
+				dialogOptions("missing_session"),
+			);
+
+			expect(
+				sink.expectOne("auth.login_prompted").measurements.durationMs,
+			).toEqual(expect.any(Number));
 		});
 	});
 });

--- a/test/unit/login/loginCoordinator.test.ts
+++ b/test/unit/login/loginCoordinator.test.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { MementoManager } from "@/core/mementoManager";
 import { SecretsManager } from "@/core/secretsManager";
 import { getHeaders } from "@/headers";
+import { AuthTelemetry } from "@/instrumentation/auth";
 import { LoginCoordinator } from "@/login/loginCoordinator";
 import { OAuthCallback } from "@/oauth/oauthCallback";
 import { maybeAskAuthMethod, maybeAskUrl } from "@/promptUtils";
@@ -14,7 +15,6 @@ import {
 	createAxiosError,
 	createMockCliCredentialManager,
 	createMockLogger,
-	createMockServiceContainer,
 	createMockUser,
 	InMemoryMemento,
 	InMemorySecretStorage,
@@ -124,14 +124,15 @@ function createTestContext(telemetry?: TelemetryService) {
 	const mementoManager = new MementoManager(memento);
 
 	const mockCredentialManager = createMockCliCredentialManager();
+	const authTelemetry = new AuthTelemetry(
+		telemetry ?? createTestTelemetryService(),
+	);
 	const coordinator = new LoginCoordinator(
-		createMockServiceContainer({
-			telemetry,
-			logger,
-			secretsManager,
-			mementoManager,
-			cliCredentialManager: mockCredentialManager,
-		}),
+		secretsManager,
+		mementoManager,
+		logger,
+		mockCredentialManager,
+		authTelemetry,
 		oauthCallback,
 		"coder.coder-remote",
 	);

--- a/test/unit/oauth/sessionManager.test.ts
+++ b/test/unit/oauth/sessionManager.test.ts
@@ -5,12 +5,17 @@ import {
 } from "axios";
 import { describe, expect, it, vi } from "vitest";
 
-import { type SecretsManager, type SessionAuth } from "@/core/secretsManager";
+import { type SessionAuth } from "@/core/secretsManager";
 import { DEFAULT_OAUTH_SCOPES } from "@/oauth/constants";
 import { OAuthSessionManager } from "@/oauth/sessionManager";
 
 import {
-	type createMockLogger,
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
+import {
+	createMockServiceContainer,
 	setupAxiosMockRoutes,
 } from "../../mocks/testHelpers";
 
@@ -25,8 +30,8 @@ import {
 	TEST_URL,
 } from "./testUtils";
 
-import type { ServiceContainer } from "@/core/container";
 import type { Deployment } from "@/deployment/types";
+import type { TelemetryService } from "@/telemetry/service";
 
 vi.mock("axios", async () => {
 	const actual = await vi.importActual<typeof import("axios")>("axios");
@@ -58,25 +63,17 @@ const REFRESH_BUFFER_MS = 5 * 60 * 1000; // Tokens refresh 5 minutes before expi
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const BACKGROUND_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
 
-function createMockServiceContainer(
-	secretsManager: SecretsManager,
-	logger: ReturnType<typeof createMockLogger>,
-): ServiceContainer {
-	return {
-		getSecretsManager: () => secretsManager,
-		getLogger: () => logger,
-	} as ServiceContainer;
-}
-
 function createTestContext(deployment: Deployment = createTestDeployment()) {
 	vi.resetAllMocks();
 
 	const base = createBaseTestContext();
-	const container = createMockServiceContainer(
-		base.secretsManager,
-		base.logger,
-	);
-	const manager = OAuthSessionManager.create(deployment, container);
+	const buildContainer = (telemetry?: TelemetryService) =>
+		createMockServiceContainer({
+			secretsManager: base.secretsManager,
+			logger: base.logger,
+			telemetry,
+		});
+	const manager = OAuthSessionManager.create(deployment, buildContainer());
 
 	/** Sets up OAuth session auth */
 	const setupOAuthSession = async (
@@ -102,7 +99,8 @@ function createTestContext(deployment: Deployment = createTestDeployment()) {
 	const createManager = (
 		d: Deployment = deployment,
 		onAuthRequired: () => Promise<void> = () => Promise.resolve(),
-	) => OAuthSessionManager.create(d, container, onAuthRequired);
+		telemetry?: TelemetryService,
+	) => OAuthSessionManager.create(d, buildContainer(telemetry), onAuthRequired);
 
 	/**
 	 * Sets up a complete OAuth operation test context.
@@ -479,6 +477,68 @@ describe("OAuthSessionManager", () => {
 
 			const result = await manager.isLoggedInWithOAuth();
 			expect(result).toBe(true);
+		});
+	});
+
+	describe("telemetry", () => {
+		const setupWithSink = async (
+			tokenEndpoint: unknown = createMockTokenResponse({ access_token: "new" }),
+		) => {
+			enableLocalTelemetry();
+			const sink = new TestSink();
+			const ctx = createTestContext();
+			const manager = ctx.createManager(
+				createTestDeployment(),
+				() => Promise.resolve(),
+				createTestTelemetryService(sink),
+			);
+			await ctx.setupForOAuthOperation({ "/oauth2/token": tokenEndpoint });
+			return { manager, sink };
+		};
+
+		it.each(["reactive", "background"] as const)(
+			"emits auth.token_refreshed with trigger=%s",
+			async (trigger) => {
+				const { manager, sink } = await setupWithSink();
+
+				await manager.refreshToken(trigger);
+
+				const event = sink.expectOne("auth.token_refreshed");
+				expect(event.properties).toMatchObject({ trigger, result: "success" });
+				expect(event.measurements.durationMs).toEqual(expect.any(Number));
+			},
+		);
+
+		it("emits auth.token_refreshed with result=error when refresh fails", async () => {
+			const { manager, sink } = await setupWithSink(
+				createOAuthAxiosError("invalid_grant"),
+			);
+
+			await expect(manager.refreshToken("reactive")).rejects.toThrow();
+
+			const event = sink.expectOne("auth.token_refreshed");
+			expect(event.properties).toMatchObject({
+				trigger: "reactive",
+				result: "error",
+			});
+			expect(event.measurements.durationMs).toEqual(expect.any(Number));
+		});
+
+		it("emits auth.token_refresh.deduped for callers that join an in-flight refresh", async () => {
+			const { manager, sink } = await setupWithSink();
+
+			const [first, second] = await Promise.all([
+				manager.refreshToken("background"),
+				manager.refreshToken("reactive"),
+			]);
+
+			expect(first).toBe(second);
+			expect(sink.eventsNamed("auth.token_refreshed")).toHaveLength(1);
+			expect(
+				sink.expectOne("auth.token_refresh.deduped").properties,
+			).toMatchObject({
+				trigger: "reactive",
+			});
 		});
 	});
 });

--- a/test/unit/remote/sshProcess.test.ts
+++ b/test/unit/remote/sshProcess.test.ts
@@ -12,7 +12,11 @@ import {
 } from "@/remote/sshProcess";
 import { NOOP_TELEMETRY_REPORTER } from "@/telemetry/reporter";
 
-import { createTestTelemetryService, TestSink } from "../../mocks/telemetry";
+import {
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
 import {
 	createMockLogger,
 	makeNetworkInfo,
@@ -44,7 +48,7 @@ describe("SshProcessMonitor", () => {
 		statusBar = new MockStatusBarItem();
 		// Provide default threshold config so getThresholdConfig() works,
 		// and enable telemetry so traces are emitted to the test sink.
-		new MockConfigurationProvider().set("coder.telemetry.level", "local");
+		enableLocalTelemetry();
 
 		// Default: process found immediately
 		vi.mocked(find).mockResolvedValue([
@@ -216,7 +220,7 @@ describe("SshProcessMonitor", () => {
 			monitor.onPidChange((pid) => pids.push(pid));
 
 			// Wait for reconnection to find new PID
-			await waitFor(() => pids.includes(888), 200);
+			await waitUntil(() => pids.includes(888), { timeout: 200 });
 
 			// Should NOT fire undefined - we keep showing last status while searching
 			expect(pids).toContain(888);
@@ -346,18 +350,15 @@ describe("SshProcessMonitor", () => {
 		it("emits found=false when discovery is abandoned by dispose", async () => {
 			const sink = new TestSink();
 			const telemetry = createTestTelemetryService(sink);
-			vol.fromJSON({
-				"/logs/ms-vscode-remote.remote-ssh/1-Remote - SSH.log":
-					"-> socksPort 12345 ->",
-			});
+			vol.fromJSON(sshLog);
 			vi.mocked(find).mockResolvedValue([]);
 
 			const monitor = createMonitor({ telemetry });
-			// Allow at least one discovery iteration to start, then abandon it.
-			await new Promise((r) => setTimeout(r, 30));
+			// `find` always returns []; dispose ends the polling loop and
+			// finalises the span with `found: false`.
 			monitor.dispose();
 
-			await waitFor(
+			await waitUntil(
 				() => sink.eventsNamed("ssh.process.discovered").length > 0,
 			);
 			expect(sink.eventsNamed("ssh.process.discovered")[0]).toMatchObject({
@@ -398,7 +399,7 @@ describe("SshProcessMonitor", () => {
 				telemetry,
 			});
 			await waitForEvent(monitor.onPidChange);
-			await waitFor(() => sink.eventsNamed("ssh.process.lost").length > 0);
+			await waitUntil(() => sink.eventsNamed("ssh.process.lost").length > 0);
 			monitor.dispose();
 
 			const disposed = sink.eventsNamed("ssh.process.disposed");
@@ -408,30 +409,31 @@ describe("SshProcessMonitor", () => {
 
 		it("emits missing_network_info as the loss cause when reads fail repeatedly", async () => {
 			vi.useFakeTimers();
-			const sink = new TestSink();
-			const telemetry = createTestTelemetryService(sink);
-			vol.fromJSON(sshLog);
-			// No /network/999.json. Every read fails until threshold is reached.
-			vi.mocked(find).mockResolvedValue([
-				{ pid: 999, ppid: 1, name: "ssh", cmd: "ssh" },
-			]);
+			try {
+				const sink = new TestSink();
+				const telemetry = createTestTelemetryService(sink);
+				vol.fromJSON(sshLog);
+				// No /network/999.json. Every read fails until threshold is reached.
+				vi.mocked(find).mockResolvedValue([
+					{ pid: 999, ppid: 1, name: "ssh", cmd: "ssh" },
+				]);
 
-			const monitor = createMonitor({
-				networkInfoPath: "/network",
-				networkPollInterval: 10,
-				telemetry,
-			});
+				const monitor = createMonitor({
+					networkInfoPath: "/network",
+					networkPollInterval: 10,
+					telemetry,
+				});
 
-			await vi.advanceTimersByTimeAsync(500);
-			await vi.waitFor(() =>
-				expect(sink.eventsNamed("ssh.process.lost").length).toBeGreaterThan(0),
-			);
+				await vi.advanceTimersByTimeAsync(500);
+				expect(sink.eventsNamed("ssh.process.lost").length).toBeGreaterThan(0);
+				expect(
+					sink.eventsNamed("ssh.process.lost")[0].properties,
+				).toMatchObject({ cause: "missing_network_info" });
 
-			expect(sink.eventsNamed("ssh.process.lost")[0].properties).toMatchObject({
-				cause: "missing_network_info",
-			});
-
-			monitor.dispose();
+				monitor.dispose();
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it("emits ssh.process.replaced (not recovered) when a different PID takes over", async () => {
@@ -451,7 +453,9 @@ describe("SshProcessMonitor", () => {
 				telemetry,
 			});
 			await waitForEvent(monitor.onPidChange);
-			await waitFor(() => sink.eventsNamed("ssh.process.replaced").length > 0);
+			await waitUntil(
+				() => sink.eventsNamed("ssh.process.replaced").length > 0,
+			);
 			// Halt monitoring before the negative assertion so the 888 loop
 			// can't race ahead and emit its own lost/recovered cycle.
 			monitor.dispose();
@@ -482,7 +486,7 @@ describe("SshProcessMonitor", () => {
 				telemetry,
 			});
 			await waitForEvent(monitor.onPidChange);
-			await waitFor(
+			await waitUntil(
 				() =>
 					sink.eventsNamed("ssh.process.lost").length > 0 &&
 					sink.eventsNamed("ssh.process.recovered").length > 0,
@@ -511,7 +515,7 @@ describe("SshProcessMonitor", () => {
 				networkPollInterval: 10,
 				telemetry,
 			});
-			await waitFor(() => sink.eventsNamed("ssh.network.sampled").length > 0);
+			await waitUntil(() => sink.eventsNamed("ssh.network.sampled").length > 0);
 
 			expect(sink.eventsNamed("ssh.network.sampled")[0]).toMatchObject({
 				properties: { p2p: "true", preferredDerp: "NYC" },
@@ -643,7 +647,7 @@ describe("SshProcessMonitor", () => {
 				codeLogDir: "/logs/window1",
 				networkInfoPath: "/network",
 			});
-			await waitFor(() => statusBar.text.includes("Direct"));
+			await waitUntil(() => statusBar.text.includes("Direct"));
 
 			expect(statusBar.text).toContain("Direct");
 			expect(statusBar.text).toContain("25.50ms");
@@ -665,7 +669,7 @@ describe("SshProcessMonitor", () => {
 				codeLogDir: "/logs/window1",
 				networkInfoPath: "/network",
 			});
-			await waitFor(() => statusBar.text.includes("SFO"));
+			await waitUntil(() => statusBar.text.includes("SFO"));
 
 			expect(statusBar.text).toContain("SFO");
 			expect(tooltipText()).toContain("relay");
@@ -682,7 +686,7 @@ describe("SshProcessMonitor", () => {
 				codeLogDir: "/logs/window1",
 				networkInfoPath: "/network",
 			});
-			await waitFor(() => statusBar.text.includes("Coder Connect"));
+			await waitUntil(() => statusBar.text.includes("Coder Connect"));
 
 			expect(statusBar.text).toContain("Coder Connect");
 		});
@@ -1002,10 +1006,9 @@ describe("SshProcessMonitor", () => {
 			);
 			startWithNetwork({ latency: 200 });
 
-			await waitFor(
-				() => statusBar.backgroundColor instanceof ThemeColor,
-				2000,
-			);
+			await waitUntil(() => statusBar.backgroundColor instanceof ThemeColor, {
+				timeout: 2000,
+			});
 			expect(statusBar.command).toBe("coder.pingWorkspace");
 		});
 	});
@@ -1046,6 +1049,18 @@ function mockReaddirOrder(dirPath: string, files: string[]): void {
 	);
 }
 
+/** Poll `cond` via `vi.waitFor` until it returns truthy. */
+async function waitUntil(
+	cond: () => boolean,
+	options?: { timeout?: number },
+): Promise<void> {
+	await vi.waitFor(() => {
+		if (!cond()) {
+			throw new Error("waitUntil: condition not met");
+		}
+	}, options);
+}
+
 /** Wait for a VS Code event to fire once */
 function waitForEvent<T>(
 	event: (listener: (e: T) => void) => { dispose(): void },
@@ -1063,19 +1078,4 @@ function waitForEvent<T>(
 			resolve(value);
 		});
 	});
-}
-
-/** Poll for a condition to become true */
-async function waitFor(
-	condition: () => boolean,
-	timeout = 1000,
-	interval = 5,
-): Promise<void> {
-	const start = Date.now();
-	while (!condition()) {
-		if (Date.now() - start > timeout) {
-			throw new Error(`waitFor timed out after ${timeout}ms`);
-		}
-		await new Promise((r) => setTimeout(r, interval));
-	}
 }

--- a/test/unit/telemetry/service.test.ts
+++ b/test/unit/telemetry/service.test.ts
@@ -124,12 +124,7 @@ describe("TelemetryService", () => {
 		});
 
 		it("forwards caller measurements alongside the framework-set durationMs", async () => {
-			await h.service.trace(
-				"auth.token_refresh",
-				() => Promise.resolve(),
-				{},
-				{ attempts: 2 },
-			);
+			await h.service.trace("op", () => Promise.resolve(), {}, { attempts: 2 });
 
 			const [event] = h.sink.events;
 			expect(event.measurements.attempts).toBe(2);
@@ -305,6 +300,7 @@ describe("TelemetryService", () => {
 			escapedSpan?.setProperty("late", "ignored");
 			escapedSpan?.setMeasurement("lateMs", 99);
 			escapedSpan?.markAborted();
+			escapedSpan?.markFailure();
 
 			// Mutations dropped: emitted event is unchanged.
 			expect(h.sink.events[0].properties.late).toBeUndefined();
@@ -312,7 +308,7 @@ describe("TelemetryService", () => {
 			expect(h.sink.events[0].properties.result).toBe("success");
 
 			// Each post-emit mutation logs a warning.
-			expect(vi.mocked(h.logger.warn).mock.calls.length).toBe(warnBefore + 3);
+			expect(vi.mocked(h.logger.warn).mock.calls.length).toBe(warnBefore + 4);
 			expect(vi.mocked(h.logger.warn).mock.calls[warnBefore][0]).toContain(
 				"setProperty",
 			);
@@ -321,6 +317,9 @@ describe("TelemetryService", () => {
 			);
 			expect(vi.mocked(h.logger.warn).mock.calls[warnBefore + 2][0]).toContain(
 				"markAborted",
+			);
+			expect(vi.mocked(h.logger.warn).mock.calls[warnBefore + 3][0]).toContain(
+				"markFailure",
 			);
 		});
 
@@ -341,6 +340,45 @@ describe("TelemetryService", () => {
 			await expect(
 				h.service.trace("op", (span) => {
 					span.markAborted();
+					return Promise.reject(boom);
+				}),
+			).rejects.toBe(boom);
+
+			expect(h.sink.events[0]).toMatchObject({
+				eventName: "op",
+				properties: { result: "error" },
+				error: { message: "kaboom" },
+			});
+		});
+
+		it("markFailure flips result to 'error' on normal return without an error block", async () => {
+			await h.service.trace("op", (span) => {
+				span.markFailure();
+				return Promise.resolve();
+			});
+
+			expect(h.sink.events[0]).toMatchObject({
+				eventName: "op",
+				properties: { result: "error" },
+			});
+			expect(h.sink.events[0].error).toBeUndefined();
+		});
+
+		it("markFailure overrides markAborted (failure wins over abort)", async () => {
+			await h.service.trace("op", (span) => {
+				span.markAborted();
+				span.markFailure();
+				return Promise.resolve();
+			});
+
+			expect(h.sink.events[0].properties.result).toBe("error");
+		});
+
+		it("thrown errors take precedence over markFailure (error block is preserved)", async () => {
+			const boom = new Error("kaboom");
+			await expect(
+				h.service.trace("op", (span) => {
+					span.markFailure();
 					return Promise.reject(boom);
 				}),
 			).rejects.toBe(boom);

--- a/test/unit/websocket/reconnectingWebSocket.test.ts
+++ b/test/unit/websocket/reconnectingWebSocket.test.ts
@@ -11,11 +11,12 @@ import {
 	type SocketFactory,
 } from "@/websocket/reconnectingWebSocket";
 
-import { createTestTelemetryService, TestSink } from "../../mocks/telemetry";
 import {
-	createMockLogger,
-	MockConfigurationProvider,
-} from "../../mocks/testHelpers";
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
+import { createMockLogger } from "../../mocks/testHelpers";
 
 import type { CloseEvent, Event as WsEvent } from "ws";
 
@@ -594,8 +595,11 @@ describe("ReconnectingWebSocket", () => {
 	});
 
 	describe("Telemetry wiring", () => {
+		beforeEach(() => {
+			enableLocalTelemetry();
+		});
+
 		it("walks the state machine through a full reconnect lifecycle", async () => {
-			new MockConfigurationProvider().set("coder.telemetry.level", "local");
 			const sink = new TestSink();
 			const telemetry = createTestTelemetryService(sink);
 			const { ws, sockets } = await createReconnectingWebSocket({ telemetry });
@@ -641,7 +645,6 @@ describe("ReconnectingWebSocket", () => {
 		});
 
 		it("emits a normal-close drop and disconnects on server-initiated close", async () => {
-			new MockConfigurationProvider().set("coder.telemetry.level", "local");
 			const sink = new TestSink();
 			const telemetry = createTestTelemetryService(sink);
 			const { ws, sockets } = await createReconnectingWebSocket({ telemetry });
@@ -669,7 +672,6 @@ describe("ReconnectingWebSocket", () => {
 		});
 
 		it("records certificate_refresh as the reconnect reason on successful refresh", async () => {
-			new MockConfigurationProvider().set("coder.telemetry.level", "local");
 			const sink = new TestSink();
 			const telemetry = createTestTelemetryService(sink);
 			const sockets: MockSocket[] = [];


### PR DESCRIPTION
## Summary

Records local telemetry for the OAuth and 401-recovery paths so latency and failure modes show up alongside the rest of the local telemetry stream.

Auth events (`src/instrumentation/auth.ts`):

- `auth.token_refreshed`: OAuth refresh attempt with `trigger` (`background` / `reactive`).
- `auth.token_refresh.deduped`: emitted when a refresh call joins an in-flight refresh so the dropped trigger stays countable.
- `auth.unauthorized_intercepted`: recovery path for a 401, with `recovery` (`refresh_success` / `login_required` / `none`) and `refreshAttempted`.
- `auth.login_prompted`: modal login prompt outcome, with `trigger` and a `reason` on abort/failure.

Alongside the auth instrumentation, the shared telemetry plumbing picks up a `measurements` argument on `TelemetryService.trace`, span outcome helpers (`markFailure` / `markAborted`), typed properties on `Span`, and test helpers (`enableLocalTelemetry`, `TestSink.expectOne`, `createMockServiceContainer`). The SSH and WebSocket instrumentation modules migrate to the typed property API.

## Split

First of two stacked PRs replacing #948 (closing #906 in two pieces). The workspace half is #963 and depends on this PR — its `remote.ts` diff stacks on the auth-side diff here.