### PR TITLE
fix(workspace-update): prompt for option drift and immutable params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@
   `coder update` non-interactively) now passes newly-required template
   parameters into the REST-API fallback build, instead of silently omitting
   them and letting the server reject the build.
+- Updating a workspace now re-prompts for an option or multi-select
+  parameter whose stored value is no longer one of the new template
+  version's options, instead of carrying a stale value forward and
+  failing the build. Immutable parameters without a stored value are
+  also surfaced, matching the dashboard's behaviour.
 - Updating a workspace from VS Code no longer hangs when the new template
   version requires parameters. The extension now prompts for any missing
   required values through VS Code input boxes and passes them to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
   parameter whose stored value is no longer one of the new template
   version's options, instead of carrying a stale value forward and
   failing the build. Immutable parameters without a stored value are
-  also surfaced, matching the dashboard's behaviour.
+  now prompted as well, closing a gap with the web dashboard.
 - Updating a workspace from VS Code no longer hangs when the new template
   version requires parameters. The extension now prompts for any missing
   required values through VS Code input boxes and passes them to

--- a/src/api/updateParameters.ts
+++ b/src/api/updateParameters.ts
@@ -7,6 +7,16 @@ import type {
 	WorkspaceBuildParameter,
 } from "coder/site/src/api/typesGenerated";
 
