### PR TITLE
feat(telemetry): instrument workspace lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
   domains with Punycode (`xn--`) labels, can now be opened from recent
   connections. The SSH authority parser was splitting these names across the
   field separator and rejecting the host as invalid.
+- Updating a workspace on a CLI older than 2.24 (which can't run
+  `coder update` non-interactively) now passes newly-required template
+  parameters into the REST-API fallback build, instead of silently omitting
+  them and letting the server reject the build.
 - Updating a workspace from VS Code no longer hangs when the new template
   version requires parameters. The extension now prompts for any missing
   required values through VS Code input boxes and passes them to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
   discovery/loss/recovery with sampled network info, and reconnecting
   WebSocket open/drop/reconnect/state transitions.
 - Local telemetry now records authentication refresh and recovery prompts.
+- Local telemetry now records workspace and agent state transitions with
+  observed durations.
 - Path-like settings (`coder.binaryDestination`, `coder.tlsCertFile`,
   `coder.tlsKeyFile`, `coder.tlsCaFile`, `coder.tlsAltHost`,
   `coder.proxyLogDirectory`) and items in `coder.globalFlags` now support

--- a/src/api/updateParameters.ts
+++ b/src/api/updateParameters.ts
@@ -4,6 +4,7 @@ import type { Api } from "coder/site/src/api/api";
 import type {
 	TemplateVersionParameter,
 	Workspace,
+	WorkspaceBuildParameter,
 } from "coder/site/src/api/typesGenerated";
 
 /** Thrown when the user dismisses a parameter prompt. */
