### PR TITLE
security: tighten configuration scope for SEC-200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,29 @@
   for input the update is failed instead of hanging, and the workspace
   falls back to starting on the existing template version with a warning.
 
+### Security
+
+- Hardened the configuration scope of security-sensitive settings so that a
+  malicious `.vscode/settings.json` cannot override them (SEC-200). Workspace
+  and folder values are now ignored by VS Code for these settings. This closes
+  a path where a workspace could redirect command execution
+  (`coder.headerCommand`, `coder.tlsCertRefreshCommand`), substitute the CLI
+  binary or its source (`coder.binarySource`, `coder.binaryDestination`,
+  `coder.disableSignatureVerification`, `coder.enableDownloads`), inject
+  CLI/SSH flags (`coder.globalFlags`, `coder.sshFlags`), swap TLS material or
+  disable TLS verification (`coder.tlsCertFile`, `coder.tlsKeyFile`,
+  `coder.tlsCaFile`, `coder.tlsAltHost`, `coder.insecure`), or override
+  identity, networking, and credential storage (`coder.defaultUrl`,
+  `coder.autologin`, `coder.useKeyring`, `coder.proxyBypass`,
+  `coder.proxyLogDirectory`).
+- Path-, command-, and network-dependent settings use `"scope": "machine"`
+  (per-machine, not synced via Settings Sync), while user-wide preferences
+  (`coder.defaultUrl`, `coder.autologin`, `coder.useKeyring`, `coder.insecure`,
+  `coder.disableSignatureVerification`, `coder.enableDownloads`) use
+  `"scope": "application"`, which preserves Settings Sync across your
+  machines while still blocking workspace overrides. This follows VS Code's
+  [recommended scope semantics](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration).
+
 ## [v1.14.5](https://github.com/coder/vscode-coder/releases/tag/v1.14.5) 2026-04-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -59,72 +59,86 @@
 				"coder.insecure": {
 					"markdownDescription": "If true, the extension will not verify the authenticity of the remote host. This is useful for self-signed certificates.",
 					"type": "boolean",
-					"default": false
+					"default": false,
+					"scope": "application"
 				},
 				"coder.binarySource": {
 					"markdownDescription": "Used to download the Coder CLI which is necessary to make SSH connections. The If-None-Match header will be set to the SHA1 of the CLI and can be used for caching. Absolute URLs will be used as-is; otherwise this value will be resolved against the deployment domain. Defaults to downloading from the Coder deployment.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.binaryDestination": {
 					"markdownDescription": "The path to the Coder CLI binary or the directory containing it. When set to a file path (e.g., `/usr/bin/coder`), the extension checks its version and downloads a replacement if it does not match the server (and downloads are enabled). When set to a directory, the extension looks for the CLI inside it (downloading if enabled). Defaults to the value of `CODER_BINARY_DESTINATION` if not set, otherwise the extension's global storage directory.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.enableDownloads": {
 					"markdownDescription": "Allow the plugin to download the CLI when missing or out of date.",
 					"type": "boolean",
-					"default": true
+					"default": true,
+					"scope": "application"
 				},
 				"coder.headerCommand": {
 					"markdownDescription": "An external command that outputs additional HTTP headers added to all requests. The command must output each header as `key=value` on its own line. The following environment variables will be available to the process: `CODER_URL`. Defaults to the value of `CODER_HEADER_COMMAND` if not set.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.tlsCertFile": {
 					"markdownDescription": "Path to file for TLS client cert. When specified, token authorization will be skipped. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.tlsKeyFile": {
 					"markdownDescription": "Path to file for TLS client key. When specified, token authorization will be skipped. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.tlsCaFile": {
 					"markdownDescription": "Path to file for TLS certificate authority. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.tlsAltHost": {
 					"markdownDescription": "Alternative hostname to use for TLS verification. This is useful when the hostname in the certificate does not match the hostname used to connect.\n\nSupports `${env:VAR}` substitution.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.tlsCertRefreshCommand": {
 					"markdownDescription": "Command to run when TLS client certificate errors occur (e.g., expired, revoked, or rejected certificates). If configured, the extension will automatically execute this command and retry failed requests. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.proxyLogDirectory": {
 					"markdownDescription": "Directory where the Coder CLI outputs SSH connection logs for debugging. Defaults to the value of `CODER_SSH_LOG_DIR` if not set, otherwise the extension's global storage directory.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.proxyBypass": {
 					"markdownDescription": "If not set, will inherit from the `no_proxy` or `NO_PROXY` environment variables. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "machine"
 				},
 				"coder.defaultUrl": {
 					"markdownDescription": "This will be shown in the URL prompt, along with the CODER_URL environment variable if set, for the user to select when logging in.",
 					"type": "string",
-					"default": ""
+					"default": "",
+					"scope": "application"
 				},
 				"coder.autologin": {
 					"markdownDescription": "Automatically log into the default URL when the extension is activated. coder.defaultUrl is preferred, otherwise the CODER_URL environment variable will be used. This setting has no effect if neither is set.",
 					"type": "boolean",
-					"default": false
+					"default": false,
+					"scope": "application"
 				},
 				"coder.disableNotifications": {
 					"markdownDescription": "Disable all notification prompts from the Coder deployment (workspace updates, scheduling reminders, resource alerts, etc.). Notifications are delivered by your Coder server and displayed by this extension.",
@@ -139,7 +153,8 @@
 				"coder.disableSignatureVerification": {
 					"markdownDescription": "Disable Coder CLI signature verification, which can be useful if you run an unsigned fork of the binary.",
 					"type": "boolean",
-					"default": false
+					"default": false,
+					"scope": "application"
 				},
 				"coder.experimental.oauth": {
 					"markdownDescription": "Enable [OAuth 2.1](https://coder.com/docs/admin/integrations/oauth2-provider) authentication. When enabled, you'll be prompted to choose between OAuth and session token authentication during login. OAuth provides automatic token refresh, eliminating the need to manually re-authenticate when your session expires.",
@@ -157,19 +172,22 @@
 					},
 					"default": [
 						"--disable-autostart"
-					]
+					],
+					"scope": "machine"
 				},
 				"coder.globalFlags": {
 					"markdownDescription": "Global flags to pass to every Coder CLI invocation. Enter each flag as a separate array item, in order. Do **not** include the `coder` command itself. See the [CLI reference](https://coder.com/docs/reference/cli) for available global flags.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`. For `--flag=value` items the expansion applies to the value half, so `--cfg=~/coder` works.\n\nFor `--header-command`, precedence is: `#coder.headerCommand#` setting, then `CODER_HEADER_COMMAND` environment variable, then the value specified here. The `--global-config` and `--use-keyring` flags are silently ignored as the extension manages them via `#coder.useKeyring#`.",
 					"type": "array",
 					"items": {
 						"type": "string"
-					}
+					},
+					"scope": "machine"
 				},
 				"coder.useKeyring": {
 					"markdownDescription": "Store session tokens in the OS keyring (macOS Keychain, Windows Credential Manager) instead of plaintext files. Requires CLI >= 2.29.0 (>= 2.31.0 to sync login from CLI to VS Code). This will attempt to sync between the CLI and VS Code since they share the same keyring entry. It will log you out of the CLI if you log out of the IDE, and vice versa. Has no effect on Linux.",
 					"type": "boolean",
-					"default": false
+					"default": false,
+					"scope": "application"
 				},
 				"coder.networkThreshold.latencyMs": {
 					"markdownDescription": "Latency threshold in milliseconds. A warning indicator appears in the status bar when latency exceeds this value. Set to `0` to disable.",


### PR DESCRIPTION
## Summary

Closes the SEC-200 attack path where a malicious `.vscode/settings.json` could override security-sensitive Coder settings — most notably the two command-execution settings (`coder.headerCommand`, `coder.tlsCertRefreshCommand`) called out in the original report.

The fix is metadata-only: each affected setting gets a `scope` of `application` or `machine`. VS Code drops workspace and folder values for both scopes, so a malicious workspace value never reaches our code. No runtime guard needed.

Also relaxes the release workflow so a fix can be cut from a release branch (paired with `release/v1.14.6` off `v1.14.5`).

## Why not `window` (the default)

VS Code's default scope is `window`, which lets **workspace and folder `settings.json` override the user setting** — exactly the SEC-200 vector. Any setting that can cause command execution, redirect network traffic, swap credentials, or substitute the CLI binary must not be controllable by a project file.

## `application` vs `machine`

Both block workspace/folder overrides, so both close SEC-200. They differ in Settings Sync behavior:

| Scope | Settable in | Synced via Settings Sync? |
|---|---|---|
| `application` | User settings only | **Yes** |
| `machine` | User OR per-machine remote settings | **No** |

We split by what the setting actually represents:

- **`application`** — user-wide preferences with no OS or filesystem coupling. Safe (and desirable) to sync across machines.
- **`machine`** — paths, shell commands, and network config that are inherently per-machine. A Windows `cmd.exe /c …` `headerCommand` syncing to a Mac would silently break; absolute paths like `tlsCaFile` don't translate.

This follows VS Code's [recommended scope semantics](https://code.visualstudio.com/api/references/contribution-points#contributes.configuration).

## Settings updated

**`application` (synced, user-wide preferences):**

| Setting | Why it's sensitive |
|---|---|
| `coder.insecure` | Disables TLS host verification |
| `coder.disableSignatureVerification` | Toggles CLI signature verification |
| `coder.enableDownloads` | Force-enables downloads in restricted environments |
| `coder.defaultUrl` | Default Coder deployment URL |
| `coder.autologin` | Combined with `defaultUrl` could auto-login elsewhere |
| `coder.useKeyring` | Credential-storage preference |

**`machine` (per-machine, not synced):**

| Setting | Why it's sensitive |
|---|---|
| `coder.headerCommand` | Runs an external shell command (SEC-200) |
| `coder.tlsCertRefreshCommand` | Runs an external shell command (SEC-200) |
| `coder.binarySource` | URL the Coder CLI is downloaded from |
| `coder.binaryDestination` | Filesystem path of the executed CLI binary |
| `coder.sshFlags` | SSH flags accept `-o ProxyCommand=…` (exec) |
| `coder.globalFlags` | Flags applied to every CLI invocation |
| `coder.tlsCertFile` | TLS client certificate path |
| `coder.tlsKeyFile` | TLS client key path |
| `coder.tlsCaFile` | TLS CA path (workspace-controlled CA → MITM) |
| `coder.tlsAltHost` | Hostname override for TLS verification |
| `coder.proxyLogDirectory` | Arbitrary write path |
| `coder.proxyBypass` | Routes traffic around the proxy |

Already `machine`: `coder.sshConfig`.

Settings deliberately left workspace-overridable (no security risk, project-local override is legitimate): `coder.networkThreshold.latencyMs`, `coder.httpClientLogLevel`, `coder.disableNotifications`, `coder.disableUpdateNotifications`, `coder.experimental.oauth`, `coder.telemetry.level`, `coder.telemetry.local`.

## CI change

Drops the `Verify tag is on main` step from `.github/workflows/release.yaml` so a security fix can be cut from a release branch (e.g. `release/v1.14.6` off `v1.14.5`) without first merging everything on `main`.

## Companion PR

A second PR cuts the same fix as **v1.14.6** off the `v1.14.5` tag for users on the stable channel. This PR delivers the change on `main`.