+const MAX_VALUE_LEN = 60;
+const MAX_LIST_ITEMS = 5;
+
+interface PromptSpec {
+	/** Drift note prepended to the parameter's description in the prompt placeholder. */
+	driftNote?: string;
+	/** Surviving picks to pre-check on a multi-select drift re-prompt. */
+	preselect?: string[];
+}
+
 /** Thrown when the user dismisses a parameter prompt. */
 export class WorkspaceUpdateCancelledError extends Error {
 	constructor() {
@@ -31,17 +41,15 @@ export async function collectUpdateParameters(
 		restClient.getWorkspaceBuildParameters(workspace.latest_build.id),
 	]);
 	const stored = new Map(currentValues.map((p) => [p.name, p.value]));
-	const toPrompt = newParams.filter((p) => needsPrompt(p, stored.get(p.name)));
+	const toPrompt = newParams.flatMap((param) => {
+		const spec = promptSpec(param, stored.get(param.name));
+		return spec ? [{ param, spec }] : [];
+	});
 
 	const collected: WorkspaceBuildParameter[] = [];
 	for (let i = 0; i < toPrompt.length; i++) {
-		const param = toPrompt[i];
-		const value = await promptForParameter(
-			param,
-			i + 1,
-			toPrompt.length,
-			stored.get(param.name),
-		);
+		const { param, spec } = toPrompt[i];
+		const value = await promptForParameter(param, spec, i + 1, toPrompt.length);
 		if (value === undefined) {
 			throw new WorkspaceUpdateCancelledError();
 		}
@@ -50,48 +58,83 @@ export async function collectUpdateParameters(
 	return collected;
 }
 
-/** Based on the dashboard's `getMissingParameters` (coder/site/src/api/api.ts). */
-function needsPrompt(
+/**
+ * Returns a `PromptSpec` if the parameter needs a fresh answer, else `undefined`.
+ *
+ * Based on the dashboard's `getMissingParameters` (coder/site/src/api/api.ts),
+ * which is the legacy-params check. Dynamic-parameter templates rely on
+ * server-side validation via the `/dynamic-parameters` WebSocket.
+ */
+function promptSpec(
 	param: TemplateVersionParameter,
 	storedValue: string | undefined,
-): boolean {
+): PromptSpec | undefined {
 	if (storedValue === undefined) {
-		// Accepting the default locks it in.
-		if (!param.mutable) return true;
-		// Deviation: dashboard prompts mutable+required even when a default
-		// exists; we skip so the server can apply the default during
-		// auto-update without surfacing a modal.
-		return param.required && !param.default_value;
+		// Immutable: prompt before the default is locked in for good.
+		if (!param.mutable) return {};
+		// `required` is false whenever a default exists (TF provider sets
+		// `optional=true`), so no separate default_value check is needed.
+		return param.required ? {} : undefined;
 	}
-	if (param.options.length === 0) return false;
-
-	const validValues = new Set(param.options.map((o) => o.value));
+	if (param.options.length === 0) return undefined;
+	const valid = new Set(param.options.map((o) => o.value));
 	if (param.form_type === "multi-select") {
 		// Beyond dashboard: detect multi-select drift too.
 		const picks = parseMultiSelectValue(storedValue);
-		return picks === null || picks.some((v) => !validValues.has(v));
+		if (picks === null) {
+			return {
+				driftNote: "No previous selections recovered.",
+				preselect: [],
+			};
+		}
+		const drifted = picks.filter((v) => !valid.has(v));
+		if (drifted.length === 0) return undefined;
+		return {
+			driftNote: `Previous selections no longer available: ${formatDriftList(drifted)}.`,
+			preselect: picks.filter((v) => valid.has(v)),
+		};
 	}
-	return !validValues.has(storedValue);
+	if (valid.has(storedValue)) return undefined;
+	const driftNote =
+		storedValue === ""
+			? "No previous value was set."
+			: `Previous value ${formatValue(storedValue)} is no longer available.`;
+	return { driftNote };
 }
 
 /** Multi-select values are stored as a JSON-encoded string array. */
 function parseMultiSelectValue(raw: string): string[] | null {
-	let parsed: unknown;
 	try {
-		parsed = JSON.parse(raw);
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) && parsed.every((v) => typeof v === "string")
+			? parsed
+			: null;
 	} catch {
 		return null;
 	}
-	return Array.isArray(parsed) && parsed.every((v) => typeof v === "string")
-		? parsed
-		: null;
+}
+
+/** Truncates and JSON-quotes a value for safe display in a placeholder. */
+function formatValue(value: string): string {
+	const truncated =
+		value.length > MAX_VALUE_LEN
+			? `${value.slice(0, MAX_VALUE_LEN)}...`
+			: value;
+	return JSON.stringify(truncated);
+}
+
+/** Joins drifted values with per-item and list-length caps. */
+function formatDriftList(values: string[]): string {
+	const head = values.slice(0, MAX_LIST_ITEMS).map(formatValue).join(", ");
+	const extra = values.length - MAX_LIST_ITEMS;
+	return extra > 0 ? `${head}, +${extra} more` : head;
 }
 
 function promptForParameter(
 	param: TemplateVersionParameter,
+	spec: PromptSpec,
 	step: number,
 	totalSteps: number,
-	storedValue: string | undefined,
 ): Promise<string | undefined> {
 	const title = param.display_name || param.name;
 	const items = quickPickItems(param);
@@ -102,13 +145,15 @@ function promptForParameter(
 		qp.title = title;
 		qp.step = step;
 		qp.totalSteps = totalSteps;
-		qp.placeholder = param.description_plaintext;
+		qp.placeholder = [spec.driftNote, param.description_plaintext]
+			.filter((s) => s)
+			.join(" ");
 		qp.items = items;
 		qp.canSelectMany = multi;
 		qp.ignoreFocusOut = true;
-		if (multi && storedValue !== undefined) {
-			const previous = new Set(parseMultiSelectValue(storedValue) ?? []);
-			qp.selectedItems = items.filter((item) => previous.has(item.value));
+		const { preselect } = spec;
+		if (multi && preselect) {
+			qp.selectedItems = items.filter((item) => preselect.includes(item.value));
 		}
 		return collectInput(qp, () => {
 			if (multi) {

--- a/src/api/updateParameters.ts
+++ b/src/api/updateParameters.ts
@@ -36,7 +36,12 @@ export async function collectUpdateParameters(
 	const collected: WorkspaceBuildParameter[] = [];
 	for (let i = 0; i < toPrompt.length; i++) {
 		const param = toPrompt[i];
-		const value = await promptForParameter(param, i + 1, toPrompt.length);
+		const value = await promptForParameter(
+			param,
+			i + 1,
+			toPrompt.length,
+			stored.get(param.name),
+		);
 		if (value === undefined) {
 			throw new WorkspaceUpdateCancelledError();
 		}
@@ -45,20 +50,24 @@ export async function collectUpdateParameters(
 	return collected;
 }
 
-/** Mirrors the dashboard's `getMissingParameters` (coder/site/src/api/api.ts). */
+/** Based on the dashboard's `getMissingParameters` (coder/site/src/api/api.ts). */
 function needsPrompt(
 	param: TemplateVersionParameter,
 	storedValue: string | undefined,
 ): boolean {
 	if (storedValue === undefined) {
-		const mustBeSet = (param.mutable && param.required) || !param.mutable;
-		// Deviation: skip when a template default exists; server falls back to it.
-		return mustBeSet && !param.default_value;
+		// Accepting the default locks it in.
+		if (!param.mutable) return true;
+		// Deviation: dashboard prompts mutable+required even when a default
+		// exists; we skip so the server can apply the default during
+		// auto-update without surfacing a modal.
+		return param.required && !param.default_value;
 	}
 	if (param.options.length === 0) return false;
 
 	const validValues = new Set(param.options.map((o) => o.value));
 	if (param.form_type === "multi-select") {
+		// Beyond dashboard: detect multi-select drift too.
 		const picks = parseMultiSelectValue(storedValue);
 		return picks === null || picks.some((v) => !validValues.has(v));
 	}
@@ -67,24 +76,22 @@ function needsPrompt(
 
 /** Multi-select values are stored as a JSON-encoded string array. */
 function parseMultiSelectValue(raw: string): string[] | null {
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(raw);
-		if (
-			Array.isArray(parsed) &&
-			parsed.every((v): v is string => typeof v === "string")
-		) {
-			return parsed;
-		}
+		parsed = JSON.parse(raw);
 	} catch {
-		// invalid JSON
+		return null;
 	}
-	return null;
+	return Array.isArray(parsed) && parsed.every((v) => typeof v === "string")
+		? parsed
+		: null;
 }
 
 function promptForParameter(
 	param: TemplateVersionParameter,
 	step: number,
 	totalSteps: number,
+	storedValue: string | undefined,
 ): Promise<string | undefined> {
 	const title = param.display_name || param.name;
 	const items = quickPickItems(param);
@@ -99,11 +106,16 @@ function promptForParameter(
 		qp.items = items;
 		qp.canSelectMany = multi;
 		qp.ignoreFocusOut = true;
+		if (multi && storedValue !== undefined) {
+			const previous = new Set(parseMultiSelectValue(storedValue) ?? []);
+			qp.selectedItems = items.filter((item) => previous.has(item.value));
+		}
 		return collectInput(qp, () => {
 			if (multi) {
-				return qp.selectedItems.length > 0
-					? JSON.stringify(qp.selectedItems.map((i) => i.value))
-					: undefined;
+				if (qp.selectedItems.length === 0) {
+					return param.required ? undefined : "[]";
+				}
+				return JSON.stringify(qp.selectedItems.map((i) => i.value));
 			}
 			return qp.selectedItems[0]?.value;
 		});

--- a/src/api/updateParameters.ts
+++ b/src/api/updateParameters.ts
@@ -16,9 +16,9 @@ export class WorkspaceUpdateCancelledError extends Error {
 }
 
 /**
- * Prompts the user for any newly-required template parameters and returns the
- * collected `{ name, value }` pairs. Throws `WorkspaceUpdateCancelledError` if
- * the user dismisses a prompt.
+ * Prompts the user for any template parameters that the new version needs
+ * answered, and returns the collected `{ name, value }` pairs. Throws
+ * `WorkspaceUpdateCancelledError` if the user dismisses a prompt.
  */
 export async function collectUpdateParameters(
 	restClient: Api,
@@ -30,11 +30,8 @@ export async function collectUpdateParameters(
 		),
 		restClient.getWorkspaceBuildParameters(workspace.latest_build.id),
 	]);
-	const candidates = newParams.filter((p) => p.required && !p.default_value);
-	if (candidates.length === 0) return [];
-
-	const existing = new Set(currentValues.map((p) => p.name));
-	const toPrompt = candidates.filter((p) => !existing.has(p.name));
+	const stored = new Map(currentValues.map((p) => [p.name, p.value]));
+	const toPrompt = newParams.filter((p) => needsPrompt(p, stored.get(p.name)));
 
 	const collected: WorkspaceBuildParameter[] = [];
 	for (let i = 0; i < toPrompt.length; i++) {
@@ -46,6 +43,42 @@ export async function collectUpdateParameters(
 		collected.push({ name: param.name, value });
 	}
 	return collected;
+}
+
+/** Mirrors the dashboard's `getMissingParameters` (coder/site/src/api/api.ts). */
+function needsPrompt(
+	param: TemplateVersionParameter,
+	storedValue: string | undefined,
+): boolean {
+	if (storedValue === undefined) {
+		const mustBeSet = (param.mutable && param.required) || !param.mutable;
+		// Deviation: skip when a template default exists; server falls back to it.
+		return mustBeSet && !param.default_value;
+	}
+	if (param.options.length === 0) return false;
+
+	const validValues = new Set(param.options.map((o) => o.value));
+	if (param.form_type === "multi-select") {
+		const picks = parseMultiSelectValue(storedValue);
+		return picks === null || picks.some((v) => !validValues.has(v));
+	}
+	return !validValues.has(storedValue);
+}
+
+/** Multi-select values are stored as a JSON-encoded string array. */
+function parseMultiSelectValue(raw: string): string[] | null {
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (
+			Array.isArray(parsed) &&
+			parsed.every((v): v is string => typeof v === "string")
+		) {
+			return parsed;
+		}
+	} catch {
+		// invalid JSON
+	}
+	return null;
 }
 
 function promptForParameter(

--- a/test/unit/api/updateParameters.test.ts
+++ b/test/unit/api/updateParameters.test.ts
@@ -210,7 +210,9 @@ describe("collectUpdateParameters", () => {
 		const { restClient, workspace } = createCollectCtx(
 			[
 				{ name: "existing" },
-				{ name: "with_default", default_value: "foo" },
+				// Required is false when a default is set; the TF provider
+				// auto-sets optional=true whenever a default is provided.
+				{ name: "with_default", required: false, default_value: "foo" },
 				{ name: "optional", required: false },
 			],
 			[{ name: "existing", value: "kept" }],
@@ -267,125 +269,88 @@ describe("collectUpdateParameters", () => {
 		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
 	});
 
-	it("re-prompts when a stored option value drifted out of the new options", async () => {
-		const optionParam: Partial<TemplateVersionParameter> = {
-			name: "size",
-			options: [
-				{ name: "Small", description: "", value: "s", icon: "" },
-				{ name: "Large", description: "", value: "l", icon: "" },
-			],
-		};
+	const US = { name: "US", description: "", value: "us", icon: "" };
+	const EU = { name: "EU", description: "", value: "eu", icon: "" };
+	const SMALL = { name: "Small", description: "", value: "s", icon: "" };
+	const LARGE = { name: "Large", description: "", value: "l", icon: "" };
+
+	it.each<{
+		kind: string;
+		param: Partial<TemplateVersionParameter>;
+		storedValue: string;
+		pick: string;
+		expected: string;
+	}>([
+		{
+			kind: "single-select drift",
+			param: { name: "size", options: [SMALL, LARGE] },
+			storedValue: "xl-retired",
+			pick: "l",
+			expected: "l",
+		},
+		{
+			kind: "single-select drift with a template default",
+			param: { name: "size", default_value: "s", options: [SMALL, LARGE] },
+			storedValue: "xl-retired",
+			pick: "l",
+			expected: "l",
+		},
+		{
+			kind: "immutable single-select drift",
+			param: { name: "zone", mutable: false, options: [US] },
+			storedValue: "eu-retired",
+			pick: "us",
+			expected: "us",
+		},
+		{
+			kind: "multi-select with a drifted pick",
+			param: { name: "regions", form_type: "multi-select", options: [US, EU] },
+			storedValue: '["us","apac-retired"]',
+			pick: "us",
+			expected: '["us"]',
+		},
+		{
+			kind: "multi-select with a non-JSON stored value",
+			param: { name: "regions", form_type: "multi-select", options: [US] },
+			storedValue: "not-json",
+			pick: "us",
+			expected: '["us"]',
+		},
+	])("re-prompts on $kind", async ({ param, storedValue, pick, expected }) => {
 		const { restClient, workspace } = createCollectCtx(
-			[optionParam],
-			[{ name: "size", value: "xl-retired" }],
+			[param],
+			[{ name: param.name!, value: storedValue }],
 		);
 		const qi = mockCreateQuickPick();
 
 		const result = collectUpdateParameters(restClient, workspace);
 		await waitShown(qi);
-		qi.accept({ selectedItems: [{ value: "l" }] });
-
-		await expect(result).resolves.toEqual([{ name: "size", value: "l" }]);
-	});
-
-	it("re-prompts on drift even when the template parameter has a default value", async () => {
-		const optionParam: Partial<TemplateVersionParameter> = {
-			name: "size",
-			default_value: "s",
-			options: [
-				{ name: "Small", description: "", value: "s", icon: "" },
-				{ name: "Large", description: "", value: "l", icon: "" },
-			],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[optionParam],
-			[{ name: "size", value: "xl-retired" }],
-		);
-		const qi = mockCreateQuickPick();
-
-		const result = collectUpdateParameters(restClient, workspace);
-		await waitShown(qi);
-		qi.accept({ selectedItems: [{ value: "l" }] });
-
-		await expect(result).resolves.toEqual([{ name: "size", value: "l" }]);
-	});
-
-	it("re-prompts on drift for an immutable param too", async () => {
-		const optionParam: Partial<TemplateVersionParameter> = {
-			name: "zone",
-			mutable: false,
-			options: [{ name: "US", description: "", value: "us", icon: "" }],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[optionParam],
-			[{ name: "zone", value: "eu-retired" }],
-		);
-		const qi = mockCreateQuickPick();
-
-		const result = collectUpdateParameters(restClient, workspace);
-		await waitShown(qi);
-		qi.accept({ selectedItems: [{ value: "us" }] });
-
-		await expect(result).resolves.toEqual([{ name: "zone", value: "us" }]);
-	});
-
-	it("re-prompts a multi-select when any stored pick drifted out", async () => {
-		const multiParam: Partial<TemplateVersionParameter> = {
-			name: "regions",
-			form_type: "multi-select",
-			options: [
-				{ name: "US", description: "", value: "us", icon: "" },
-				{ name: "EU", description: "", value: "eu", icon: "" },
-			],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[multiParam],
-			[{ name: "regions", value: '["us","apac-retired"]' }],
-		);
-		const qi = mockCreateQuickPick();
-
-		const result = collectUpdateParameters(restClient, workspace);
-		await waitShown(qi);
-		qi.accept({ selectedItems: [{ value: "us" }] });
+		qi.accept({ selectedItems: [{ value: pick }] });
 
 		await expect(result).resolves.toEqual([
-			{ name: "regions", value: '["us"]' },
+			{ name: param.name, value: expected },
 		]);
 	});
 
-	it("re-prompts a multi-select when the stored value isn't a JSON string array", async () => {
-		const multiParam: Partial<TemplateVersionParameter> = {
-			name: "regions",
-			form_type: "multi-select",
-			options: [{ name: "US", description: "", value: "us", icon: "" }],
-		};
+	it.each<{
+		kind: string;
+		param: Partial<TemplateVersionParameter>;
+		storedValue: string;
+	}>([
+		{
+			kind: "every multi-select pick is still in the new options",
+			param: { name: "regions", form_type: "multi-select", options: [US, EU] },
+			storedValue: '["us","eu"]',
+		},
+		{
+			kind: "the multi-select stored value is an empty JSON array",
+			param: { name: "regions", form_type: "multi-select", options: [US] },
+			storedValue: "[]",
+		},
+	])("skips when $kind", async ({ param, storedValue }) => {
 		const { restClient, workspace } = createCollectCtx(
-			[multiParam],
-			[{ name: "regions", value: "not-json" }],
-		);
-		const qi = mockCreateQuickPick();
-
-		const result = collectUpdateParameters(restClient, workspace);
-		await waitShown(qi);
-		qi.accept({ selectedItems: [{ value: "us" }] });
-
-		await expect(result).resolves.toEqual([
-			{ name: "regions", value: '["us"]' },
-		]);
-	});
-
-	it("skips a multi-select when every stored pick is still in the new options", async () => {
-		const multiParam: Partial<TemplateVersionParameter> = {
-			name: "regions",
-			form_type: "multi-select",
-			options: [
-				{ name: "US", description: "", value: "us", icon: "" },
-				{ name: "EU", description: "", value: "eu", icon: "" },
-			],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[multiParam],
-			[{ name: "regions", value: '["us","eu"]' }],
+			[param],
+			[{ name: param.name!, value: storedValue }],
 		);
 
 		await expect(
@@ -394,49 +359,108 @@ describe("collectUpdateParameters", () => {
 		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
 	});
 
-	it("skips a multi-select when the stored value is an empty JSON array", async () => {
-		const multiParam: Partial<TemplateVersionParameter> = {
-			name: "regions",
-			form_type: "multi-select",
-			options: [{ name: "US", description: "", value: "us", icon: "" }],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[multiParam],
-			[{ name: "regions", value: "[]" }],
-		);
+	it.each<{
+		kind: string;
+		param: Partial<TemplateVersionParameter>;
+		storedValue: string;
+		expectedPlaceholder?: string;
+		expectedPreselect?: Array<{ label: string; value: string }>;
+		picks: string[];
+		expected: string;
+	}>([
+		{
+			kind: "single-select drift, appended to the description",
+			param: {
+				name: "size",
+				description_plaintext: "Pick a t-shirt size.",
+				options: [SMALL, LARGE],
+			},
+			storedValue: "xl-retired",
+			expectedPlaceholder:
+				'Previous value "xl-retired" is no longer available. Pick a t-shirt size.',
+			picks: ["l"],
+			expected: "l",
+		},
+		{
+			kind: "single-select with an empty stored value",
+			param: { name: "size", options: [SMALL] },
+			storedValue: "",
+			expectedPlaceholder: "No previous value was set.",
+			picks: ["s"],
+			expected: "s",
+		},
+		{
+			kind: "multi-select drift, escaping quotes/commas and pre-selecting survivors",
+			param: { name: "regions", form_type: "multi-select", options: [US, EU] },
+			storedValue: '["us","a,b","c\\"d"]',
+			expectedPlaceholder:
+				'Previous selections no longer available: "a,b", "c\\"d".',
+			expectedPreselect: [{ label: "US", value: "us" }],
+			picks: ["us"],
+			expected: '["us"]',
+		},
+		{
+			kind: "multi-select drift, pre-selecting survivors without placeholder check",
+			param: { name: "regions", form_type: "multi-select", options: [US, EU] },
+			storedValue: '["us","apac-retired"]',
+			expectedPreselect: [{ label: "US", value: "us" }],
+			picks: ["us", "eu"],
+			expected: '["us","eu"]',
+		},
+		{
+			kind: "multi-select drift with many drifted picks, capped with +N more",
+			param: { name: "regions", form_type: "multi-select", options: [US] },
+			storedValue: JSON.stringify(["d1", "d2", "d3", "d4", "d5", "d6", "d7"]),
+			expectedPlaceholder:
+				'Previous selections no longer available: "d1", "d2", "d3", "d4", "d5", +2 more.',
+			picks: ["us"],
+			expected: '["us"]',
+		},
+		{
+			kind: "multi-select with an unparseable stored value",
+			param: { name: "regions", form_type: "multi-select", options: [US] },
+			storedValue: "not-json",
+			expectedPlaceholder: "No previous selections recovered.",
+			expectedPreselect: [],
+			picks: ["us"],
+			expected: '["us"]',
+		},
+	])(
+		"prompts on $kind",
+		async ({
+			param,
+			storedValue,
+			expectedPlaceholder,
+			expectedPreselect,
+			picks,
+			expected,
+		}) => {
+			const { restClient, workspace } = createCollectCtx(
+				[param],
+				[{ name: param.name!, value: storedValue }],
+			);
+			const qi = mockCreateQuickPick();
 
-		await expect(
-			collectUpdateParameters(restClient, workspace),
-		).resolves.toEqual([]);
-		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
-	});
-
-	it("pre-selects still-valid picks on a multi-select drift re-prompt", async () => {
-		const multiParam: Partial<TemplateVersionParameter> = {
-			name: "regions",
-			form_type: "multi-select",
-			options: [
-				{ name: "US", description: "", value: "us", icon: "" },
-				{ name: "EU", description: "", value: "eu", icon: "" },
-			],
-		};
-		const { restClient, workspace } = createCollectCtx(
-			[multiParam],
-			[{ name: "regions", value: '["us","apac-retired"]' }],
-		);
-		const qi = mockCreateQuickPick();
-
-		const result = collectUpdateParameters(restClient, workspace);
-		await waitShown(qi);
-		expect(qi.mock.selectedItems).toEqual([
-			{ label: "US", description: "", value: "us" },
-		]);
-		qi.accept({ selectedItems: [{ value: "us" }, { value: "eu" }] });
-
-		await expect(result).resolves.toEqual([
-			{ name: "regions", value: '["us","eu"]' },
-		]);
-	});
+			const result = collectUpdateParameters(restClient, workspace);
+			await waitShown(qi);
+			if (expectedPlaceholder !== undefined) {
+				expect(qi.mock.placeholder).toBe(expectedPlaceholder);
+			}
+			if (expectedPreselect !== undefined) {
+				expect(qi.mock.selectedItems).toEqual(
+					expectedPreselect.map((p) => ({
+						label: p.label,
+						description: "",
+						value: p.value,
+					})),
+				);
+			}
+			qi.accept({ selectedItems: picks.map((v) => ({ value: v })) });
+			await expect(result).resolves.toEqual([
+				{ name: param.name, value: expected },
+			]);
+		},
+	);
 
 	it("keeps the prompt open on an empty submission for a required multi-select", async () => {
 		const multiParam: Partial<TemplateVersionParameter> = {

--- a/test/unit/api/updateParameters.test.ts
+++ b/test/unit/api/updateParameters.test.ts
@@ -222,6 +222,145 @@ describe("collectUpdateParameters", () => {
 		expect(vscode.window.createInputBox).not.toHaveBeenCalled();
 	});
 
+	it("prompts an immutable param that has no stored value (even if not required)", async () => {
+		const { restClient, workspace } = createCollectCtx([
+			{ name: "zone", required: false, mutable: false },
+		]);
+		const qi = mockCreateInputBox();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ value: "us-east" });
+
+		await expect(result).resolves.toEqual([{ name: "zone", value: "us-east" }]);
+	});
+
+	it("skips an option param whose stored value is still in the new options", async () => {
+		const optionParam: Partial<TemplateVersionParameter> = {
+			name: "size",
+			options: [
+				{ name: "Small", description: "", value: "s", icon: "" },
+				{ name: "Large", description: "", value: "l", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[optionParam],
+			[{ name: "size", value: "l" }],
+		);
+
+		await expect(
+			collectUpdateParameters(restClient, workspace),
+		).resolves.toEqual([]);
+		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
+	});
+
+	it("re-prompts when a stored option value drifted out of the new options", async () => {
+		const optionParam: Partial<TemplateVersionParameter> = {
+			name: "size",
+			options: [
+				{ name: "Small", description: "", value: "s", icon: "" },
+				{ name: "Large", description: "", value: "l", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[optionParam],
+			[{ name: "size", value: "xl-retired" }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [{ value: "l" }] });
+
+		await expect(result).resolves.toEqual([{ name: "size", value: "l" }]);
+	});
+
+	it("re-prompts on drift even when the template parameter has a default value", async () => {
+		const optionParam: Partial<TemplateVersionParameter> = {
+			name: "size",
+			default_value: "s",
+			options: [
+				{ name: "Small", description: "", value: "s", icon: "" },
+				{ name: "Large", description: "", value: "l", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[optionParam],
+			[{ name: "size", value: "xl-retired" }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [{ value: "l" }] });
+
+		await expect(result).resolves.toEqual([{ name: "size", value: "l" }]);
+	});
+
+	it("re-prompts on drift for an immutable param too", async () => {
+		const optionParam: Partial<TemplateVersionParameter> = {
+			name: "zone",
+			mutable: false,
+			options: [{ name: "US", description: "", value: "us", icon: "" }],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[optionParam],
+			[{ name: "zone", value: "eu-retired" }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [{ value: "us" }] });
+
+		await expect(result).resolves.toEqual([{ name: "zone", value: "us" }]);
+	});
+
+	it("re-prompts a multi-select when any stored pick drifted out", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			form_type: "multi-select",
+			options: [
+				{ name: "US", description: "", value: "us", icon: "" },
+				{ name: "EU", description: "", value: "eu", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: '["us","apac-retired"]' }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [{ value: "us" }] });
+
+		await expect(result).resolves.toEqual([
+			{ name: "regions", value: '["us"]' },
+		]);
+	});
+
+	it("re-prompts a multi-select when the stored value isn't a JSON string array", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			form_type: "multi-select",
+			options: [{ name: "US", description: "", value: "us", icon: "" }],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: "not-json" }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [{ value: "us" }] });
+
+		await expect(result).resolves.toEqual([
+			{ name: "regions", value: '["us"]' },
+		]);
+	});
+
 	it("throws WorkspaceUpdateCancelledError when the prompt is dismissed", async () => {
 		const { restClient, workspace } = createCollectCtx([{}]);
 		const qi = mockCreateInputBox();

--- a/test/unit/api/updateParameters.test.ts
+++ b/test/unit/api/updateParameters.test.ts
@@ -235,6 +235,19 @@ describe("collectUpdateParameters", () => {
 		await expect(result).resolves.toEqual([{ name: "zone", value: "us-east" }]);
 	});
 
+	it("prompts an immutable param even when a template default exists", async () => {
+		const { restClient, workspace } = createCollectCtx([
+			{ name: "zone", mutable: false, default_value: "us-east" },
+		]);
+		const qi = mockCreateInputBox();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ value: "us-west" });
+
+		await expect(result).resolves.toEqual([{ name: "zone", value: "us-west" }]);
+	});
+
 	it("skips an option param whose stored value is still in the new options", async () => {
 		const optionParam: Partial<TemplateVersionParameter> = {
 			name: "size",
@@ -359,6 +372,114 @@ describe("collectUpdateParameters", () => {
 		await expect(result).resolves.toEqual([
 			{ name: "regions", value: '["us"]' },
 		]);
+	});
+
+	it("skips a multi-select when every stored pick is still in the new options", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			form_type: "multi-select",
+			options: [
+				{ name: "US", description: "", value: "us", icon: "" },
+				{ name: "EU", description: "", value: "eu", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: '["us","eu"]' }],
+		);
+
+		await expect(
+			collectUpdateParameters(restClient, workspace),
+		).resolves.toEqual([]);
+		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
+	});
+
+	it("skips a multi-select when the stored value is an empty JSON array", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			form_type: "multi-select",
+			options: [{ name: "US", description: "", value: "us", icon: "" }],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: "[]" }],
+		);
+
+		await expect(
+			collectUpdateParameters(restClient, workspace),
+		).resolves.toEqual([]);
+		expect(vscode.window.createQuickPick).not.toHaveBeenCalled();
+	});
+
+	it("pre-selects still-valid picks on a multi-select drift re-prompt", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			form_type: "multi-select",
+			options: [
+				{ name: "US", description: "", value: "us", icon: "" },
+				{ name: "EU", description: "", value: "eu", icon: "" },
+			],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: '["us","apac-retired"]' }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		expect(qi.mock.selectedItems).toEqual([
+			{ label: "US", description: "", value: "us" },
+		]);
+		qi.accept({ selectedItems: [{ value: "us" }, { value: "eu" }] });
+
+		await expect(result).resolves.toEqual([
+			{ name: "regions", value: '["us","eu"]' },
+		]);
+	});
+
+	it("keeps the prompt open on an empty submission for a required multi-select", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			required: true,
+			form_type: "multi-select",
+			options: [{ name: "US", description: "", value: "us", icon: "" }],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: '["apac-retired"]' }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [] });
+		expect(qi.mock.dispose).not.toHaveBeenCalled();
+		qi.accept({ selectedItems: [{ value: "us" }] });
+
+		await expect(result).resolves.toEqual([
+			{ name: "regions", value: '["us"]' },
+		]);
+	});
+
+	it("accepts an empty selection on a non-required multi-select re-prompt", async () => {
+		const multiParam: Partial<TemplateVersionParameter> = {
+			name: "regions",
+			required: false,
+			form_type: "multi-select",
+			options: [{ name: "US", description: "", value: "us", icon: "" }],
+		};
+		const { restClient, workspace } = createCollectCtx(
+			[multiParam],
+			[{ name: "regions", value: '["apac-retired"]' }],
+		);
+		const qi = mockCreateQuickPick();
+
+		const result = collectUpdateParameters(restClient, workspace);
+		await waitShown(qi);
+		qi.accept({ selectedItems: [] });
+
+		await expect(result).resolves.toEqual([{ name: "regions", value: "[]" }]);
 	});
 
 	it("throws WorkspaceUpdateCancelledError when the prompt is dismissed", async () => {


### PR DESCRIPTION
Aligns workspace-update parameter collection with the dashboard's `getMissingParameters` ([coder/site/src/api/api.ts:39](https://github.com/coder/coder/blob/main/site/src/api/api.ts#L39)). Two cases previously slipped through and produced server-side build rejections with no UI:

- A stored option/multi-select value that is no longer one of the new template version's options (option-value drift) was carried forward verbatim.
- An immutable parameter without a stored value was never prompted, even though it can never be set after the first build.

`promptSpec(param, storedValue)` centralizes the decision; multi-select drift is also detected (parsing the JSON-encoded stored value) because the dashboard explicitly skips multi-select.

On a multi-select drift re-prompt the QuickPick now pre-selects the picks that are still valid, so the user does not have to re-select what was already correct. Non-required multi-selects can now also submit zero picks (previously the prompt stayed open with no way to express "none").

### Behavior matrix

| Case | Behavior | Vs. dashboard |
|---|---|---|
| No stored value, mutable + required, no default | Prompt | match |
| No stored value, mutable + required, has default | n/a | **unreachable** (TF provider auto-sets `optional=true` when a default exists, so `required && default_value` cannot co-occur) |
| No stored value, immutable | Prompt | match |
| No stored value, not required (mutable) | Skip | match |
| Stored value still in new options | Skip | match |
| Single-select drift | Prompt (no preselect) | match |
| Multi-select drift | Prompt with valid picks pre-selected | **beyond** (dashboard skips multi-select) |
| Multi-select stored value not valid JSON | Prompt | beyond (defensive) |
| Non-required multi-select submitted empty | Accept as `"[]"` | n/a (pre-existing prompt code) |

Note: this is the legacy-params check. Templates using dynamic parameters with conditional `required`, conditionally-appearing parameters, or dynamically-narrowed option lists are not covered; tracked in [#972](https://github.com/coder/vscode-coder/issues/972).

### Files

- `src/api/updateParameters.ts`: `promptSpec`, `parseMultiSelectValue`, `formatValue`/`formatDriftList`; `promptForParameter` consumes a `PromptSpec` carrying the drift note and surviving picks.
- `test/unit/api/updateParameters.test.ts`: cases covering single/multi drift, immutable + default, multi-select happy path, empty-array stored value, empty submission, preselect verification, drift-list capping, unparseable JSON sentinel, empty-stored-value sentinel, and description-merging.
- `CHANGELOG.md`: user-facing entry under Unreleased > Fixed.