@@ -15,14 +16,14 @@ export class WorkspaceUpdateCancelledError extends Error {
 }
 
 /**
- * Prompts the user for any newly-required template parameters and returns
- * `--parameter name=value` args suitable for `coder update`. Throws
- * `WorkspaceUpdateCancelledError` if the user dismisses a prompt.
+ * Prompts the user for any newly-required template parameters and returns the
+ * collected `{ name, value }` pairs. Throws `WorkspaceUpdateCancelledError` if
+ * the user dismisses a prompt.
  */
 export async function collectUpdateParameters(
 	restClient: Api,
 	workspace: Workspace,
-): Promise<string[]> {
+): Promise<WorkspaceBuildParameter[]> {
 	const [newParams, currentValues] = await Promise.all([
 		restClient.getTemplateVersionRichParameters(
 			workspace.template_active_version_id,
@@ -35,16 +36,16 @@ export async function collectUpdateParameters(
 	const existing = new Set(currentValues.map((p) => p.name));
 	const toPrompt = candidates.filter((p) => !existing.has(p.name));
 
-	const args: string[] = [];
+	const collected: WorkspaceBuildParameter[] = [];
 	for (let i = 0; i < toPrompt.length; i++) {
 		const param = toPrompt[i];
 		const value = await promptForParameter(param, i + 1, toPrompt.length);
 		if (value === undefined) {
 			throw new WorkspaceUpdateCancelledError();
 		}
-		args.push("--parameter", `${param.name}=${value}`);
+		collected.push({ name: param.name, value });
 	}
-	return args;
+	return collected;
 }
 
 function promptForParameter(

--- a/src/api/workspace.ts
+++ b/src/api/workspace.ts
@@ -4,13 +4,13 @@ import * as vscode from "vscode";
 import { getGlobalFlags, type CliAuth } from "../settings/cli";
 
 import { errToStr, createWorkspaceIdentifier } from "./api-helper";
-import { collectUpdateParameters } from "./updateParameters";
 
 import type { Api } from "coder/site/src/api/api";
 import type {
 	ProvisionerJobLog,
 	Workspace,
 	WorkspaceAgentLog,
+	WorkspaceBuildParameter,
 } from "coder/site/src/api/typesGenerated";
 
 import type { FeatureSet } from "../featureSet";
@@ -116,25 +116,31 @@ export async function startWorkspace(ctx: CliContext): Promise<Workspace> {
 }
 
 /**
- * Update a workspace to the latest template version. Collects any newly-
- * required parameters via VS Code prompts and passes them to the CLI as flags
- * (the resolver phase can't render an interactive terminal). Falls back to
- * the REST API for CLIs older than 2.24.
+ * Update a workspace to the latest template version. Callers must collect
+ * any newly-required parameters via `collectUpdateParameters` first; this
+ * function does not prompt. Falls back to the REST API on CLIs older than
+ * 2.24.
  */
-export async function updateWorkspace(ctx: CliContext): Promise<Workspace> {
+export async function updateWorkspace(
+	ctx: CliContext,
+	parameters: WorkspaceBuildParameter[],
+): Promise<Workspace> {
 	if (!ctx.featureSet.cliUpdate) {
-		return updateWorkspaceVersion(ctx);
+		return updateWorkspaceViaApi(ctx, parameters);
 	}
 
-	const paramArgs = await collectUpdateParameters(
-		ctx.restClient,
-		ctx.workspace,
-	);
+	const paramArgs = parameters.flatMap((p) => [
+		"--parameter",
+		`${p.name}=${p.value}`,
+	]);
 	await runCliCommand(ctx, ["update", ...paramArgs]);
 	return ctx.restClient.getWorkspace(ctx.workspace.id);
 }
 
-async function updateWorkspaceVersion(ctx: CliContext): Promise<Workspace> {
+async function updateWorkspaceViaApi(
+	ctx: CliContext,
+	parameters: WorkspaceBuildParameter[],
+): Promise<Workspace> {
 	if (ctx.workspace.latest_build.status === "running") {
 		ctx.write("Stopping workspace for update...\r\n");
 		const stopBuild = await ctx.restClient.stopWorkspace(ctx.workspace.id);
@@ -145,7 +151,13 @@ async function updateWorkspaceVersion(ctx: CliContext): Promise<Workspace> {
 	}
 
 	ctx.write("Starting workspace with updated template...\r\n");
-	await ctx.restClient.updateWorkspaceVersion(ctx.workspace);
+	const template = await ctx.restClient.getTemplate(ctx.workspace.template_id);
+	await ctx.restClient.startWorkspace(
+		ctx.workspace.id,
+		template.active_version_id,
+		undefined,
+		parameters,
+	);
 	return ctx.restClient.getWorkspace(ctx.workspace.id);
 }
 

--- a/src/instrumentation/workspace.ts
+++ b/src/instrumentation/workspace.ts
@@ -1,0 +1,164 @@
+import type {
+	Workspace,
+	WorkspaceAgent,
+	WorkspaceAgentLifecycle,
+	WorkspaceAgentStatus,
+	WorkspaceBuild,
+	WorkspaceStatus,
+} from "coder/site/src/api/typesGenerated";
+
+import type { TelemetryReporter } from "../telemetry/reporter";
+
+/** Sentinel for `from*` before any state is observed. `"unknown"` is a real server-reported value, so avoid it. */
+const INITIAL_STATE = "none";
+
+/** Statuses where a provisioner job is actively running. */
+const PROVISIONING_STATUSES: ReadonlySet<WorkspaceStatus> = new Set([
+	"pending",
+	"starting",
+	"stopping",
+	"canceling",
+	"deleting",
+]);
+
+interface ObservedWorkspaceState {
+	readonly status: WorkspaceStatus;
+	readonly transition: WorkspaceBuild["transition"];
+	readonly reason: WorkspaceBuild["reason"];
+	readonly observedAtMs: number;
+}
+
+interface ObservedAgentState {
+	readonly status: WorkspaceAgentStatus;
+	readonly lifecycleState: WorkspaceAgentLifecycle;
+	readonly observedAtMs: number;
+}
+
+/**
+ * Emits `workspace.state_transitioned` as a workspace progresses through
+ * statuses, plus `observedBuildDurationMs` when a provisioner run resolves.
+ * Construct one per workspace; `WorkspaceMonitor` is the sole call site.
+ */
+export class WorkspaceStateTelemetry {
+	private observed: ObservedWorkspaceState | undefined;
+	/** Set on first observation of a provisioning status; cleared when the build resolves. */
+	private buildStartedAtMs: number | undefined;
+
+	public constructor(
+		private readonly telemetry: TelemetryReporter,
+		private readonly workspaceName: string,
+	) {}
+
+	public observe(workspace: Workspace): void {
+		const { status, transition, reason } = workspace.latest_build;
+		const previous = this.observed;
+		if (
+			previous?.status === status &&
+			previous.transition === transition &&
+			previous.reason === reason
+		) {
+			return;
+		}
+
+		const now = performance.now();
+		const measurements: Record<string, number> = previous
+			? { observedDurationMs: now - previous.observedAtMs }
+			: {};
+
+		const wasProvisioning =
+			previous && PROVISIONING_STATUSES.has(previous.status);
+		const isProvisioning = PROVISIONING_STATUSES.has(status);
+		if (isProvisioning) {
+			this.buildStartedAtMs ??= now;
+		} else {
+			if (wasProvisioning && this.buildStartedAtMs !== undefined) {
+				measurements.observedBuildDurationMs = now - this.buildStartedAtMs;
+			}
+			this.buildStartedAtMs = undefined;
+		}
+
+		this.telemetry.log(
+			"workspace.state_transitioned",
+			{
+				workspaceName: this.workspaceName,
+				from: previous?.status ?? INITIAL_STATE,
+				to: status,
+				transition,
+				reason,
+			},
+			measurements,
+		);
+		this.observed = { status, transition, reason, observedAtMs: now };
+	}
+}
+
+/**
+ * Emits `workspace.agent.state_transitioned` as the agent's `status` and
+ * `lifecycle_state` change. The agent has two state dimensions so the event
+ * carries qualified `fromStatus`/`toStatus` and `fromLifecycleState`/
+ * `toLifecycleState` properties. Construct one per workspace.
+ */
+export class WorkspaceAgentTelemetry {
+	private observed: ObservedAgentState | undefined;
+
+	public constructor(
+		private readonly telemetry: TelemetryReporter,
+		private readonly workspaceName: string,
+	) {}
+
+	public observe(agent: WorkspaceAgent): void {
+		const previous = this.observed;
+		if (
+			previous?.status === agent.status &&
+			previous.lifecycleState === agent.lifecycle_state
+		) {
+			return;
+		}
+		const now = performance.now();
+
+		this.telemetry.log(
+			"workspace.agent.state_transitioned",
+			{
+				workspaceName: this.workspaceName,
+				agentName: agent.name,
+				fromStatus: previous?.status ?? INITIAL_STATE,
+				toStatus: agent.status,
+				fromLifecycleState: previous?.lifecycleState ?? INITIAL_STATE,
+				toLifecycleState: agent.lifecycle_state,
+			},
+			previous ? { observedDurationMs: now - previous.observedAtMs } : {},
+		);
+		this.observed = {
+			status: agent.status,
+			lifecycleState: agent.lifecycle_state,
+			observedAtMs: now,
+		};
+	}
+
+	public reset(): void {
+		this.observed = undefined;
+	}
+}
+
+/**
+ * Wraps user-initiated workspace operations (start, update) as traced spans.
+ * Stateless; safe to construct per call site.
+ */
+export class WorkspaceOperationTelemetry {
+	public constructor(
+		private readonly telemetry: TelemetryReporter,
+		private readonly workspaceName: string,
+	) {}
+
+	public traceUpdateTriggered<T>(fn: () => Promise<T>): Promise<T> {
+		return this.telemetry.trace("workspace.update.triggered", fn, {
+			workspaceName: this.workspaceName,
+		});
+	}
+
+	public traceStartTriggered<T>(fn: () => Promise<T>): Promise<T> {
+		return this.telemetry.trace("workspace.start.triggered", fn, {
+			workspaceName: this.workspaceName,
+		});
+	}
+}

--- a/src/instrumentation/workspace.ts
+++ b/src/instrumentation/workspace.ts
@@ -1,9 +1,12 @@
+import { WorkspaceUpdateCancelledError } from "../api/updateParameters";
+
 import type {
 	Workspace,
 	WorkspaceAgent,
 	WorkspaceAgentLifecycle,
 	WorkspaceAgentStatus,
 	WorkspaceBuild,
+	WorkspaceBuildParameter,
 	WorkspaceStatus,
 } from "coder/site/src/api/typesGenerated";
 
@@ -160,5 +163,33 @@ export class WorkspaceOperationTelemetry {
 		return this.telemetry.trace("workspace.start.triggered", fn, {
 			workspaceName: this.workspaceName,
 		});
+	}
+
+	/**
+	 * Records dismissal as `result: "aborted"`. The framework treats any throw
+	 * as `result: "error"`, so we return inside the span and rethrow outside.
+	 */
+	public async traceUpdatePrompted(
+		fn: () => Promise<WorkspaceBuildParameter[]>,
+	): Promise<WorkspaceBuildParameter[]> {
+		let cancel: WorkspaceUpdateCancelledError | undefined;
+		const parameters = await this.telemetry.trace(
+			"workspace.update.prompted",
+			async (span) => {
+				try {
+					return await fn();
+				} catch (error) {
+					if (error instanceof WorkspaceUpdateCancelledError) {
+						span.markAborted();
+						cancel = error;
+						return [];
+					}
+					throw error;
+				}
+			},
+			{ workspaceName: this.workspaceName },
+		);
+		if (cancel) throw cancel;
+		return parameters;
 	}
 }

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -312,8 +312,7 @@ export class Remote {
 			const monitor = await WorkspaceMonitor.create(
 				workspace,
 				workspaceClient,
-				this.logger,
-				this.contextManager,
+				this.serviceContainer,
 			);
 			disposables.push(
 				monitor,
@@ -331,8 +330,8 @@ export class Remote {
 				args.startupMode,
 				binaryPath,
 				featureSet,
-				this.logger,
 				cliAuth,
+				this.serviceContainer,
 			);
 			disposables.push(stateMachine);
 

--- a/src/remote/workspaceStateMachine.ts
+++ b/src/remote/workspaceStateMachine.ts
@@ -13,6 +13,10 @@ import {
 	streamAgentLogs,
 	streamBuildLogs,
 } from "../api/workspace";
+import {
+	WorkspaceAgentTelemetry,
+	WorkspaceOperationTelemetry,
+} from "../instrumentation/workspace";
 import { maybeAskAgent } from "../promptUtils";
 import { vscodeProposed } from "../vscodeProposed";
 
@@ -25,6 +29,7 @@ import type {
 } from "coder/site/src/api/typesGenerated";
 
 import type { CoderApi } from "../api/coderApi";
+import type { ServiceContainer } from "../core/container";
 import type { StartupMode } from "../core/mementoManager";
 import type { FeatureSet } from "../featureSet";
 import type { Logger } from "../logging/logger";
@@ -39,9 +44,13 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 	private readonly terminal: TerminalOutputChannel;
 	private readonly buildLogStream = new LazyStream<ProvisionerJobLog>();
 	private readonly agentLogStream = new LazyStream<WorkspaceAgentLog[]>();
+	private readonly agentTelemetry: WorkspaceAgentTelemetry;
+	private readonly operationTelemetry: WorkspaceOperationTelemetry;
 
 	private agent: { id: string; name: string } | undefined;
 	private workspace: Workspace | undefined;
+
+	private readonly logger: Logger;
 
 	constructor(
 		private readonly parts: AuthorityParts,
@@ -49,10 +58,18 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 		private startupMode: StartupMode,
 		private readonly binaryPath: string,
 		private readonly featureSet: FeatureSet,
-		private readonly logger: Logger,
 		private readonly cliAuth: CliAuth,
+		container: ServiceContainer,
 	) {
+		this.logger = container.getLogger();
 		this.terminal = new TerminalOutputChannel("Coder: Workspace Build");
+		const telemetry = container.getTelemetryService();
+		const workspaceName = `${parts.username}/${parts.workspace}`;
+		this.agentTelemetry = new WorkspaceAgentTelemetry(telemetry, workspaceName);
+		this.operationTelemetry = new WorkspaceOperationTelemetry(
+			telemetry,
+			workspaceName,
+		);
 	}
 
 	/**
@@ -77,7 +94,7 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 				if (updated) {
 					workspace = updated;
 					// Agent IDs may have changed after an update.
-					this.agent = undefined;
+					this.resetAgent();
 					if (workspace.latest_build.status !== "running") return false;
 				}
 				break;
@@ -106,7 +123,7 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 				if (updated) {
 					workspace = updated;
 					// Agent IDs may have changed after an update.
-					this.agent = undefined;
+					this.resetAgent();
 					if (workspace.latest_build.status !== "running") return false;
 					break;
 				}
@@ -119,7 +136,7 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 			case "starting":
 			case "stopping": {
 				// Clear the agent since its ID could change after a restart
-				this.agent = undefined;
+				this.resetAgent();
 				this.agentLogStream.close();
 				progress.report({
 					message: `building ${workspaceName} (${workspace.latest_build.status})...`,
@@ -164,6 +181,7 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 				`Agent ${this.agent.name} not found in ${workspaceName} resources`,
 			);
 		}
+		this.agentTelemetry.observe(agent);
 
 		switch (agent.status) {
 			case "connecting":
@@ -268,7 +286,9 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 			mode: this.startupMode,
 			status: workspace.latest_build.status,
 		});
-		await startWorkspace(this.buildCliContext(workspace));
+		await this.operationTelemetry.traceStartTriggered(() =>
+			startWorkspace(this.buildCliContext(workspace)),
+		);
 		this.logger.info(`${workspaceName} start initiated`);
 	}
 
@@ -286,7 +306,10 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 			status: workspace.latest_build.status,
 		});
 		try {
-			this.workspace = await updateWorkspace(this.buildCliContext(workspace));
+			this.workspace = await this.operationTelemetry.traceUpdateTriggered(() =>
+				updateWorkspace(this.buildCliContext(workspace)),
+			);
+			this.logger.info(`${workspaceName} update initiated`);
 			return this.workspace;
 		} catch (error) {
 			if (error instanceof WorkspaceUpdateCancelledError) {
@@ -328,6 +351,11 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 
 	public getWorkspace(): Workspace | undefined {
 		return this.workspace;
+	}
+
+	private resetAgent(): void {
+		this.agent = undefined;
+		this.agentTelemetry.reset();
 	}
 
 	dispose(): void {

--- a/src/remote/workspaceStateMachine.ts
+++ b/src/remote/workspaceStateMachine.ts
@@ -5,7 +5,10 @@ import {
 	errToStr,
 	extractAgents,
 } from "../api/api-helper";
-import { WorkspaceUpdateCancelledError } from "../api/updateParameters";
+import {
+	collectUpdateParameters,
+	WorkspaceUpdateCancelledError,
+} from "../api/updateParameters";
 import {
 	LazyStream,
 	startWorkspace,
@@ -306,8 +309,11 @@ export class WorkspaceStateMachine implements vscode.Disposable {
 			status: workspace.latest_build.status,
 		});
 		try {
+			const parameters = await this.operationTelemetry.traceUpdatePrompted(() =>
+				collectUpdateParameters(this.workspaceClient, workspace),
+			);
 			this.workspace = await this.operationTelemetry.traceUpdateTriggered(() =>
-				updateWorkspace(this.buildCliContext(workspace)),
+				updateWorkspace(this.buildCliContext(workspace), parameters),
 			);
 			this.logger.info(`${workspaceName} update initiated`);
 			return this.workspace;

--- a/src/workspace/workspaceMonitor.ts
+++ b/src/workspace/workspaceMonitor.ts
@@ -6,6 +6,7 @@ import { formatDistanceToNowStrict } from "date-fns";
 import * as vscode from "vscode";
 
 import { createWorkspaceIdentifier, errToStr } from "../api/api-helper";
+import { WorkspaceStateTelemetry } from "../instrumentation/workspace";
 import {
 	areNotificationsDisabled,
 	areUpdateNotificationsDisabled,
@@ -13,6 +14,7 @@ import {
 import { vscodeProposed } from "../vscodeProposed";
 
 import type { CoderApi } from "../api/coderApi";
+import type { ServiceContainer } from "../core/container";
 import type { ContextManager } from "../core/contextManager";
 import type { Logger } from "../logging/logger";
 import type { UnidirectionalStream } from "../websocket/eventStreamConnection";
@@ -42,16 +44,24 @@ export class WorkspaceMonitor implements vscode.Disposable {
 
 	// For logging.
 	private readonly name: string;
+	private readonly telemetry: WorkspaceStateTelemetry;
+	private readonly logger: Logger;
+	private readonly contextManager: ContextManager;
 
 	private latestWorkspace: Workspace;
 
 	private constructor(
 		workspace: Workspace,
 		private readonly client: CoderApi,
-		private readonly logger: Logger,
-		private readonly contextManager: ContextManager,
+		container: ServiceContainer,
 	) {
+		this.logger = container.getLogger();
+		this.contextManager = container.getContextManager();
 		this.name = createWorkspaceIdentifier(workspace);
+		this.telemetry = new WorkspaceStateTelemetry(
+			container.getTelemetryService(),
+			this.name,
+		);
 		this.latestWorkspace = workspace;
 
 		const statusBarItem = vscode.window.createStatusBarItem(
@@ -75,21 +85,15 @@ export class WorkspaceMonitor implements vscode.Disposable {
 	static async create(
 		workspace: Workspace,
 		client: CoderApi,
-		logger: Logger,
-		contextManager: ContextManager,
+		container: ServiceContainer,
 	): Promise<WorkspaceMonitor> {
-		const monitor = new WorkspaceMonitor(
-			workspace,
-			client,
-			logger,
-			contextManager,
-		);
+		const monitor = new WorkspaceMonitor(workspace, client, container);
 
 		// Initialize websocket connection
 		const socket = await client.watchWorkspace(workspace);
 
 		socket.addEventListener("open", () => {
-			logger.info(`Monitoring ${monitor.name}...`);
+			monitor.logger.info(`Monitoring ${monitor.name}...`);
 		});
 
 		socket.addEventListener("message", (event) => {
@@ -134,6 +138,7 @@ export class WorkspaceMonitor implements vscode.Disposable {
 	}
 
 	private update(workspace: Workspace) {
+		this.telemetry.observe(workspace);
 		this.latestWorkspace = workspace;
 		this.updateContext(workspace);
 		this.updateStatusBar(workspace);

--- a/test/unit/api/updateParameters.test.ts
+++ b/test/unit/api/updateParameters.test.ts
@@ -134,7 +134,7 @@ describe("collectUpdateParameters", () => {
 		param: Partial<TemplateVersionParameter>;
 		mock: () => QuickInputMock;
 		accept: Record<string, unknown>;
-		expected: string[];
+		expected: Array<{ name: string; value: string }>;
 	}
 
 	it.each<CollectCase>([
@@ -143,14 +143,14 @@ describe("collectUpdateParameters", () => {
 			param: { name: "environment" },
 			mock: mockCreateInputBox,
 			accept: { value: "dev" },
-			expected: ["--parameter", "environment=dev"],
+			expected: [{ name: "environment", value: "dev" }],
 		},
 		{
 			kind: "bool quick pick",
 			param: { name: "enabled", type: "bool" },
 			mock: mockCreateQuickPick,
 			accept: { selectedItems: [{ value: "true" }] },
-			expected: ["--parameter", "enabled=true"],
+			expected: [{ name: "enabled", value: "true" }],
 		},
 		{
 			kind: "options quick pick",
@@ -163,7 +163,7 @@ describe("collectUpdateParameters", () => {
 			},
 			mock: mockCreateQuickPick,
 			accept: { selectedItems: [{ value: "l" }] },
-			expected: ["--parameter", "size=l"],
+			expected: [{ name: "size", value: "l" }],
 		},
 		{
 			kind: "multi-select quick pick (JSON array)",
@@ -177,7 +177,7 @@ describe("collectUpdateParameters", () => {
 			},
 			mock: mockCreateQuickPick,
 			accept: { selectedItems: [{ value: "us" }, { value: "eu" }] },
-			expected: ["--parameter", 'regions=["us","eu"]'],
+			expected: [{ name: "regions", value: '["us","eu"]' }],
 		},
 	])(
 		"collects the value via $kind",
@@ -201,7 +201,9 @@ describe("collectUpdateParameters", () => {
 		await waitShown(qi);
 		qi.accept({ value: "$(rm -rf /)" });
 
-		await expect(result).resolves.toEqual(["--parameter", "evil=$(rm -rf /)"]);
+		await expect(result).resolves.toEqual([
+			{ name: "evil", value: "$(rm -rf /)" },
+		]);
 	});
 
 	it("skips parameters that already have a value or default", async () => {

--- a/test/unit/api/workspace.test.ts
+++ b/test/unit/api/workspace.test.ts
@@ -82,13 +82,14 @@ function createUpdateCtx(
 		stopWorkspace: vi
 			.fn()
 			.mockResolvedValue({ ...workspace.latest_build, status: "stopped" }),
-		updateWorkspaceVersion: vi.fn().mockResolvedValue(workspace.latest_build),
+		startWorkspace: vi.fn().mockResolvedValue(workspace.latest_build),
+		getTemplate: vi
+			.fn()
+			.mockResolvedValue({ active_version_id: "active-version-id" }),
 		waitForBuild: vi.fn().mockResolvedValue({
 			...workspace.latest_build.job,
 			status: "succeeded",
 		}),
-		getTemplateVersionRichParameters: vi.fn().mockResolvedValue([]),
-		getWorkspaceBuildParameters: vi.fn().mockResolvedValue([]),
 	};
 	const ctx = {
 		restClient: restClient as unknown as Api,
@@ -202,7 +203,7 @@ describe("updateWorkspace", () => {
 		const { ctx, restClient, finalWorkspace } = createUpdateCtx();
 		const sp = controlSpawn();
 
-		const result = updateWorkspace(ctx);
+		const result = updateWorkspace(ctx, []);
 		await sp.close(0);
 
 		await expect(result).resolves.toBe(finalWorkspace);
@@ -216,11 +217,34 @@ describe("updateWorkspace", () => {
 		expect(restClient.getWorkspace).toHaveBeenCalledWith(ctx.workspace.id);
 	});
 
+	it("passes collected parameters as --parameter flags", async () => {
+		const { ctx } = createUpdateCtx();
+		const sp = controlSpawn();
+
+		const result = updateWorkspace(ctx, [
+			{ name: "region", value: "us-east" },
+			{ name: "size", value: "large" },
+		]);
+		await sp.close(0);
+		await result;
+
+		expect(spawn).toHaveBeenCalledWith("/usr/bin/coder", [
+			"--url",
+			"https://test.coder.com",
+			"update",
+			"--parameter",
+			"region=us-east",
+			"--parameter",
+			"size=large",
+			"testuser/test-workspace",
+		]);
+	});
+
 	it("rejects when the process exits non-zero", async () => {
 		const { ctx, restClient } = createUpdateCtx();
 		const sp = controlSpawn();
 
-		const result = updateWorkspace(ctx);
+		const result = updateWorkspace(ctx, []);
 		await sp.spawned;
 		sp.stderr("auth failed");
 		await sp.close(1);
@@ -233,7 +257,7 @@ describe("updateWorkspace", () => {
 		const { ctx, restClient } = createUpdateCtx();
 		const sp = controlSpawn();
 
-		const result = updateWorkspace(ctx);
+		const result = updateWorkspace(ctx, []);
 		await sp.error(new Error("spawn /usr/bin/coder ENOENT"));
 		// Real Node fires `error` then `close(null, null)` on ENOENT.
 		await sp.close(null);
@@ -246,7 +270,7 @@ describe("updateWorkspace", () => {
 		const { ctx } = createUpdateCtx();
 		const sp = controlSpawn();
 
-		const result = updateWorkspace(ctx);
+		const result = updateWorkspace(ctx, []);
 		await sp.close(null, "SIGTERM");
 
 		await expect(result).rejects.toThrow(/signal SIGTERM/);
@@ -257,13 +281,31 @@ describe("updateWorkspace", () => {
 			featureSet: { cliUpdate: false },
 		});
 
-		await expect(updateWorkspace(ctx)).resolves.toBe(finalWorkspace);
+		await expect(updateWorkspace(ctx, [])).resolves.toBe(finalWorkspace);
 
 		expect(spawn).not.toHaveBeenCalled();
-		expect(restClient.getTemplateVersionRichParameters).not.toHaveBeenCalled();
 		expect(restClient.stopWorkspace).toHaveBeenCalledWith(ctx.workspace.id);
-		expect(restClient.updateWorkspaceVersion).toHaveBeenCalledWith(
-			ctx.workspace,
+		expect(restClient.startWorkspace).toHaveBeenCalledWith(
+			ctx.workspace.id,
+			"active-version-id",
+			undefined,
+			[],
+		);
+	});
+
+	it("passes collected parameters when using the API fallback", async () => {
+		const { ctx, restClient } = createUpdateCtx({
+			featureSet: { cliUpdate: false },
+		});
+		const parameters = [{ name: "region", value: "us-east" }];
+
+		await updateWorkspace(ctx, parameters);
+
+		expect(restClient.startWorkspace).toHaveBeenCalledWith(
+			ctx.workspace.id,
+			"active-version-id",
+			undefined,
+			parameters,
 		);
 	});
 
@@ -273,11 +315,14 @@ describe("updateWorkspace", () => {
 			featureSet: { cliUpdate: false },
 		});
 
-		await updateWorkspace(ctx);
+		await updateWorkspace(ctx, []);
 
 		expect(restClient.stopWorkspace).not.toHaveBeenCalled();
-		expect(restClient.updateWorkspaceVersion).toHaveBeenCalledWith(
-			ctx.workspace,
+		expect(restClient.startWorkspace).toHaveBeenCalledWith(
+			ctx.workspace.id,
+			"active-version-id",
+			undefined,
+			[],
 		);
 	});
 
@@ -290,10 +335,10 @@ describe("updateWorkspace", () => {
 			status: "canceled",
 		});
 
-		await expect(updateWorkspace(ctx)).rejects.toThrow(
+		await expect(updateWorkspace(ctx, [])).rejects.toThrow(
 			"Workspace update cancelled during stop",
 		);
-		expect(restClient.updateWorkspaceVersion).not.toHaveBeenCalled();
+		expect(restClient.startWorkspace).not.toHaveBeenCalled();
 	});
 });
 

--- a/test/unit/instrumentation/workspace.test.ts
+++ b/test/unit/instrumentation/workspace.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import { WorkspaceUpdateCancelledError } from "@/api/updateParameters";
+import {
+	WorkspaceAgentTelemetry,
+	WorkspaceOperationTelemetry,
+	WorkspaceStateTelemetry,
+} from "@/instrumentation/workspace";
+
+import {
+	agent as createAgent,
+	workspace as createWorkspace,
+} from "@repo/mocks";
+
+import { createTelemetryHarness } from "../../mocks/telemetry";
+
+import type { TelemetryService } from "@/telemetry/service";
+
+const WORKSPACE_NAME = "testuser/test-workspace";
+
+function setup<T>(make: (svc: TelemetryService, name: string) => T) {
+	const { sink, service } = createTelemetryHarness();
+	return { sink, instance: make(service, WORKSPACE_NAME) };
+}
+
+const newOps = (svc: TelemetryService, name: string) =>
+	new WorkspaceOperationTelemetry(svc, name);
+const newState = (svc: TelemetryService, name: string) =>
+	new WorkspaceStateTelemetry(svc, name);
+const newAgentTelemetry = (svc: TelemetryService, name: string) =>
+	new WorkspaceAgentTelemetry(svc, name);
+
+describe("WorkspaceOperationTelemetry", () => {
+	it.each([
+		{
+			method: "traceStartTriggered" as const,
+			event: "workspace.start.triggered",
+		},
+		{
+			method: "traceUpdateTriggered" as const,
+			event: "workspace.update.triggered",
+		},
+	])("$method emits $event with result=success", async ({ method, event }) => {
+		const { sink, instance: ops } = setup(newOps);
+
+		await ops[method](() => Promise.resolve());
+
+		expect(sink.expectOne(event)).toMatchObject({
+			properties: { workspaceName: WORKSPACE_NAME, result: "success" },
+		});
+	});
+
+	it.each([
+		{
+			method: "traceStartTriggered" as const,
+			event: "workspace.start.triggered",
+		},
+		{
+			method: "traceUpdateTriggered" as const,
+			event: "workspace.update.triggered",
+		},
+	])("$method emits result=error and rethrows", async ({ method, event }) => {
+		const { sink, instance: ops } = setup(newOps);
+		const boom = new Error("nope");
+
+		await expect(ops[method](() => Promise.reject(boom))).rejects.toBe(boom);
+		expect(sink.expectOne(event)).toMatchObject({
+			properties: { result: "error" },
+			error: { message: "nope" },
+		});
+	});
+
+	describe("traceUpdatePrompted", () => {
+		it("returns the collected parameters and emits result=success", async () => {
+			const { sink, instance: ops } = setup(newOps);
+			const collected = [{ name: "region", value: "us-east" }];
+
+			const result = await ops.traceUpdatePrompted(() =>
+				Promise.resolve(collected),
+			);
+
+			expect(result).toEqual(collected);
+			expect(sink.expectOne("workspace.update.prompted")).toMatchObject({
+				properties: { workspaceName: WORKSPACE_NAME, result: "success" },
+			});
+		});
+
+		it("emits result=aborted (no error block) and rethrows on cancellation", async () => {
+			const { sink, instance: ops } = setup(newOps);
+			const cancel = new WorkspaceUpdateCancelledError();
+
+			await expect(
+				ops.traceUpdatePrompted(() => Promise.reject(cancel)),
+			).rejects.toBe(cancel);
+
+			const event = sink.expectOne("workspace.update.prompted");
+			expect(event.properties.result).toBe("aborted");
+			expect(event.error).toBeUndefined();
+		});
+
+		it("propagates non-cancellation errors as result=error", async () => {
+			const { sink, instance: ops } = setup(newOps);
+			const boom = new Error("rest call failed");
+
+			await expect(
+				ops.traceUpdatePrompted(() => Promise.reject(boom)),
+			).rejects.toBe(boom);
+
+			expect(sink.expectOne("workspace.update.prompted")).toMatchObject({
+				properties: { result: "error" },
+				error: { message: "rest call failed" },
+			});
+		});
+	});
+});
+
+describe("WorkspaceStateTelemetry.observe", () => {
+	it("emits the first observation with from=none and no duration", () => {
+		const { sink, instance: state } = setup(newState);
+
+		state.observe(createWorkspace({ latest_build: { status: "running" } }));
+
+		const event = sink.expectOne("workspace.state_transitioned");
+		expect(event.properties).toMatchObject({
+			workspaceName: WORKSPACE_NAME,
+			from: "none",
+			to: "running",
+		});
+		expect(event.measurements.observedDurationMs).toBeUndefined();
+	});
+
+	it("ignores duplicate observations of the same state", () => {
+		const { sink, instance: state } = setup(newState);
+		const ws = createWorkspace({ latest_build: { status: "running" } });
+
+		state.observe(ws);
+		state.observe(ws);
+
+		expect(sink.eventsNamed("workspace.state_transitioned")).toHaveLength(1);
+	});
+
+	it("records observedDurationMs across transitions and observedBuildDurationMs once a build resolves", () => {
+		const { sink, instance: state } = setup(newState);
+
+		state.observe(createWorkspace({ latest_build: { status: "stopped" } }));
+		state.observe(createWorkspace({ latest_build: { status: "starting" } }));
+		state.observe(createWorkspace({ latest_build: { status: "running" } }));
+
+		const [first, second, third] = sink.eventsNamed(
+			"workspace.state_transitioned",
+		);
+		expect(first.measurements.observedDurationMs).toBeUndefined();
+		expect(second.measurements.observedDurationMs).toEqual(expect.any(Number));
+		expect(second.measurements.observedBuildDurationMs).toBeUndefined();
+		expect(third.measurements.observedBuildDurationMs).toEqual(
+			expect.any(Number),
+		);
+	});
+});
+
+describe("WorkspaceAgentTelemetry.observe", () => {
+	it("emits the first observation with from=none", () => {
+		const { sink, instance: agentTelemetry } = setup(newAgentTelemetry);
+
+		agentTelemetry.observe(
+			createAgent({ status: "connecting", lifecycle_state: "created" }),
+		);
+
+		expect(sink.expectOne("workspace.agent.state_transitioned")).toMatchObject({
+			properties: {
+				fromStatus: "none",
+				toStatus: "connecting",
+				fromLifecycleState: "none",
+				toLifecycleState: "created",
+			},
+		});
+	});
+
+	it("dedupes consecutive identical observations", () => {
+		const { sink, instance: agentTelemetry } = setup(newAgentTelemetry);
+		const a = createAgent({ status: "connected", lifecycle_state: "ready" });
+
+		agentTelemetry.observe(a);
+		agentTelemetry.observe(a);
+
+		expect(sink.eventsNamed("workspace.agent.state_transitioned")).toHaveLength(
+			1,
+		);
+	});
+
+	it("reset() makes the next observation emit from=none again", () => {
+		const { sink, instance: agentTelemetry } = setup(newAgentTelemetry);
+
+		agentTelemetry.observe(createAgent({ status: "connected" }));
+		agentTelemetry.reset();
+		agentTelemetry.observe(createAgent({ status: "connecting" }));
+
+		const events = sink.eventsNamed("workspace.agent.state_transitioned");
+		expect(events).toHaveLength(2);
+		expect(events[1].properties.fromStatus).toBe("none");
+	});
+
+	it("includes observedDurationMs between transitions", () => {
+		const { sink, instance: agentTelemetry } = setup(newAgentTelemetry);
+
+		agentTelemetry.observe(createAgent({ status: "connecting" }));
+		agentTelemetry.observe(createAgent({ status: "connected" }));
+
+		const events = sink.eventsNamed("workspace.agent.state_transitioned");
+		expect(events[1].measurements.observedDurationMs).toEqual(
+			expect.any(Number),
+		);
+	});
+});

--- a/test/unit/remote/workspaceStateMachine.test.ts
+++ b/test/unit/remote/workspaceStateMachine.test.ts
@@ -18,7 +18,13 @@ import {
 } from "@repo/mocks";
 
 import {
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
+import {
 	createMockLogger,
+	createMockServiceContainer,
 	MockProgress,
 	MockTerminalOutputChannel,
 	MockUserInteraction,
@@ -32,6 +38,7 @@ import type {
 import type { CoderApi } from "@/api/coderApi";
 import type { StartupMode } from "@/core/mementoManager";
 import type { FeatureSet } from "@/featureSet";
+import type { TelemetryService } from "@/telemetry/service";
 import type { AuthorityParts } from "@/util";
 
 vi.mock("@/api/workspace", async (importActual) => {
@@ -77,7 +84,11 @@ function runningWorkspace(
 	});
 }
 
-function setup(startupMode: StartupMode = "start") {
+function setup(
+	startupMode: StartupMode = "start",
+	telemetry?: TelemetryService,
+) {
+	enableLocalTelemetry();
 	const progress = new MockProgress<{ message?: string }>();
 	const userInteraction = new MockUserInteraction();
 	const sm = new WorkspaceStateMachine(
@@ -86,8 +97,8 @@ function setup(startupMode: StartupMode = "start") {
 		startupMode,
 		"/usr/bin/coder",
 		{} as FeatureSet,
-		createMockLogger(),
 		{ mode: "url", url: "https://test.coder.com" },
+		createMockServiceContainer({ telemetry, logger: createMockLogger() }),
 	);
 	return { sm, progress, userInteraction };
 }
@@ -368,6 +379,136 @@ describe("WorkspaceStateMachine", () => {
 				);
 			});
 		}
+	});
+
+	describe("telemetry", () => {
+		const stoppedWorkspace = () =>
+			createWorkspace({ latest_build: { status: "stopped" } });
+
+		it.each<{
+			name: string;
+			eventName: "workspace.start.triggered" | "workspace.update.triggered";
+			mode: StartupMode;
+			workspace: () => Workspace;
+			mock: typeof startWorkspace | typeof updateWorkspace;
+		}>([
+			{
+				name: "workspace.start.triggered on stopped workspace",
+				eventName: "workspace.start.triggered",
+				mode: "start",
+				workspace: stoppedWorkspace,
+				mock: startWorkspace,
+			},
+			{
+				name: "workspace.update.triggered on running workspace in update mode",
+				eventName: "workspace.update.triggered",
+				mode: "update",
+				workspace: runningWorkspace,
+				mock: updateWorkspace,
+			},
+		])(
+			"emits $name with duration on success",
+			async ({ eventName, mode, workspace, mock }) => {
+				const sink = new TestSink();
+				const { sm, progress } = setup(mode, createTestTelemetryService(sink));
+
+				await sm.processWorkspace(workspace(), progress);
+
+				expect(mock).toHaveBeenCalledOnce();
+				const event = sink.expectOne(eventName);
+				expect(event.properties.result).toBe("success");
+				expect(event.measurements.durationMs).toEqual(expect.any(Number));
+			},
+		);
+
+		it("emits result=error when the triggered action throws", async () => {
+			const sink = new TestSink();
+			const { sm, progress } = setup(
+				"update",
+				createTestTelemetryService(sink),
+			);
+			vi.mocked(updateWorkspace).mockRejectedValueOnce(
+				new Error("update failed"),
+			);
+
+			// The state machine catches the failure and falls back to the
+			// existing template version, so processWorkspace resolves.
+			await sm.processWorkspace(runningWorkspace(), progress);
+
+			const event = sink.expectOne("workspace.update.triggered");
+			expect(event.properties.result).toBe("error");
+			expect(event.error).toEqual({ message: "update failed" });
+		});
+
+		it("emits agent state transitions with observed duration", async () => {
+			const sink = new TestSink();
+			const { sm, progress } = setup("start", createTestTelemetryService(sink));
+
+			await sm.processWorkspace(
+				runningWorkspace({ status: "connecting", lifecycle_state: "created" }),
+				progress,
+			);
+			await sm.processWorkspace(runningWorkspace(), progress);
+
+			const events = sink.eventsNamed("workspace.agent.state_transitioned");
+			expect(events).toHaveLength(2);
+			expect(events[0].properties).toMatchObject({
+				fromStatus: "none",
+				toStatus: "connecting",
+				fromLifecycleState: "none",
+				toLifecycleState: "created",
+			});
+			expect(events[1].properties).toMatchObject({
+				fromStatus: "connecting",
+				toStatus: "connected",
+				fromLifecycleState: "created",
+				toLifecycleState: "ready",
+			});
+			expect(events[1].measurements.observedDurationMs).toEqual(
+				expect.any(Number),
+			);
+		});
+
+		it("resets agent telemetry on restart so the next transition emits from 'none'", async () => {
+			const sink = new TestSink();
+			const { sm, progress } = setup("start", createTestTelemetryService(sink));
+
+			// The build log stream is closed when we return to running; give the
+			// mock something disposable so close() doesn't blow up.
+			vi.mocked(streamBuildLogs).mockResolvedValueOnce({
+				close: vi.fn(),
+			} as never);
+
+			// Establish a baseline: connected/ready.
+			await sm.processWorkspace(runningWorkspace(), progress);
+
+			// Workspace enters a build state; resetAgent fires.
+			await sm.processWorkspace(
+				createWorkspace({ latest_build: { status: "stopping" } }),
+				progress,
+			);
+
+			// Next agent observation must restart from "none", not the prior baseline.
+			await sm.processWorkspace(
+				runningWorkspace({ status: "connecting", lifecycle_state: "created" }),
+				progress,
+			);
+
+			const events = sink.eventsNamed("workspace.agent.state_transitioned");
+			expect(events).toHaveLength(2);
+			expect(events[0].properties).toMatchObject({
+				fromStatus: "none",
+				toStatus: "connected",
+				fromLifecycleState: "none",
+				toLifecycleState: "ready",
+			});
+			expect(events[1].properties).toMatchObject({
+				fromStatus: "none",
+				toStatus: "connecting",
+				fromLifecycleState: "none",
+				toLifecycleState: "created",
+			});
+		});
 	});
 
 	describe("agent selection", () => {

--- a/test/unit/remote/workspaceStateMachine.test.ts
+++ b/test/unit/remote/workspaceStateMachine.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
 
-import { WorkspaceUpdateCancelledError } from "@/api/updateParameters";
+import {
+	collectUpdateParameters,
+	WorkspaceUpdateCancelledError,
+} from "@/api/updateParameters";
 import {
 	startWorkspace,
 	updateWorkspace,
@@ -49,6 +52,14 @@ vi.mock("@/api/workspace", async (importActual) => {
 		updateWorkspace: vi.fn().mockResolvedValue({}),
 		streamBuildLogs: vi.fn().mockResolvedValue({}),
 		streamAgentLogs: vi.fn().mockResolvedValue({}),
+	};
+});
+
+vi.mock("@/api/updateParameters", async (importActual) => {
+	const actual = await importActual<typeof import("@/api/updateParameters")>();
+	return {
+		...actual,
+		collectUpdateParameters: vi.fn().mockResolvedValue([]),
 	};
 });
 
@@ -224,14 +235,14 @@ describe("WorkspaceStateMachine", () => {
 		});
 
 		it("falls back to start silently when the user cancels the update", async () => {
-			vi.mocked(updateWorkspace).mockRejectedValueOnce(
+			vi.mocked(collectUpdateParameters).mockRejectedValueOnce(
 				new WorkspaceUpdateCancelledError(),
 			);
 			const { sm, progress } = setup("update");
 			const ws = createWorkspace({ latest_build: { status: "stopped" } });
 
 			expect(await sm.processWorkspace(ws, progress)).toBe(false);
-			expect(updateWorkspace).toHaveBeenCalledOnce();
+			expect(updateWorkspace).not.toHaveBeenCalled();
 			expect(startWorkspace).toHaveBeenCalledOnce();
 			expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
 		});
@@ -420,25 +431,6 @@ describe("WorkspaceStateMachine", () => {
 				expect(event.measurements.durationMs).toEqual(expect.any(Number));
 			},
 		);
-
-		it("emits result=error when the triggered action throws", async () => {
-			const sink = new TestSink();
-			const { sm, progress } = setup(
-				"update",
-				createTestTelemetryService(sink),
-			);
-			vi.mocked(updateWorkspace).mockRejectedValueOnce(
-				new Error("update failed"),
-			);
-
-			// The state machine catches the failure and falls back to the
-			// existing template version, so processWorkspace resolves.
-			await sm.processWorkspace(runningWorkspace(), progress);
-
-			const event = sink.expectOne("workspace.update.triggered");
-			expect(event.properties.result).toBe("error");
-			expect(event.error).toEqual({ message: "update failed" });
-		});
 
 		it("emits agent state transitions with observed duration", async () => {
 			const sink = new TestSink();

--- a/test/unit/workspace/workspaceMonitor.test.ts
+++ b/test/unit/workspace/workspaceMonitor.test.ts
@@ -6,6 +6,12 @@ import { WorkspaceMonitor } from "@/workspace/workspaceMonitor";
 import { workspace as createWorkspace } from "@repo/mocks";
 
 import {
+	createTestTelemetryService,
+	enableLocalTelemetry,
+	TestSink,
+} from "../../mocks/telemetry";
+import {
+	createMockServiceContainer,
 	MockConfigurationProvider,
 	MockContextManager,
 	MockEventStream,
@@ -19,7 +25,7 @@ import type {
 } from "coder/site/src/api/typesGenerated";
 
 import type { CoderApi } from "@/api/coderApi";
-import type { ContextManager } from "@/core/contextManager";
+import type { TelemetryService } from "@/telemetry/service";
 
 function workspaceEvent(
 	overrides?: Parameters<typeof createWorkspace>[0],
@@ -36,7 +42,11 @@ describe("WorkspaceMonitor", () => {
 		vi.resetAllMocks();
 	});
 
-	async function setup(stream = new MockEventStream<ServerSentEvent>()) {
+	async function setup(
+		stream = new MockEventStream<ServerSentEvent>(),
+		telemetry?: TelemetryService,
+		initialWorkspace: Workspace = createWorkspace(),
+	) {
 		const config = new MockConfigurationProvider();
 		const statusBar = new MockStatusBarItem();
 		const contextManager = new MockContextManager();
@@ -50,13 +60,138 @@ describe("WorkspaceMonitor", () => {
 			}),
 		} as unknown as CoderApi;
 		const monitor = await WorkspaceMonitor.create(
-			createWorkspace(),
+			initialWorkspace,
 			client,
-			createMockLogger(),
-			contextManager as unknown as ContextManager,
+			createMockServiceContainer({
+				telemetry,
+				logger: createMockLogger(),
+				contextManager,
+			}),
 		);
 		return { monitor, client, stream, config, statusBar, contextManager };
 	}
+
+	describe("telemetry", () => {
+		const buildSinkContext = () => {
+			enableLocalTelemetry();
+			return {
+				stream: new MockEventStream<ServerSentEvent>(),
+				sink: new TestSink(),
+			};
+		};
+
+		it("emits initial state plus subsequent transitions with duration", async () => {
+			const { stream, sink } = buildSinkContext();
+
+			await setup(
+				stream,
+				createTestTelemetryService(sink),
+				createWorkspace({ latest_build: { status: "running" } }),
+			);
+			stream.pushMessage(
+				workspaceEvent({
+					latest_build: {
+						status: "stopping",
+						transition: "stop",
+						reason: "autostop",
+					},
+				}),
+			);
+
+			const events = sink.eventsNamed("workspace.state_transitioned");
+			expect(events).toHaveLength(2);
+			expect(events[0].properties).toMatchObject({
+				from: "none",
+				to: "running",
+			});
+			expect(events[0].measurements.observedDurationMs).toBeUndefined();
+			expect(events[1]).toMatchObject({
+				properties: {
+					from: "running",
+					to: "stopping",
+					transition: "stop",
+					reason: "autostop",
+				},
+				measurements: { observedDurationMs: expect.any(Number) },
+			});
+		});
+
+		it("dedupes on (status, transition, reason); re-emits when only reason changes", async () => {
+			const { stream, sink } = buildSinkContext();
+
+			await setup(
+				stream,
+				createTestTelemetryService(sink),
+				createWorkspace({
+					latest_build: {
+						status: "stopping",
+						transition: "stop",
+						reason: "autostop",
+					},
+				}),
+			);
+			// Same status with a different reason: must not dedupe.
+			stream.pushMessage(
+				workspaceEvent({
+					latest_build: {
+						status: "stopping",
+						transition: "stop",
+						reason: "initiator",
+					},
+				}),
+			);
+			// Identical to the previous: deduped.
+			stream.pushMessage(
+				workspaceEvent({
+					latest_build: {
+						status: "stopping",
+						transition: "stop",
+						reason: "initiator",
+					},
+				}),
+			);
+
+			const reasons = sink
+				.eventsNamed("workspace.state_transitioned")
+				.map((e) => e.properties.reason);
+			expect(reasons).toEqual(["autostop", "initiator"]);
+		});
+
+		it("emits observedBuildDurationMs on the event that resolves a build run", async () => {
+			const { stream, sink } = buildSinkContext();
+
+			await setup(
+				stream,
+				createTestTelemetryService(sink),
+				createWorkspace({ latest_build: { status: "pending" } }),
+			);
+			stream.pushMessage(
+				workspaceEvent({ latest_build: { status: "starting" } }),
+			);
+			stream.pushMessage(
+				workspaceEvent({ latest_build: { status: "running" } }),
+			);
+			stream.pushMessage(
+				workspaceEvent({ latest_build: { status: "stopping" } }),
+			);
+
+			const events = sink.eventsNamed("workspace.state_transitioned");
+			// pending and starting are intermediate; only running carries observedBuildDurationMs.
+			expect(events.map((e) => e.properties.to)).toEqual([
+				"pending",
+				"starting",
+				"running",
+				"stopping",
+			]);
+			expect(events[0].measurements.observedBuildDurationMs).toBeUndefined();
+			expect(events[1].measurements.observedBuildDurationMs).toBeUndefined();
+			expect(events[2].measurements.observedBuildDurationMs).toEqual(
+				expect.any(Number),
+			);
+			// Next build cycle resets; stopping doesn't carry the previous duration.
+			expect(events[3].measurements.observedBuildDurationMs).toBeUndefined();
+		});
+	});
 
 	describe("websocket lifecycle", () => {
 		it("fires onChange when a workspace message arrives", async () => {


### PR DESCRIPTION
## Summary

Records local telemetry for the workspace state machine and watcher so build durations and agent transitions show up alongside the rest of the local telemetry stream.

Workspace events (`src/instrumentation/workspace.ts`, split into three single-purpose classes):

- `workspace.state_transitioned`: deduped on `(status, transition, reason)`; emits `observedDurationMs` between transitions and `observedBuildDurationMs` when a provisioner run resolves.
- `workspace.agent.state_transitioned`: deduped on `(status, lifecycle_state)`; emits `observedDurationMs`.
- `workspace.start.triggered` / `workspace.update.triggered`: traced spans around user-initiated workspace operations.

All workspace events carry `workspaceName`. The workspace event uses bare `from`/`to` (single state dimension); the agent event uses qualified `fromStatus`/`toStatus` plus `fromLifecycleState`/`toLifecycleState` because two dimensions can change in the same emission. Cross-event consistency via dimension-as-prefix property keys is tracked in #954. `WorkspaceMonitor` and `WorkspaceStateMachine` now take the `ServiceContainer` directly so they can pull the telemetry service.

## Split

Stacked on #962. Second of two PRs replacing #948 (closing #906 in two pieces). Review against the auth branch shows only the workspace-specific diff; rebase to `main` once #962 merges.