### PR TITLE
feat(telemetry): halve JSONL storage, cap SSH sample rate, restructure OTLP export

### DIFF
--- a/src/core/container.ts
+++ b/src/core/container.ts
@@ -53,17 +53,16 @@ export class ServiceContainer implements vscode.Disposable {
 			this.logger,
 		);
 
-		const sessionId = newSessionId();
+		const session = buildSession(
+			extractExtensionVersion(context.extension.packageJSON),
+			newSessionId(),
+		);
 		const localJsonlSink = LocalJsonlSink.start(
 			{
 				baseDir: this.pathResolver.getTelemetryPath(),
-				sessionId,
+				session,
 			},
 			this.logger,
-		);
-		const session = buildSession(
-			extractExtensionVersion(context.extension.packageJSON),
-			sessionId,
 		);
 		this.telemetryService = new TelemetryService(
 			session,

--- a/src/instrumentation/CONVENTIONS.md
+++ b/src/instrumentation/CONVENTIONS.md
@@ -115,6 +115,8 @@ Coder's own pipeline, so a bare `cache_source` can't collide with a future OTel
 - **Measurements** are raw numbers. Don't pre-bucket into string labels: both
   export as record attributes, and a query can bucket the raw number at read
   time. `result` and `durationMs` are framework-managed and cannot be set.
+  `durationMs` never reaches OTLP; the export derives span start/end times
+  from it.
 - **Units.** There is no unit field at emit time, so put the unit in the
   measurement key as a `_ms` / `_seconds` / `_mbits` suffix, the same way for
   every event.

--- a/src/instrumentation/EVENTS.md
+++ b/src/instrumentation/EVENTS.md
@@ -404,13 +404,13 @@ Emitted by `HttpRequestsTelemetry`, which lives with the HTTP logging in
 `src/logging`. A per-minute rollup of REST traffic, one event per method and
 route bucket.
 
-| Attribute                                                              | Values                                                              |
-| ---------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `method`                                                               | HTTP method                                                         |
-| `route`                                                                | normalized route (ids replaced by placeholders)                     |
-| `window_seconds` (measurement)                                         | actual window length                                                |
-| `count.1xx` through `count.5xx`, `count.network_error` (measurements)  | export as cumulative counters with unit `{request}`                 |
-| `duration.p50_ms`, `duration.p95_ms`, `duration.p99_ms` (measurements) | export as gauges (`http.requests.duration.p50` etc.) with unit `ms` |
+| Attribute                                                              | Values                                                                                                               |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `method`                                                               | HTTP method                                                                                                          |
+| `route`                                                                | normalized route (ids replaced by placeholders)                                                                      |
+| `window_seconds` (measurement)                                         | actual window length                                                                                                 |
+| `count.1xx` through `count.5xx`, `count.network_error` (measurements)  | omitted when 0; export as cumulative counters with unit `{request}`                                                  |
+| `duration.p50_ms`, `duration.p95_ms`, `duration.p99_ms` (measurements) | omitted when no request carried timing metadata; export as gauges (`http.requests.duration.p50` etc.) with unit `ms` |
 
 ## WebSocket connections
 

--- a/src/instrumentation/EVENTS.md
+++ b/src/instrumentation/EVENTS.md
@@ -82,9 +82,8 @@ context.
 On OTLP export the context becomes resource attributes (`service.name:
 coder-vscode-extension`, `service.version`, `service.instance.id`, `host.id`,
 `host.arch`, `os.type`, `os.version`, `vscode.platform.name`,
-`vscode.platform.version`, `coder.deployment.url`) plus per-record provenance
-(`coder.event.extension_version`, `coder.event.session_id`,
-`coder.event.deployment_url`).
+`vscode.platform.version`, `coder.deployment.url`) on the resource block
+holding the producing session's records.
 
 ## Consuming exports
 
@@ -97,7 +96,11 @@ date range in one of two formats:
   ad-hoc processing.
 - **OTLP**: a zip of standard OTLP/JSON envelopes (spans in `traces.json`,
   logs in `logs.json`, metric events as data points in `metrics.json`) plus
-  a `manifest.json` describing the export. Feed these to any OTel-compatible
+  a `manifest.json` describing the export. Each envelope holds one resource
+  block per producing session and UTC date, carrying that session's context
+  as resource attributes; within a block, metric data points are grouped
+  under one `metrics[]` entry per metric name and unit, and cumulative
+  counters restart at the block boundary. Feed these to any OTel-compatible
   tool that ingests OTLP/JSON, such as an OpenTelemetry Collector pipeline or
   your observability backend's import tooling.
 

--- a/src/instrumentation/EVENTS.md
+++ b/src/instrumentation/EVENTS.md
@@ -298,6 +298,7 @@ Emitted by `DiagnosticTelemetry` around each diagnostic command.
 | `interval.count` (measurement)             | speed test only                                                  |
 | `throughput_mbits` (measurement)           | speed test only                                                  |
 | `event.count` (measurement)                | telemetry export only                                            |
+| `file.skipped_count` (measurement)         | telemetry export only; unreadable files skipped, omitted at zero |
 
 ## Deployment
 

--- a/src/instrumentation/EVENTS.md
+++ b/src/instrumentation/EVENTS.md
@@ -382,9 +382,10 @@ Emitted by `SshTelemetry`.
 
 #### `ssh.network.sampled`
 
-Tunnel network sample. Emitted on a p2p flip, a preferred-DERP change, a
-meaningful latency change (at least 25 ms or 20 %), or a roughly 60 s
-heartbeat.
+Tunnel network sample. Emitted on a roughly 60 s heartbeat, or on a p2p
+flip, a preferred-DERP change, or a meaningful latency change (at least
+25 ms and at least 20 %). Change-triggered emissions are limited to one per
+15 s; a change that persists past that cooldown is emitted when it expires.
 
 | Attribute                      | Values                                                             |
 | ------------------------------ | ------------------------------------------------------------------ |

--- a/src/instrumentation/EVENTS.md
+++ b/src/instrumentation/EVENTS.md
@@ -34,27 +34,50 @@ Signal kinds, which each category groups its events by:
 
 Framework-managed envelope fields (wire keys, JSONL):
 
-| Field             | Meaning                                                                                     |
-| ----------------- | ------------------------------------------------------------------------------------------- |
-| `event_id`        | Unique per event (OTel span id, 16 hex)                                                     |
-| `event_name`      | The event names below                                                                       |
-| `timestamp`       | ISO 8601 emission time                                                                      |
-| `event_sequence`  | Monotonic per-session counter                                                               |
-| `schema_version`  | Integer, currently `1`; bumped only on breaking wire changes, additive fields never bump it |
-| `trace_id`        | Spans and their child events only (OTel trace id, 32 hex)                                   |
-| `parent_event_id` | Phases and span logs only; the parent span's `event_id`                                     |
-| `error`           | `{ message, type?, code? }`, only when an error was captured                                |
+| Field             | Meaning                                                                |
+| ----------------- | ---------------------------------------------------------------------- |
+| `event_id`        | Unique per event (OTel span id, 16 hex)                                |
+| `event_name`      | The event names below                                                  |
+| `timestamp`       | ISO 8601 emission time                                                 |
+| `event_sequence`  | Monotonic per-session counter                                          |
+| `deployment_url`  | Deployment active at emit time; empty until set via `setDeploymentUrl` |
+| `trace_id`        | Spans and their child events only (OTel trace id, 32 hex)              |
+| `parent_event_id` | Phases and span logs only; the parent span's `event_id`                |
+| `error`           | `{ message, type?, code? }`, only when an error was captured           |
 
-Session context, stamped on every event under `context`:
+Session-constant context is written once per file instead of on every row:
+the first line of every telemetry file (including rotated `.N` segments) is
+a header carrying the wire schema version, the sink start time, and the
+session context; each row below it implicitly inherits the version and
+context.
 
-| Field                                  | Source                                                                    |
-| -------------------------------------- | ------------------------------------------------------------------------- |
-| `extension_version`                    | package.json version                                                      |
-| `machine_id`                           | `vscode.env.machineId`                                                    |
-| `session_id`                           | Generated per session                                                     |
-| `os_type` / `os_version` / `host_arch` | `process.platform` (windows normalized) / `os.release()` / `process.arch` |
-| `platform_name` / `platform_version`   | `vscode.env.appName` / `vscode.version`                                   |
-| `deployment_url`                       | Set once known via `setDeploymentUrl`                                     |
+```json
+{
+	"kind": "header",
+	"schema_version": 1,
+	"timestamp": "...",
+	"context": {
+		"extension_version": "...",
+		"machine_id": "...",
+		"session_id": "...",
+		"os_type": "...",
+		"os_version": "...",
+		"host_arch": "...",
+		"platform_name": "...",
+		"platform_version": "..."
+	}
+}
+```
+
+| Field                                  | Source                                                                                      |
+| -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `schema_version`                       | Integer, currently `1`; bumped only on breaking wire changes, additive fields never bump it |
+| `timestamp`                            | ISO 8601 sink start time; at or before every row's timestamp                                |
+| `extension_version`                    | package.json version                                                                        |
+| `machine_id`                           | `vscode.env.machineId`                                                                      |
+| `session_id`                           | Generated per session                                                                       |
+| `os_type` / `os_version` / `host_arch` | `process.platform` (windows normalized) / `os.release()` / `process.arch`                   |
+| `platform_name` / `platform_version`   | `vscode.env.appName` / `vscode.version`                                                     |
 
 On OTLP export the context becomes resource attributes (`service.name:
 coder-vscode-extension`, `service.version`, `service.instance.id`, `host.id`,
@@ -69,8 +92,9 @@ Events buffer on disk as JSONL; nothing leaves the machine on its own. The
 **Coder: Export Telemetry** command flushes the buffer and writes a chosen
 date range in one of two formats:
 
-- **JSON**: one file holding an array of the wire-format rows described
-  above, for direct inspection or ad-hoc processing.
+- **JSON**: one file holding an array of self-contained events, each
+  carrying its full context and schema version, for direct inspection or
+  ad-hoc processing.
 - **OTLP**: a zip of standard OTLP/JSON envelopes (spans in `traces.json`,
   logs in `logs.json`, metric events as data points in `metrics.json`) plus
   a `manifest.json` describing the export. Feed these to any OTel-compatible

--- a/src/instrumentation/diagnostics.ts
+++ b/src/instrumentation/diagnostics.ts
@@ -2,6 +2,7 @@ import { recordAborted, recordError } from "./outcomes";
 
 import type { SpeedtestResult } from "@repo/shared";
 
+import type { ExportResult } from "../telemetry/export/pipeline";
 import type { ExportFormat } from "../telemetry/export/writers/types";
 import type { TelemetryReporter } from "../telemetry/reporter";
 import type { Span } from "../telemetry/span";
@@ -29,7 +30,7 @@ export interface DiagnosticTrace {
 	error(category?: DiagnosticErrorCategory): void;
 	setRequestedDuration(seconds: number): void;
 	succeedSpeedtest(result: SpeedtestResult): void;
-	succeedExport(format: ExportFormat, eventCount: number): void;
+	succeedExport(format: ExportFormat, result: ExportResult): void;
 }
 
 /** Emits `command.diagnostic.completed` around each diagnostic command. */
@@ -71,8 +72,11 @@ class SpanDiagnosticTrace implements DiagnosticTrace {
 		);
 	}
 
-	public succeedExport(format: ExportFormat, eventCount: number): void {
+	public succeedExport(format: ExportFormat, result: ExportResult): void {
 		this.span.setProperty("format", format);
-		this.span.setMeasurement("event.count", eventCount);
+		this.span.setMeasurement("event.count", result.eventCount);
+		if (result.skippedFileCount > 0) {
+			this.span.setMeasurement("file.skipped_count", result.skippedFileCount);
+		}
 	}
 }

--- a/src/instrumentation/ssh.ts
+++ b/src/instrumentation/ssh.ts
@@ -175,6 +175,7 @@ function hasMeaningfulLatencyChange(
 		return current !== 0;
 	}
 	const absoluteChange = Math.abs(current - previous);
+	// The absolute floor mutes fast-link jitter; the ratio mutes slow-link noise.
 	return (
 		absoluteChange >= NETWORK_LATENCY_MIN_ABSOLUTE_CHANGE_MS &&
 		absoluteChange / Math.abs(previous) >= NETWORK_LATENCY_CHANGE_RATIO

--- a/src/instrumentation/ssh.ts
+++ b/src/instrumentation/ssh.ts
@@ -2,6 +2,7 @@ import type { NetworkInfo } from "../remote/sshProcess";
 import type { TelemetryReporter } from "../telemetry/reporter";
 
 const NETWORK_SAMPLE_INTERVAL_MS = 60_000;
+const NETWORK_CHANGE_COOLDOWN_MS = 15_000;
 const NETWORK_LATENCY_CHANGE_RATIO = 0.2;
 const NETWORK_LATENCY_MIN_ABSOLUTE_CHANGE_MS = 25;
 
@@ -141,14 +142,21 @@ export class SshTelemetry {
 	}
 }
 
-/** Emit on p2p flip, DERP change, large latency swing, or heartbeat interval. */
+/** Emit on the heartbeat interval, or on a p2p flip, DERP change, or large
+ * latency swing once the change cooldown has elapsed. Suppression leaves the
+ * last emitted sample in place, so a change that persists through the
+ * cooldown is emitted when it expires rather than lost. */
 function shouldEmitSample(
 	previous: NetworkSample,
 	current: NetworkInfo,
 	now: number,
 ): boolean {
-	if (now - previous.emittedAtMs >= NETWORK_SAMPLE_INTERVAL_MS) {
+	const sinceLastEmit = now - previous.emittedAtMs;
+	if (sinceLastEmit >= NETWORK_SAMPLE_INTERVAL_MS) {
 		return true;
+	}
+	if (sinceLastEmit < NETWORK_CHANGE_COOLDOWN_MS) {
+		return false;
 	}
 	if (current.p2p !== previous.p2p) {
 		return true;
@@ -168,7 +176,7 @@ function hasMeaningfulLatencyChange(
 	}
 	const absoluteChange = Math.abs(current - previous);
 	return (
-		absoluteChange >= NETWORK_LATENCY_MIN_ABSOLUTE_CHANGE_MS ||
+		absoluteChange >= NETWORK_LATENCY_MIN_ABSOLUTE_CHANGE_MS &&
 		absoluteChange / Math.abs(previous) >= NETWORK_LATENCY_CHANGE_RATIO
 	);
 }

--- a/src/logging/httpRequestsTelemetry.ts
+++ b/src/logging/httpRequestsTelemetry.ts
@@ -197,6 +197,10 @@ function elapsedMs(
 }
 
 function percentile(sortedValues: readonly number[], p: number): number {
+	// Indexing an empty array would return undefined as a number.
+	if (sortedValues.length === 0) {
+		return 0;
+	}
 	const index = Math.ceil(sortedValues.length * p) - 1;
 	return sortedValues[Math.max(0, index)];
 }

--- a/src/logging/httpRequestsTelemetry.ts
+++ b/src/logging/httpRequestsTelemetry.ts
@@ -142,23 +142,31 @@ export class HttpRequestsTelemetry implements Disposable {
 		);
 		for (const [method, byRoute] of this.#buckets) {
 			for (const [route, bucket] of byRoute) {
-				const sortedDurations = bucket.durationsMs.toSorted((a, b) => a - b);
-				this.#telemetry.log(
-					EVENT_NAME,
-					{ method, route },
-					{
-						window_seconds: elapsedSeconds,
-						"count.1xx": bucket.count1xx,
-						"count.2xx": bucket.count2xx,
-						"count.3xx": bucket.count3xx,
-						"count.4xx": bucket.count4xx,
-						"count.5xx": bucket.count5xx,
-						"count.network_error": bucket.countNetworkError,
-						"duration.p50_ms": percentile(sortedDurations, 0.5),
-						"duration.p95_ms": percentile(sortedDurations, 0.95),
-						"duration.p99_ms": percentile(sortedDurations, 0.99),
-					},
-				);
+				const counts: Record<string, number> = {
+					"count.1xx": bucket.count1xx,
+					"count.2xx": bucket.count2xx,
+					"count.3xx": bucket.count3xx,
+					"count.4xx": bucket.count4xx,
+					"count.5xx": bucket.count5xx,
+					"count.network_error": bucket.countNetworkError,
+				};
+				const measurements: Record<string, number> = {
+					window_seconds: elapsedSeconds,
+				};
+				// Zero counters are omitted; absence reads as "none in this window".
+				for (const [key, count] of Object.entries(counts)) {
+					if (count > 0) {
+						measurements[key] = count;
+					}
+				}
+				// Percentiles are omitted when no request carried timing metadata.
+				if (bucket.durationsMs.length > 0) {
+					const sorted = bucket.durationsMs.toSorted((a, b) => a - b);
+					measurements["duration.p50_ms"] = percentile(sorted, 0.5);
+					measurements["duration.p95_ms"] = percentile(sorted, 0.95);
+					measurements["duration.p99_ms"] = percentile(sorted, 0.99);
+				}
+				this.#telemetry.log(EVENT_NAME, { method, route }, measurements);
 			}
 		}
 		this.#buckets.clear();
@@ -189,9 +197,6 @@ function elapsedMs(
 }
 
 function percentile(sortedValues: readonly number[], p: number): number {
-	if (sortedValues.length === 0) {
-		return 0;
-	}
 	const index = Math.ceil(sortedValues.length * p) - 1;
 	return sortedValues[Math.max(0, index)];
 }

--- a/src/telemetry/export/command.ts
+++ b/src/telemetry/export/command.ts
@@ -10,6 +10,7 @@ import {
 import {
 	collectTelemetryExport,
 	type ExportRequest,
+	type ExportResult,
 	type ExportRuntime,
 } from "./pipeline";
 import { promptForExport, type ExportChoice } from "./prompts";
@@ -20,8 +21,6 @@ import type { TelemetryContext } from "../event";
 import type { FlushStatus } from "../service";
 
 import type { ExportFormat } from "./writers/types";
-
-const REVEAL_ACTION = "Reveal in File Explorer";
 
 const PROGRESS_OPTIONS = {
 	location: vscode.ProgressLocation.Notification,
@@ -36,7 +35,7 @@ const PROGRESS_OPTIONS = {
 export interface ExportTelemetryObserver {
 	abort(stage: "prompt" | "progress"): void;
 	error(): void;
-	succeedExport(format: ExportFormat, eventCount: number): void;
+	succeedExport(format: ExportFormat, result: ExportResult): void;
 }
 
 export async function runExportTelemetryCommand(
@@ -87,12 +86,15 @@ function exportRuntime(
 			),
 		onCleanupError: (err, target) =>
 			logger.warn("Failed to clean up after telemetry export", target, err),
+		// The skipped file's name and line are in the error message.
+		onFileSkipped: (err) =>
+			logger.warn("Telemetry export skipped an unreadable file", err),
 	};
 }
 
 /** Turns the export result into the matching user-facing notification. */
 async function reportOutcome(
-	result: ProgressResult<number>,
+	result: ProgressResult<ExportResult>,
 	choice: ExportChoice,
 	logger: Logger,
 	observer: ExportTelemetryObserver,
@@ -110,29 +112,59 @@ async function reportOutcome(
 		return;
 	}
 
-	const eventCount = result.value;
-	observer.succeedExport(choice.format, eventCount);
+	const { eventCount, skippedFileCount } = result.value;
+	observer.succeedExport(choice.format, result.value);
 	if (eventCount === 0) {
-		void vscode.window.showInformationMessage(
+		void showExportMessage(
 			`No telemetry events found for ${choice.range.label}.`,
+			skippedFileCount,
+			logger,
 		);
 		return;
 	}
-	await notifyExportSucceeded(choice.outputPath, eventCount, logger);
+	const action = await showExportMessage(
+		`Exported ${formatEventCount(eventCount)} to ${choice.outputPath}.`,
+		skippedFileCount,
+		logger,
+		"Reveal in File Explorer",
+	);
+	if (action === "Reveal in File Explorer") {
+		await revealExportedFile(choice.outputPath, logger);
+	}
 }
 
-async function notifyExportSucceeded(
+type ExportAction = "Reveal in File Explorer";
+
+/**
+ * A partial export warns and names the unreadable-file count. "Show Output"
+ * is offered on warnings and handled here; only caller actions are returned.
+ */
+async function showExportMessage(
+	message: string,
+	skippedFileCount: number,
+	logger: Logger,
+	...actions: ExportAction[]
+): Promise<ExportAction | undefined> {
+	if (skippedFileCount === 0) {
+		return vscode.window.showInformationMessage(message, ...actions);
+	}
+	const files = skippedFileCount === 1 ? "file" : "files";
+	const action = await vscode.window.showWarningMessage(
+		`${message} ${skippedFileCount} ${files} could not be read. Check the Coder output for details.`,
+		...actions,
+		"Show Output",
+	);
+	if (action === "Show Output") {
+		logger.show();
+		return undefined;
+	}
+	return action;
+}
+
+async function revealExportedFile(
 	outputPath: string,
-	eventCount: number,
 	logger: Logger,
 ): Promise<void> {
-	const action = await vscode.window.showInformationMessage(
-		`Exported ${formatEventCount(eventCount)} to ${outputPath}.`,
-		REVEAL_ACTION,
-	);
-	if (action !== REVEAL_ACTION) {
-		return;
-	}
 	try {
 		await vscode.commands.executeCommand(
 			"revealFileInOS",

--- a/src/telemetry/export/files.ts
+++ b/src/telemetry/export/files.ts
@@ -5,10 +5,7 @@ import * as readline from "node:readline";
 
 import { toError } from "../../error/errorUtils";
 import * as localJsonlFiles from "../localJsonlFiles";
-import {
-	parseTelemetryEventLine,
-	TelemetryFileParseError,
-} from "../wireFormat";
+import { TelemetryFileParser, TelemetryFileParseError } from "../wireFormat";
 
 import {
 	fileDateCanContainRangeEvent,
@@ -95,6 +92,7 @@ async function* streamTelemetryEventsFromFiles(
 			input: stream,
 			crlfDelay: Infinity,
 		});
+		const parser = new TelemetryFileParser(name);
 		let lineNumber = 0;
 		try {
 			for await (const line of lines) {
@@ -102,8 +100,8 @@ async function* streamTelemetryEventsFromFiles(
 				if (line.trim() === "") {
 					continue;
 				}
-				const event = parseTelemetryEventLine(line, name, lineNumber);
-				if (isTimestampInRange(event.timestamp, range)) {
+				const event = parser.parseLine(line, lineNumber);
+				if (event && isTimestampInRange(event.timestamp, range)) {
 					yield event;
 				}
 			}

--- a/src/telemetry/export/files.ts
+++ b/src/telemetry/export/files.ts
@@ -57,14 +57,17 @@ export async function listTelemetryFilesForRange(
  * Merge per-session event streams by timestamp, keeping only events whose
  * timestamp falls inside `range`. Output stays globally sorted while each
  * session's timestamps are monotonic; if a session's clock moves backward,
- * that session's append order is preserved.
+ * that session's append order is preserved. A file that cannot be read or
+ * parsed is reported through `onFileError` and skipped from its first bad
+ * line, so one bad file cannot sink an export.
  */
 export async function* streamTelemetryEventsSorted(
 	files: readonly TelemetryLogFile[],
 	range: TelemetryDateRange,
+	onFileError: (err: Error, fileName: string) => void,
 ): AsyncIterable<TelemetryEvent> {
 	const iterators = groupFilesBySession(files).map((sessionFiles) =>
-		streamTelemetryEventsFromFiles(sessionFiles, range),
+		streamTelemetryEventsFromFiles(sessionFiles, range, onFileError),
 	);
 	const frontier: EventCursor[] = [];
 	try {
@@ -84,6 +87,7 @@ export async function* streamTelemetryEventsSorted(
 async function* streamTelemetryEventsFromFiles(
 	files: readonly TelemetryLogFile[],
 	range: TelemetryDateRange,
+	onFileError: (err: Error, fileName: string) => void,
 ): AsyncGenerator<TelemetryEvent> {
 	for (const file of files) {
 		const name = path.basename(file.path);
@@ -106,13 +110,15 @@ async function* streamTelemetryEventsFromFiles(
 				}
 			}
 		} catch (err) {
-			if (err instanceof TelemetryFileParseError) {
-				throw err;
-			}
 			const at = lineNumber > 0 ? `:${lineNumber}` : "";
-			throw new Error(
-				`Failed to read telemetry file ${name}${at}: ${toError(err).message}`,
-				{ cause: err },
+			onFileError(
+				err instanceof TelemetryFileParseError
+					? err
+					: new Error(
+							`Failed to read telemetry file ${name}${at}: ${toError(err).message}`,
+							{ cause: err },
+						),
+				name,
 			);
 		} finally {
 			try {

--- a/src/telemetry/export/pipeline.ts
+++ b/src/telemetry/export/pipeline.ts
@@ -20,6 +20,12 @@ export interface ExportRequest {
 	readonly writer: ExportWriter;
 }
 
+export interface ExportResult {
+	readonly eventCount: number;
+	/** Files skipped because they could not be read or parsed. */
+	readonly skippedFileCount: number;
+}
+
 /**
  * Host hooks the export needs: cancellation, flush, progress, and a cleanup
  * callback. Free of VS Code types so the pipeline is testable without a UI.
@@ -30,19 +36,22 @@ export interface ExportRuntime {
 	readonly report: (message: string) => void;
 	/** The pre-export flush did not fully succeed, so recent events may be missing. */
 	readonly onFlushIncomplete: () => void;
+	/** A file could not be read or parsed; the export continues without it (caller logs). */
+	readonly onFileSkipped: (err: Error, fileName: string) => void;
 	/** A temp file, staging dir, or empty export could not be removed (caller logs). */
 	readonly onCleanupError: (err: unknown, target: string) => void;
 }
 
 /**
  * Flushes telemetry, then streams every event in the range to `outputPath`.
- * Returns the number written; an export matching nothing leaves no file
- * behind. Throws on cancellation or write failure.
+ * Returns the count written and any unreadable files skipped; an export
+ * matching nothing leaves no file behind. Throws on cancellation or write
+ * failure.
  */
 export async function collectTelemetryExport(
 	request: ExportRequest,
 	runtime: ExportRuntime,
-): Promise<number> {
+): Promise<ExportResult> {
 	runtime.report("Flushing buffered events...");
 	const flushStatus = await runtime.flushTelemetry();
 	throwIfAborted(runtime.signal);
@@ -56,12 +65,16 @@ export async function collectTelemetryExport(
 		request.range,
 	);
 	if (files.length === 0) {
-		return 0;
+		return { eventCount: 0, skippedFileCount: 0 };
 	}
 
 	runtime.report("Writing export...");
+	let skippedFileCount = 0;
 	const events = abortable(
-		streamTelemetryEventsSorted(files, request.range),
+		streamTelemetryEventsSorted(files, request.range, (err, fileName) => {
+			skippedFileCount += 1;
+			runtime.onFileSkipped(err, fileName);
+		}),
 		runtime.signal,
 	);
 	const eventCount = await request.writer(
@@ -73,7 +86,7 @@ export async function collectTelemetryExport(
 	if (eventCount === 0) {
 		await removeEmptyExport(request.outputPath, runtime.onCleanupError);
 	}
-	return eventCount;
+	return { eventCount, skippedFileCount };
 }
 
 /** Removes the file a writer produced for an export that matched no events. */

--- a/src/telemetry/export/writers/otlp/envelope.ts
+++ b/src/telemetry/export/writers/otlp/envelope.ts
@@ -2,17 +2,24 @@ import { createWriteStream } from "node:fs";
 
 import { wrapError } from "../../../../error/errorUtils";
 
-/** `append` is not re-entrant. */
+/** `openBlock` and `append` are not re-entrant. */
 export interface EnvelopeFile {
+	/** Opens a new block, closing the previous one with the block suffix. */
+	openBlock(prefix: string): Promise<void>;
+	/** Appends one record to the open block; rejects if no block is open. */
 	append(value: unknown): Promise<void>;
 	close(): Promise<void>;
 }
 
-/** Streams `<prefix>v1,v2,...<suffix>` JSON into `filePath`. */
+/**
+ * Streams `<filePrefix>block,block,...<fileSuffix>` JSON into `filePath`,
+ * where each block is `<prefix>v1,v2,...<blockSuffix>`.
+ */
 export async function openEnvelopeFile(
 	filePath: string,
-	prefix: string,
-	suffix: string,
+	filePrefix: string,
+	blockSuffix: string,
+	fileSuffix: string,
 ): Promise<EnvelopeFile> {
 	const stream = createWriteStream(filePath, { encoding: "utf8" });
 	// Open failures (ENOENT/EACCES) surface as 'error' events, not write
@@ -42,15 +49,28 @@ export async function openEnvelopeFile(
 		awaitOp((cb) => stream.write(chunk, "utf8", cb));
 
 	try {
-		await writeChunk(prefix);
+		await writeChunk(filePrefix);
 	} catch (err) {
 		stream.destroy();
 		throw wrapError("write", filePath, err);
 	}
+	let blockOpen = false;
 	let written = 0;
 	let closed = false;
 	return {
+		async openBlock(prefix) {
+			try {
+				await writeChunk((blockOpen ? blockSuffix + "," : "") + prefix);
+			} catch (err) {
+				throw wrapError("write", filePath, err);
+			}
+			blockOpen = true;
+			written = 0;
+		},
 		async append(value) {
+			if (!blockOpen) {
+				throw new Error(`No open block to append to in ${filePath}`);
+			}
 			try {
 				await writeChunk((written === 0 ? "" : ",") + JSON.stringify(value));
 			} catch (err) {
@@ -64,7 +84,7 @@ export async function openEnvelopeFile(
 			}
 			closed = true;
 			try {
-				await writeChunk(suffix);
+				await writeChunk((blockOpen ? blockSuffix : "") + fileSuffix);
 				await awaitOp((cb) => stream.end(cb));
 			} catch (err) {
 				// destroy() never throws synchronously, so it can't mask the

--- a/src/telemetry/export/writers/otlp/metricBlockBuffer.ts
+++ b/src/telemetry/export/writers/otlp/metricBlockBuffer.ts
@@ -1,0 +1,53 @@
+import type { OtlpGaugePoint, OtlpMetric, OtlpSumPoint } from "./types";
+
+interface BufferedMetricSeries {
+	/** First record seen for the series; carries name/description/unit and sum metadata. */
+	readonly template: OtlpMetric;
+	readonly gaugePoints: OtlpGaugePoint[];
+	readonly sumPoints: OtlpSumPoint[];
+}
+
+/**
+ * Groups single-point metric records into one `metrics[]` entry per
+ * (name, unit, kind), as the OTLP metrics proto expects. The writer drains
+ * the buffer at block boundaries and at a point cap, bounding memory.
+ */
+export class MetricBlockBuffer {
+	readonly #series = new Map<string, BufferedMetricSeries>();
+	#points = 0;
+
+	/** Buffered data point count across all series. */
+	get points(): number {
+		return this.#points;
+	}
+
+	add(records: readonly OtlpMetric[]): void {
+		for (const record of records) {
+			const kind = record.gauge !== undefined ? "gauge" : "sum";
+			const key = `${record.name}\x00${record.unit}\x00${kind}`;
+			let series = this.#series.get(key);
+			if (series === undefined) {
+				series = { template: record, gaugePoints: [], sumPoints: [] };
+				this.#series.set(key, series);
+			}
+			series.gaugePoints.push(...(record.gauge?.dataPoints ?? []));
+			series.sumPoints.push(...(record.sum?.dataPoints ?? []));
+			this.#points +=
+				(record.gauge?.dataPoints.length ?? 0) +
+				(record.sum?.dataPoints.length ?? 0);
+		}
+	}
+
+	/** Returns the grouped metrics in first-seen order and clears the buffer. */
+	drain(): OtlpMetric[] {
+		const drained = [...this.#series.values()].map(
+			({ template, gaugePoints, sumPoints }): OtlpMetric =>
+				template.sum !== undefined
+					? { ...template, sum: { ...template.sum, dataPoints: sumPoints } }
+					: { ...template, gauge: { dataPoints: gaugePoints } },
+		);
+		this.#series.clear();
+		this.#points = 0;
+		return drained;
+	}
+}

--- a/src/telemetry/export/writers/otlp/records.ts
+++ b/src/telemetry/export/writers/otlp/records.ts
@@ -45,7 +45,10 @@ export const ENVELOPES = {
 } as const satisfies Record<Signal, EnvelopeSpec>;
 
 const OTLP_SCHEMA_URL = "https://opentelemetry.io/schemas/1.24.0";
-export const ENVELOPE_SUFFIX = "]}]}]}\n";
+/** Closes one resource block: records array, scope wrapper, resource wrapper. */
+export const RESOURCE_BLOCK_SUFFIX = "]}]}";
+/** Closes the top-level resource list opened by `envelopeFilePrefix`. */
+export const ENVELOPE_FILE_SUFFIX = "]}\n";
 
 const AGGREGATION_TEMPORALITY_CUMULATIVE = 2;
 // OTLP proto SpanKind reserves 0 for UNSPECIFIED; @opentelemetry/api values
@@ -55,12 +58,18 @@ const OTLP_SPAN_KIND_OFFSET = 1;
 // OtlpStatus.code is a wire-format int, so compare against a numeric alias.
 const OTLP_STATUS_ERROR: number = SpanStatusCode.ERROR;
 
-export function envelopePrefix(
+/** Opens the envelope's top-level resource list (`resourceLogs` etc.). */
+export function envelopeFilePrefix(envelope: EnvelopeSpec): string {
+	return `{"${envelope.resourceKey}":[`;
+}
+
+/** Opens one resource block: resource and scope wrappers up to the records array. */
+export function resourceBlockPrefix(
 	envelope: EnvelopeSpec,
 	resource: string,
 	scope: string,
 ): string {
-	return `{"${envelope.resourceKey}":[{"resource":${resource},"schemaUrl":"${OTLP_SCHEMA_URL}","${envelope.scopeKey}":[{"scope":${scope},"schemaUrl":"${OTLP_SCHEMA_URL}","${envelope.recordsKey}":[`;
+	return `{"resource":${resource},"schemaUrl":"${OTLP_SCHEMA_URL}","${envelope.scopeKey}":[{"scope":${scope},"schemaUrl":"${OTLP_SCHEMA_URL}","${envelope.recordsKey}":[`;
 }
 
 export interface CumulativeState {
@@ -73,9 +82,10 @@ export function newCumulativeState(): CumulativeState {
 }
 
 /**
- * Resource attributes describe the export tool (forwarder), not the original
- * producer. Per-event identity is stamped on each record by
- * `eventContextAttributes` so multi-session exports preserve provenance.
+ * Resource attributes identifying the session that produced a resource
+ * block's records. The writer builds one per block from the producing
+ * event's context, so multi-session exports attribute every record to its
+ * own session.
  */
 export function otlpResource(context: TelemetryContext) {
 	return {
@@ -91,19 +101,6 @@ export function otlpResource(context: TelemetryContext) {
 			"vscode.platform.version": context.platformVersion,
 			"coder.deployment.url": context.deploymentUrl,
 		}),
-	};
-}
-
-/**
- * Per-event identity stamped on every record so multi-session exports stay
- * attributable. Spread LAST in attribute maps so caller-supplied properties
- * keyed `coder.event.*` cannot override the canonical provenance.
- */
-function eventContextAttributes(event: TelemetryEvent): Record<string, string> {
-	return {
-		"coder.event.extension_version": event.context.extensionVersion,
-		"coder.event.session_id": event.context.sessionId,
-		"coder.event.deployment_url": event.context.deploymentUrl,
 	};
 }
 
@@ -130,7 +127,6 @@ export function logRecord(event: TelemetryEvent): OtlpLogRecord {
 			...event.properties,
 			...event.measurements,
 			...(event.error && exceptionAttributes(event.error)),
-			...eventContextAttributes(event),
 		}),
 		...(event.traceId !== undefined && { traceId: event.traceId }),
 		...(event.parentEventId !== undefined && { spanId: event.parentEventId }),
@@ -149,7 +145,6 @@ export function spanRecord(
 		...event.properties,
 		...measurements,
 		"coder.event_name": event.eventName,
-		...eventContextAttributes(event),
 	};
 	// OTel wants every error span to carry a low-cardinality error.type, so
 	// backfill the exception type or code, falling back to OTel's _OTHER sentinel.
@@ -231,7 +226,6 @@ export function metricRecords(
 		attributes: keyValues({
 			...event.properties,
 			"coder.event_name": event.eventName,
-			...eventContextAttributes(event),
 		}),
 		timeNano,
 		windowStartNano,

--- a/src/telemetry/export/writers/otlp/writer.ts
+++ b/src/telemetry/export/writers/otlp/writer.ts
@@ -66,6 +66,12 @@ interface ResourceBlock {
 	readonly resource: string;
 }
 
+/** Single-entry cache of the last serialized OTLP resource. */
+interface ResourceCache {
+	readonly context: TelemetryContext;
+	readonly resource: string;
+}
+
 /** Mutable per-export state shared by the routing helpers. */
 interface ExportRun {
 	readonly channels: Record<Signal, Channel>;
@@ -75,6 +81,7 @@ interface ExportRun {
 	/** Cumulative counter state; reset at every block boundary. */
 	state: CumulativeState;
 	block: ResourceBlock | undefined;
+	resourceCache: ResourceCache | undefined;
 }
 
 // Read high-water mark (HWM): bytes buffered per read while streaming a staged
@@ -159,6 +166,7 @@ async function writeStagedFiles(
 		metricBuffer: new MetricBlockBuffer(),
 		state: newCumulativeState(),
 		block: undefined,
+		resourceCache: undefined,
 	};
 
 	let succeeded = false;
@@ -302,7 +310,7 @@ async function openEventBlock(
 	const date = toUtcDateString(
 		new Date(parseTelemetryTimestampMs(event.timestamp)),
 	);
-	const resource = JSON.stringify(otlpResource(event.context));
+	const resource = serializeResourceCached(run, event.context);
 	const key = date + resource;
 	if (run.block?.key === key) {
 		return;
@@ -310,6 +318,23 @@ async function openEventBlock(
 	await flushMetricBlock(run);
 	run.state = newCumulativeState();
 	run.block = { key, resource };
+}
+
+/**
+ * Cached by context identity: the parser reuses one context object across
+ * rows, so this serializes once per file rather than once per event.
+ */
+function serializeResourceCached(
+	run: ExportRun,
+	context: TelemetryContext,
+): string {
+	if (run.resourceCache?.context !== context) {
+		run.resourceCache = {
+			context,
+			resource: JSON.stringify(otlpResource(context)),
+		};
+	}
+	return run.resourceCache.resource;
 }
 
 /** Writes the buffered metric series under the block that produced them. */

--- a/src/telemetry/export/writers/otlp/writer.ts
+++ b/src/telemetry/export/writers/otlp/writer.ts
@@ -10,21 +10,27 @@ import {
 	toError,
 	wrapError,
 } from "../../../../error/errorUtils";
+import { toUtcDateString } from "../../../../util/date";
 import { writeAtomically } from "../../../../util/fs";
 import { describeMetricEvent } from "../../metrics";
+import { parseTelemetryTimestampMs } from "../../range";
 
 import { openEnvelopeFile, type EnvelopeFile } from "./envelope";
 import { buildManifest, MANIFEST_FILE, type RecordCounts } from "./manifest";
+import { MetricBlockBuffer } from "./metricBlockBuffer";
 import {
 	ENVELOPES,
-	ENVELOPE_SUFFIX,
+	ENVELOPE_FILE_SUFFIX,
+	RESOURCE_BLOCK_SUFFIX,
 	type CumulativeState,
-	envelopePrefix,
+	type EnvelopeSpec,
+	envelopeFilePrefix,
 	logRecord,
 	metricRecords,
 	newCumulativeState,
 	otlpResource,
 	otlpScope,
+	resourceBlockPrefix,
 	type Signal,
 	spanRecord,
 } from "./records";
@@ -43,16 +49,45 @@ export interface OtlpExportCounts {
 const OTLP_FORMAT = "otlp-json";
 
 interface Channel {
-	file: EnvelopeFile;
+	readonly envelope: EnvelopeSpec;
+	readonly file: EnvelopeFile;
 	/** Source events routed to this signal. */
 	count: number;
 	/** OTLP records written to this signal. */
 	records: number;
+	/** Key of the resource block currently open in this envelope, if any. */
+	blockKey: string | undefined;
+}
+
+/** One resource block: a contiguous run of events sharing a block key. */
+interface ResourceBlock {
+	readonly key: string;
+	/** Serialized OTLP resource built from the producing event's context. */
+	readonly resource: string;
+}
+
+/** Mutable per-export state shared by the routing helpers. */
+interface ExportRun {
+	readonly channels: Record<Signal, Channel>;
+	/** Serialized instrumentation scope of the exporting session. */
+	readonly scope: string;
+	readonly metricBuffer: MetricBlockBuffer;
+	/** Cumulative counter state; reset at every block boundary. */
+	state: CumulativeState;
+	block: ResourceBlock | undefined;
 }
 
 // Read high-water mark (HWM): bytes buffered per read while streaming a staged
 // envelope into the zip.
 const READ_HWM_BYTES = 256 * 1024;
+
+// Maximum deflate effort: exports run on demand, so CPU cost is irrelevant
+// next to bundle size.
+const ZIP_COMPRESSION_LEVEL = 9;
+
+// Force-flush bound for buffered metric points, so one block cannot grow the
+// buffer without limit. A flushed series continues in a new `metrics[]` entry.
+export const MAX_BUFFERED_METRIC_POINTS = 10_000;
 
 /**
  * Writes `events` as an OTLP/JSON zip (`logs.json`, `traces.json`,
@@ -117,17 +152,22 @@ async function writeStagedFiles(
 	signal: AbortSignal | undefined,
 	descriptor: ExportDescriptor,
 ): Promise<OtlpExportCounts> {
-	const resource = JSON.stringify(otlpResource(context));
-	const scope = JSON.stringify(otlpScope(context.extensionVersion));
-	const channels = await openChannels(dir, resource, scope);
-	const state = newCumulativeState();
+	const channels = await openChannels(dir);
+	const run: ExportRun = {
+		channels,
+		scope: JSON.stringify(otlpScope(context.extensionVersion)),
+		metricBuffer: new MetricBlockBuffer(),
+		state: newCumulativeState(),
+		block: undefined,
+	};
 
 	let succeeded = false;
 	try {
 		for await (const event of events) {
 			throwIfAborted(signal);
-			await routeEvent(event, channels, state);
+			await routeEvent(event, run);
 		}
+		await flushMetricBlock(run);
 		succeeded = true;
 	} finally {
 		// On success surface close failures; on failure swallow them so the
@@ -172,19 +212,16 @@ async function writeManifest(
 	);
 }
 
-async function openChannels(
-	dir: string,
-	resource: string,
-	scope: string,
-): Promise<Record<Signal, Channel>> {
+async function openChannels(dir: string): Promise<Record<Signal, Channel>> {
 	const open = async (signal: Signal): Promise<Channel> => {
 		const envelope = ENVELOPES[signal];
 		const file = await openEnvelopeFile(
 			path.join(dir, envelope.file),
-			envelopePrefix(envelope, resource, scope),
-			ENVELOPE_SUFFIX,
+			envelopeFilePrefix(envelope),
+			RESOURCE_BLOCK_SUFFIX,
+			ENVELOPE_FILE_SUFFIX,
 		);
-		return { file, count: 0, records: 0 };
+		return { envelope, file, count: 0, records: 0, blockKey: undefined };
 	};
 	// Promise.allSettled so one failure doesn't orphan its siblings' fds.
 	const settled = await Promise.allSettled([
@@ -223,23 +260,25 @@ function isTimedSpan(
 
 async function routeEvent(
 	event: TelemetryEvent,
-	channels: Record<Signal, Channel>,
-	state: CumulativeState,
+	run: ExportRun,
 ): Promise<void> {
 	try {
+		await openEventBlock(event, run);
 		const metric = describeMetricEvent(event);
 		if (metric) {
-			await appendRecords(
-				channels.metrics,
-				metricRecords(event, metric, state),
-			);
-			channels.metrics.count += 1;
+			// Buffered so data points group under one metric per series; records
+			// are counted when the block's buffer flushes.
+			run.metricBuffer.add(metricRecords(event, metric, run.state));
+			run.channels.metrics.count += 1;
+			if (run.metricBuffer.points >= MAX_BUFFERED_METRIC_POINTS) {
+				await flushMetricBlock(run);
+			}
 		} else if (isTimedSpan(event)) {
-			await appendRecords(channels.traces, [spanRecord(event)]);
-			channels.traces.count += 1;
+			await appendRecords(run, run.channels.traces, [spanRecord(event)]);
+			run.channels.traces.count += 1;
 		} else {
-			await appendRecords(channels.logs, [logRecord(event)]);
-			channels.logs.count += 1;
+			await appendRecords(run, run.channels.logs, [logRecord(event)]);
+			run.channels.logs.count += 1;
 		}
 	} catch (err) {
 		throw wrapError(
@@ -250,10 +289,53 @@ async function routeEvent(
 	}
 }
 
+/**
+ * Starts a new resource block when the event's UTC date or producing context
+ * changes: buffered metrics flush under the previous block and cumulative
+ * counters reset, as OTel models a process restart. Input files sort by
+ * (date, session, part), so equal keys arrive as contiguous runs.
+ */
+async function openEventBlock(
+	event: TelemetryEvent,
+	run: ExportRun,
+): Promise<void> {
+	const date = toUtcDateString(
+		new Date(parseTelemetryTimestampMs(event.timestamp)),
+	);
+	const resource = JSON.stringify(otlpResource(event.context));
+	const key = date + resource;
+	if (run.block?.key === key) {
+		return;
+	}
+	await flushMetricBlock(run);
+	run.state = newCumulativeState();
+	run.block = { key, resource };
+}
+
+/** Writes the buffered metric series under the block that produced them. */
+async function flushMetricBlock(run: ExportRun): Promise<void> {
+	const records = run.metricBuffer.drain();
+	if (records.length > 0) {
+		await appendRecords(run, run.channels.metrics, records);
+	}
+}
+
 async function appendRecords(
+	run: ExportRun,
 	channel: Channel,
 	records: Iterable<unknown>,
 ): Promise<void> {
+	const block = run.block;
+	if (block === undefined) {
+		// Unreachable: records are only produced after openEventBlock.
+		throw new Error(`No open resource block for ${channel.envelope.file}`);
+	}
+	if (channel.blockKey !== block.key) {
+		await channel.file.openBlock(
+			resourceBlockPrefix(channel.envelope, block.resource, run.scope),
+		);
+		channel.blockKey = block.key;
+	}
 	for (const record of records) {
 		await channel.file.append(record);
 		channel.records += 1;
@@ -348,7 +430,7 @@ async function streamFileIntoZip(
 	signal: AbortSignal | undefined,
 	waitForDrain: () => Promise<void>,
 ): Promise<void> {
-	const entry = new ZipDeflate(name);
+	const entry = new ZipDeflate(name, { level: ZIP_COMPRESSION_LEVEL });
 	zip.add(entry);
 	const readStream = createReadStream(filePath, {
 		highWaterMark: READ_HWM_BYTES,

--- a/src/telemetry/sinks/localJsonlSink.ts
+++ b/src/telemetry/sinks/localJsonlSink.ts
@@ -14,7 +14,11 @@ import {
 	type FileCleanupCandidate,
 } from "../../util/fileCleanup";
 import * as localJsonlFiles from "../localJsonlFiles";
-import { serializeTelemetryEventLine } from "../wireFormat";
+import {
+	serializeTelemetryEventLine,
+	serializeTelemetryFileHeaderLine,
+	type SessionContext,
+} from "../wireFormat";
 
 import type { Logger } from "../../logging/logger";
 import type { TelemetryEvent, TelemetryLevel, TelemetrySink } from "../event";
@@ -23,7 +27,7 @@ const SINK_NAME = "local-jsonl";
 
 export interface LocalJsonlSinkOptions {
 	baseDir: string;
-	sessionId: string;
+	session: SessionContext;
 }
 
 interface CurrentFile {
@@ -35,11 +39,13 @@ interface CurrentFile {
 /**
  * Writes telemetry events as JSON Lines. Each VS Code session writes its
  * own files (`telemetry-YYYY-MM-DD-{sessionId8}.jsonl` plus `.N.jsonl` size
- * segments), so concurrent windows cannot race on appends or rotation.
- * `write` is sync and never throws. Disk I/O happens in `flush`/`dispose`;
- * a failed flush rejects so awaited callers (the export) can react, while
- * background flushes ignore it. Tunables come from `coder.telemetry.local`
- * and update reactively.
+ * segments), so concurrent windows cannot race on appends or rotation. Every
+ * file opens with a header line carrying the sink start time and session
+ * context; rows hold only
+ * per-event fields. `write` is sync and never throws. Disk I/O happens in
+ * `flush`/`dispose`; a failed flush rejects so awaited callers (the export)
+ * can react, while background flushes ignore it. Tunables come from
+ * `coder.telemetry.local` and update reactively.
  */
 export class LocalJsonlSink implements TelemetrySink, vscode.Disposable {
 	public readonly name = SINK_NAME;
@@ -47,6 +53,8 @@ export class LocalJsonlSink implements TelemetrySink, vscode.Disposable {
 
 	readonly #baseDir: string;
 	readonly #sessionSlug: string;
+	readonly #headerLine: string;
+	readonly #headerBytes: number;
 	readonly #logger: Logger;
 	readonly #buffer: string[] = [];
 	#config: LocalSinkConfig;
@@ -64,7 +72,9 @@ export class LocalJsonlSink implements TelemetrySink, vscode.Disposable {
 		config: LocalSinkConfig,
 	) {
 		this.#baseDir = opts.baseDir;
-		this.#sessionSlug = toSessionSlug(opts.sessionId);
+		this.#sessionSlug = toSessionSlug(opts.session.sessionId);
+		this.#headerLine = serializeTelemetryFileHeaderLine(opts.session);
+		this.#headerBytes = Buffer.byteLength(this.#headerLine, "utf8");
 		this.#logger = logger;
 		this.#config = config;
 	}
@@ -220,8 +230,16 @@ export class LocalJsonlSink implements TelemetrySink, vscode.Disposable {
 	async #append(payload: string, payloadBytes: number): Promise<void> {
 		await fs.mkdir(this.#baseDir, { recursive: true });
 		const next = await this.#nextFile(payloadBytes);
-		await fs.appendFile(this.#segmentPath(next), payload, "utf8");
-		this.#current = { ...next, size: next.size + payloadBytes };
+		// A zero-size target has no header yet (only this session ever writes
+		// its files, and every prior append wrote one). Prepending it to the
+		// same appendFile call means no file can end up header-only or torn.
+		const withHeader = next.size === 0;
+		const data = withHeader ? this.#headerLine + payload : payload;
+		const dataBytes = withHeader
+			? this.#headerBytes + payloadBytes
+			: payloadBytes;
+		await fs.appendFile(this.#segmentPath(next), data, "utf8");
+		this.#current = { ...next, size: next.size + dataBytes };
 	}
 
 	async #nextFile(payloadSize: number): Promise<CurrentFile> {

--- a/src/telemetry/sinks/localJsonlSink.ts
+++ b/src/telemetry/sinks/localJsonlSink.ts
@@ -41,8 +41,8 @@ interface CurrentFile {
  * own files (`telemetry-YYYY-MM-DD-{sessionId8}.jsonl` plus `.N.jsonl` size
  * segments), so concurrent windows cannot race on appends or rotation. Every
  * file opens with a header line carrying the sink start time and session
- * context; rows hold only
- * per-event fields. `write` is sync and never throws. Disk I/O happens in
+ * context; rows hold only per-event fields. `write` is sync and never throws.
+ * Disk I/O happens in
  * `flush`/`dispose`; a failed flush rejects so awaited callers (the export)
  * can react, while background flushes ignore it. Tunables come from
  * `coder.telemetry.local` and update reactively.
@@ -242,6 +242,10 @@ export class LocalJsonlSink implements TelemetrySink, vscode.Disposable {
 		this.#current = { ...next, size: next.size + dataBytes };
 	}
 
+	/**
+	 * `maxFileBytes` is payload-granular: a segment's first write includes
+	 * the header, so it may overshoot by up to `headerBytes`.
+	 */
 	async #nextFile(payloadSize: number): Promise<CurrentFile> {
 		const today = toUtcDateString(new Date());
 		const seeded =

--- a/src/telemetry/wireFormat.ts
+++ b/src/telemetry/wireFormat.ts
@@ -180,6 +180,7 @@ export function serializeTelemetryEvent(
 export class TelemetryFileParser {
 	readonly #source: string;
 	#header: z.infer<typeof TelemetryFileHeaderSchema> | undefined;
+	#context: TelemetryContext | undefined;
 
 	constructor(source: string) {
 		this.#source = source;
@@ -199,7 +200,11 @@ export class TelemetryFileParser {
 
 	#parse(line: string): TelemetryEvent | undefined {
 		const value = wireToCamel(JSON.parse(line));
-		if (hasKind(value)) {
+		const kind = kindOf(value);
+		if (kind !== undefined) {
+			if (kind !== "header") {
+				throw new Error(`unknown kind ${JSON.stringify(kind)}`);
+			}
 			if (this.#header) {
 				throw new Error("unexpected second file header");
 			}
@@ -210,20 +215,23 @@ export class TelemetryFileParser {
 			throw new Error("expected a file header before event rows");
 		}
 		const { deploymentUrl, ...row } = TelemetryEventRowSchema.parse(value);
+		// One object per deployment URL run lets consumers memoize by identity.
+		if (this.#context?.deploymentUrl !== deploymentUrl) {
+			this.#context = { ...this.#header.context, deploymentUrl };
+		}
 		return {
 			...row,
 			schemaVersion: this.#header.schemaVersion,
-			context: { ...this.#header.context, deploymentUrl },
+			context: this.#context,
 		};
 	}
 }
 
-function hasKind(value: unknown): boolean {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		(value as Record<string, unknown>).kind !== undefined
-	);
+/** The line's `kind` discriminator; event rows have none. */
+function kindOf(value: unknown): unknown {
+	return typeof value === "object" && value !== null
+		? (value as Record<string, unknown>).kind
+		: undefined;
 }
 
 const SNAKE_TO_CAMEL = /_([a-z])/g;

--- a/src/telemetry/wireFormat.ts
+++ b/src/telemetry/wireFormat.ts
@@ -1,11 +1,10 @@
 import { z } from "zod";
 
 /**
- * Wire schema version stamped on every telemetry row. Each row carries its
- * own version because rows are self-contained: one row maps to one exported
- * record, with no file-level header to anchor a single version to. Bump only
- * on a breaking change to the JSONL shape (a renamed, removed, or retyped
- * field); additive optional fields do not need a bump.
+ * Wire schema version stamped on the header line of every telemetry file and
+ * applied to all rows below it. Bump only on a breaking change to the JSONL
+ * shape (a renamed, removed, or retyped field); additive optional fields do
+ * not need a bump.
  */
 export const CURRENT_TELEMETRY_SCHEMA_VERSION = 1;
 
@@ -21,24 +20,20 @@ const SessionContextSchema = z.object({
 	platformVersion: z.string(),
 });
 
-/** Session attributes plus the deployment URL active at emit time. */
-const TelemetryContextSchema = SessionContextSchema.extend({
-	deploymentUrl: z.string(),
+/** First line of every telemetry file: schema version, start time, session context. */
+const TelemetryFileHeaderSchema = z.object({
+	kind: z.literal("header"),
+	schemaVersion: z.number().int().positive(),
+	/** Sink start time; at or before every row's timestamp. */
+	timestamp: z.iso.datetime({ offset: true }),
+	context: SessionContextSchema,
 });
 
-/**
- * Canonical telemetry event. Derived TS types (`TelemetryEvent`,
- * `TelemetryContext`, `SessionContext`) come straight from these schemas,
- * so the wire format and the in-memory shape can't drift.
- */
-const TelemetryEventSchema = z.object({
+const TelemetryEventBaseSchema = z.object({
 	eventId: z.string(),
 	eventName: z.string(),
 	timestamp: z.iso.datetime({ offset: true }),
 	eventSequence: z.number(),
-	/** Wire schema version of this row. See `CURRENT_TELEMETRY_SCHEMA_VERSION`. */
-	schemaVersion: z.number().int().positive(),
-	context: TelemetryContextSchema,
 	properties: z.record(z.string(), z.string()),
 	measurements: z.record(z.string(), z.number()),
 	/** Shared by all events in a trace. Maps to OTel `trace_id`. */
@@ -58,16 +53,38 @@ const TelemetryEventSchema = z.object({
 		.optional(),
 });
 
+/**
+ * Event row as stored on disk. Session-constant fields live in the file
+ * header; the row adds only the mutable deployment URL.
+ */
+const TelemetryEventRowSchema = TelemetryEventBaseSchema.extend({
+	deploymentUrl: z.string(),
+});
+
 /** Deep `readonly` since zod's inferred types are mutable by default. */
 type DeepReadonly<T> = T extends object
 	? { readonly [K in keyof T]: DeepReadonly<T[K]> }
 	: T;
 
 export type SessionContext = DeepReadonly<z.infer<typeof SessionContextSchema>>;
+
+/** Session attributes plus the deployment URL active at emit time. */
 export type TelemetryContext = DeepReadonly<
-	z.infer<typeof TelemetryContextSchema>
+	z.infer<typeof SessionContextSchema> & { deploymentUrl: string }
 >;
-export type TelemetryEvent = DeepReadonly<z.infer<typeof TelemetryEventSchema>>;
+
+/**
+ * Canonical in-memory telemetry event: the row fields plus the schema version
+ * and session context carried by the file header. Derived from the wire
+ * schemas so the wire format and the in-memory shape can't drift.
+ */
+export type TelemetryEvent = DeepReadonly<
+	z.infer<typeof TelemetryEventBaseSchema> & {
+		/** Wire schema version of the file the event came from. See `CURRENT_TELEMETRY_SCHEMA_VERSION`. */
+		schemaVersion: number;
+		context: TelemetryContext;
+	}
+>;
 
 /** Lets stream readers tell a parse failure apart from an IO failure. */
 export class TelemetryFileParseError extends Error {
@@ -77,32 +94,13 @@ export class TelemetryFileParseError extends Error {
 	}
 }
 
-/** Serializes one event to its newline-terminated JSONL row. */
-export function serializeTelemetryEventLine(event: TelemetryEvent): string {
-	return JSON.stringify(serializeTelemetryEvent(event)) + "\n";
-}
-
-/** Snake-case row written to disk by the sink and read back by the exporter. */
-export function serializeTelemetryEvent(
-	event: TelemetryEvent,
-): Record<string, unknown> {
+/** Per-event fields in their snake_case wire form. */
+function eventWireFields(event: TelemetryEvent): Record<string, unknown> {
 	return {
 		event_id: event.eventId,
 		event_name: event.eventName,
 		timestamp: event.timestamp,
 		event_sequence: event.eventSequence,
-		schema_version: event.schemaVersion,
-		context: {
-			extension_version: event.context.extensionVersion,
-			machine_id: event.context.machineId,
-			session_id: event.context.sessionId,
-			os_type: event.context.osType,
-			os_version: event.context.osVersion,
-			host_arch: event.context.hostArch,
-			platform_name: event.context.platformName,
-			platform_version: event.context.platformVersion,
-			deployment_url: event.context.deploymentUrl,
-		},
 		properties: event.properties,
 		measurements: event.measurements,
 		...(event.traceId !== undefined && { trace_id: event.traceId }),
@@ -113,20 +111,119 @@ export function serializeTelemetryEvent(
 	};
 }
 
-/** Parses one JSONL row. Throws `TelemetryFileParseError` on bad input. */
-export function parseTelemetryEventLine(
-	line: string,
-	source: string,
-	lineNumber: number,
-): TelemetryEvent {
-	try {
-		return TelemetryEventSchema.parse(wireToCamel(JSON.parse(line)));
-	} catch (err) {
-		throw new TelemetryFileParseError(
-			`Failed to parse telemetry file ${source}:${lineNumber}: ${describeParseError(err)}`,
-			{ cause: err },
-		);
+/** Session attributes in their snake_case wire form. */
+function sessionWireFields(session: SessionContext): Record<string, unknown> {
+	return {
+		extension_version: session.extensionVersion,
+		machine_id: session.machineId,
+		session_id: session.sessionId,
+		os_type: session.osType,
+		os_version: session.osVersion,
+		host_arch: session.hostArch,
+		platform_name: session.platformName,
+		platform_version: session.platformVersion,
+	};
+}
+
+/** Serializes the newline-terminated header line opening a telemetry file, stamped with the current time. */
+export function serializeTelemetryFileHeaderLine(
+	session: SessionContext,
+): string {
+	return (
+		JSON.stringify({
+			kind: "header",
+			schema_version: CURRENT_TELEMETRY_SCHEMA_VERSION,
+			timestamp: new Date().toISOString(),
+			context: sessionWireFields(session),
+		}) + "\n"
+	);
+}
+
+/**
+ * Serializes one event to its newline-terminated JSONL row. Session-constant
+ * fields are written once in the file header, so the row carries only the
+ * per-event fields plus the deployment URL active at emit time.
+ */
+export function serializeTelemetryEventLine(event: TelemetryEvent): string {
+	return (
+		JSON.stringify({
+			...eventWireFields(event),
+			deployment_url: event.context.deploymentUrl,
+		}) + "\n"
+	);
+}
+
+/**
+ * Snake-case object carrying the full event including its context, so each
+ * exported record is self-contained. Used by the JSON export, not the sink.
+ */
+export function serializeTelemetryEvent(
+	event: TelemetryEvent,
+): Record<string, unknown> {
+	return {
+		...eventWireFields(event),
+		schema_version: event.schemaVersion,
+		context: {
+			...sessionWireFields(event.context),
+			deployment_url: event.context.deploymentUrl,
+		},
+	};
+}
+
+/**
+ * Stateful parser for one telemetry JSONL file. The first line must be the
+ * file header; every row below it combines with the header's session context
+ * to yield a full `TelemetryEvent`. Throws `TelemetryFileParseError` on
+ * malformed lines, rows before the header, duplicate headers, or an unknown
+ * `kind`. A header with no rows is a valid, empty file.
+ */
+export class TelemetryFileParser {
+	readonly #source: string;
+	#header: z.infer<typeof TelemetryFileHeaderSchema> | undefined;
+
+	constructor(source: string) {
+		this.#source = source;
 	}
+
+	/** Parses one line, returning its event or undefined for the header line. */
+	parseLine(line: string, lineNumber: number): TelemetryEvent | undefined {
+		try {
+			return this.#parse(line);
+		} catch (err) {
+			throw new TelemetryFileParseError(
+				`Failed to parse telemetry file ${this.#source}:${lineNumber}: ${describeParseError(err)}`,
+				{ cause: err },
+			);
+		}
+	}
+
+	#parse(line: string): TelemetryEvent | undefined {
+		const value = wireToCamel(JSON.parse(line));
+		if (hasKind(value)) {
+			if (this.#header) {
+				throw new Error("unexpected second file header");
+			}
+			this.#header = TelemetryFileHeaderSchema.parse(value);
+			return undefined;
+		}
+		if (!this.#header) {
+			throw new Error("expected a file header before event rows");
+		}
+		const { deploymentUrl, ...row } = TelemetryEventRowSchema.parse(value);
+		return {
+			...row,
+			schemaVersion: this.#header.schemaVersion,
+			context: { ...this.#header.context, deploymentUrl },
+		};
+	}
+}
+
+function hasKind(value: unknown): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		(value as Record<string, unknown>).kind !== undefined
+	);
 }
 
 const SNAKE_TO_CAMEL = /_([a-z])/g;

--- a/test/mocks/telemetry.ts
+++ b/test/mocks/telemetry.ts
@@ -7,7 +7,10 @@ import {
 	type TelemetrySink,
 } from "@/telemetry/event";
 import { TelemetryService } from "@/telemetry/service";
-import { CURRENT_TELEMETRY_SCHEMA_VERSION } from "@/telemetry/wireFormat";
+import {
+	CURRENT_TELEMETRY_SCHEMA_VERSION,
+	type SessionContext,
+} from "@/telemetry/wireFormat";
 
 import { createMockLogger, MockConfigurationProvider } from "./testHelpers";
 
@@ -72,6 +75,18 @@ export function createTelemetryHarness(): {
 	return { sink, service: createTestTelemetryService(sink) };
 }
 
+/** Shared session fixture so test values cannot drift. */
+export const TEST_SESSION_CONTEXT: SessionContext = {
+	extensionVersion: "1.14.5",
+	machineId: "machine-id",
+	sessionId: "session-id",
+	osType: "linux",
+	osVersion: "6.0.0",
+	hostArch: "x64",
+	platformName: "Visual Studio Code",
+	platformVersion: "1.106.0",
+};
+
 /**
  * Factory for `TelemetryEvent` fixtures. Each call gets a fresh `eventId` and
  * monotonic `eventSequence`; overrides win.
@@ -89,14 +104,7 @@ export function createTelemetryEventFactory(): (
 			eventSequence: seq,
 			schemaVersion: CURRENT_TELEMETRY_SCHEMA_VERSION,
 			context: {
-				extensionVersion: "1.14.5",
-				machineId: "machine-id",
-				sessionId: "session-id",
-				osType: "linux",
-				osVersion: "6.0.0",
-				hostArch: "x64",
-				platformName: "Visual Studio Code",
-				platformVersion: "1.106.0",
+				...TEST_SESSION_CONTEXT,
 				deploymentUrl: "https://coder.example.com",
 			},
 			properties: {},

--- a/test/unit/api/coderApi.test.ts
+++ b/test/unit/api/coderApi.test.ts
@@ -277,14 +277,11 @@ describe("CoderApi", () => {
 				{ method: "GET", route: "/api/v2/workspaces/{id}" },
 				expect.objectContaining({
 					window_seconds: 60,
-					"count.1xx": 0,
 					"count.2xx": 1,
-					"count.3xx": 0,
-					"count.4xx": 0,
-					"count.5xx": 0,
-					"count.network_error": 0,
 				}),
 			);
+			// Status classes with no requests in the window are omitted.
+			expect(log.mock.calls[0][2]).not.toHaveProperty("count.5xx");
 		});
 
 		describe("certificate refresh and retry", () => {

--- a/test/unit/instrumentation/ssh.test.ts
+++ b/test/unit/instrumentation/ssh.test.ts
@@ -177,10 +177,17 @@ describe("SshTelemetry", () => {
 
 		it.each([
 			{
-				name: "no change in window",
+				name: "no change within the cooldown",
 				prev: {},
 				next: {},
 				advanceMs: 1_000,
+				expected: 1,
+			},
+			{
+				name: "no change after the cooldown",
+				prev: {},
+				next: {},
+				advanceMs: 16_000,
 				expected: 1,
 			},
 			{

--- a/test/unit/instrumentation/ssh.test.ts
+++ b/test/unit/instrumentation/ssh.test.ts
@@ -187,35 +187,56 @@ describe("SshTelemetry", () => {
 				name: "latency change below both thresholds (50 -> 51)",
 				prev: {},
 				next: { latency: 51 },
+				advanceMs: 15_000,
+				expected: 1,
+			},
+			{
+				name: "latency change meeting only the ratio threshold (50 -> 70)",
+				prev: {},
+				next: { latency: 70 },
+				advanceMs: 15_000,
+				expected: 1,
+			},
+			{
+				name: "latency change meeting only the absolute threshold (200 -> 230)",
+				prev: { latency: 200 },
+				next: { latency: 230 },
+				advanceMs: 15_000,
+				expected: 1,
+			},
+			{
+				name: "latency change meeting both thresholds (50 -> 80)",
+				prev: {},
+				next: { latency: 80 },
+				advanceMs: 15_000,
+				expected: 2,
+			},
+			{
+				name: "latency change within the cooldown (50 -> 80)",
+				prev: {},
+				next: { latency: 80 },
 				advanceMs: 1_000,
 				expected: 1,
 			},
 			{
-				name: "ratio branch only (50 -> 70)",
+				name: "p2p flip after the cooldown",
 				prev: {},
-				next: { latency: 70 },
-				advanceMs: 1_000,
+				next: { p2p: false },
+				advanceMs: 15_000,
 				expected: 2,
 			},
 			{
-				name: "absolute branch only (200 -> 230)",
-				prev: { latency: 200 },
-				next: { latency: 230 },
-				advanceMs: 1_000,
-				expected: 2,
-			},
-			{
-				name: "p2p flip",
+				name: "p2p flip within the cooldown",
 				prev: {},
 				next: { p2p: false },
 				advanceMs: 1_000,
-				expected: 2,
+				expected: 1,
 			},
 			{
-				name: "DERP region change",
+				name: "DERP region change after the cooldown",
 				prev: {},
 				next: { preferred_derp: "SFO" },
-				advanceMs: 1_000,
+				advanceMs: 15_000,
 				expected: 2,
 			},
 			{
@@ -229,7 +250,7 @@ describe("SshTelemetry", () => {
 				name: "baseline established from zero-latency placeholder (0 -> 5)",
 				prev: { latency: 0 },
 				next: { latency: 5 },
-				advanceMs: 1_000,
+				advanceMs: 15_000,
 				expected: 2,
 			},
 		])(
@@ -244,6 +265,20 @@ describe("SshTelemetry", () => {
 				expect(sink.eventsNamed("ssh.network.sampled")).toHaveLength(expected);
 			},
 		);
+
+		it("coalesces a change suppressed by the cooldown into a later emission", () => {
+			const { ssh, sink } = setup();
+
+			ssh.networkSampled(makeNetworkInfo());
+			vi.advanceTimersByTime(3_000);
+			ssh.networkSampled(makeNetworkInfo({ p2p: false }));
+			vi.advanceTimersByTime(12_000);
+			ssh.networkSampled(makeNetworkInfo({ p2p: false }));
+
+			const samples = sink.eventsNamed("ssh.network.sampled");
+			expect(samples).toHaveLength(2);
+			expect(samples[1].properties.p2p).toBe("false");
+		});
 
 		it("includes p2p, preferred_derp, latency, and bandwidth in the emitted sample", () => {
 			const { ssh, sink } = setup();

--- a/test/unit/logging/httpRequestsTelemetry.test.ts
+++ b/test/unit/logging/httpRequestsTelemetry.test.ts
@@ -77,12 +77,7 @@ describe("HttpRequestsTelemetry", () => {
 			{ method: "GET", route: "/api/v2/workspaces/{id}" },
 			{
 				window_seconds: WINDOW_SECONDS,
-				"count.1xx": 0,
 				"count.2xx": 2,
-				"count.3xx": 0,
-				"count.4xx": 0,
-				"count.5xx": 0,
-				"count.network_error": 0,
 				"duration.p50_ms": 100,
 				"duration.p95_ms": 200,
 				"duration.p99_ms": 200,
@@ -94,6 +89,26 @@ describe("HttpRequestsTelemetry", () => {
 			{ method: "POST", route: "/api/v2/workspaces/{id}" },
 			expect.objectContaining({ "count.2xx": 1 }),
 		);
+	});
+
+	it("omits count keys for status classes with no requests in the window", async () => {
+		start();
+		recordResponse(rollup, {
+			method: "GET",
+			url: "/api/v2/workspaces/abc",
+			status: 200,
+		});
+
+		await advanceOneWindow();
+
+		const [, , measurements] = log.mock.calls[0];
+		expect(Object.keys(measurements ?? {}).sort()).toEqual([
+			"count.2xx",
+			"duration.p50_ms",
+			"duration.p95_ms",
+			"duration.p99_ms",
+			"window_seconds",
+		]);
 	});
 
 	it("counts status code classes and network errors", async () => {
@@ -180,16 +195,11 @@ describe("HttpRequestsTelemetry", () => {
 
 		await advanceOneWindow();
 
-		expect(log).toHaveBeenCalledWith(
-			"http.requests",
-			{ method: "GET", route: "/api/v2/workspaces/{id}" },
-			expect.objectContaining({
-				"count.2xx": 1,
-				"duration.p50_ms": 0,
-				"duration.p95_ms": 0,
-				"duration.p99_ms": 0,
-			}),
-		);
+		const [, , measurements] = log.mock.calls[0];
+		expect(Object.keys(measurements ?? {}).sort()).toEqual([
+			"count.2xx",
+			"window_seconds",
+		]);
 	});
 
 	it("flushes any pending bucket on dispose", () => {

--- a/test/unit/telemetry/export/command.test.ts
+++ b/test/unit/telemetry/export/command.test.ts
@@ -40,7 +40,7 @@ const OK_FLUSH: FlushStatus = { ok: true, sinks: [] };
 function setup(
 	opts: {
 		choice?: ExportChoice;
-		outcome?: { count: number } | { error: unknown };
+		outcome?: { count: number; skipped?: number } | { error: unknown };
 		revealChoice?: string;
 	} = {},
 ) {
@@ -56,7 +56,10 @@ function setup(
 	if ("error" in outcome) {
 		vi.mocked(collectTelemetryExport).mockRejectedValue(outcome.error);
 	} else {
-		vi.mocked(collectTelemetryExport).mockResolvedValue(outcome.count);
+		vi.mocked(collectTelemetryExport).mockResolvedValue({
+			eventCount: outcome.count,
+			skippedFileCount: outcome.skipped ?? 0,
+		});
 	}
 
 	const observer: ExportTelemetryObserver = {
@@ -64,12 +67,15 @@ function setup(
 		error: vi.fn(),
 		succeedExport: vi.fn(),
 	};
+	const logger = createMockLogger();
+
 	return {
 		observer,
+		logger,
 		run: () =>
 			runExportTelemetryCommand(
 				TELEMETRY_DIR,
-				createMockLogger(),
+				logger,
 				vi.fn(() => Promise.resolve(OK_FLUSH)),
 				context,
 				observer,
@@ -114,7 +120,7 @@ describe("runExportTelemetryCommand", () => {
 		vi.mocked(collectTelemetryExport).mockImplementation(
 			(_request, runtime) => {
 				onFlushIncomplete = runtime.onFlushIncomplete;
-				return Promise.resolve(2);
+				return Promise.resolve({ eventCount: 2, skippedFileCount: 0 });
 			},
 		);
 
@@ -135,12 +141,40 @@ describe("runExportTelemetryCommand", () => {
 
 			await run();
 
-			expect(observer.succeedExport).toHaveBeenCalledWith("json", count);
+			expect(observer.succeedExport).toHaveBeenCalledWith("json", {
+				eventCount: count,
+				skippedFileCount: 0,
+			});
 
 			expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
 				`${message} ${OUTPUT_PATH}.`,
 				REVEAL_ACTION,
 			);
+		});
+
+		it("warns and names the skip count when files were skipped", async () => {
+			const { run } = setup({ outcome: { count: 2, skipped: 1 } });
+
+			await run();
+
+			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+				`Exported 2 telemetry events to ${OUTPUT_PATH}. 1 file could not be read. Check the Coder output for details.`,
+				REVEAL_ACTION,
+				"Show Output",
+			);
+			expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+		});
+
+		it("opens the Coder output when Show Output is clicked", async () => {
+			const { logger, run } = setup({ outcome: { count: 2, skipped: 1 } });
+			vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(
+				"Show Output" as never,
+			);
+
+			await run();
+
+			expect(logger.show).toHaveBeenCalled();
+			expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
 		});
 
 		it("reveals the file when the user clicks the action", async () => {
@@ -180,10 +214,24 @@ describe("runExportTelemetryCommand", () => {
 
 			await run();
 
-			expect(observer.succeedExport).toHaveBeenCalledWith("json", 0);
+			expect(observer.succeedExport).toHaveBeenCalledWith("json", {
+				eventCount: 0,
+				skippedFileCount: 0,
+			});
 
 			expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
 				"No telemetry events found for Last 24 hours.",
+			);
+		});
+
+		it("warns when every matching file was skipped", async () => {
+			const { run } = setup({ outcome: { count: 0, skipped: 2 } });
+
+			await run();
+
+			expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+				"No telemetry events found for Last 24 hours. 2 files could not be read. Check the Coder output for details.",
+				"Show Output",
 			);
 		});
 	});

--- a/test/unit/telemetry/export/files.test.ts
+++ b/test/unit/telemetry/export/files.test.ts
@@ -9,7 +9,10 @@ import {
 } from "@/telemetry/export/files";
 import { createCustomDateRange } from "@/telemetry/export/range";
 import { parseFileName } from "@/telemetry/localJsonlFiles";
-import { serializeTelemetryEventLine } from "@/telemetry/wireFormat";
+import {
+	serializeTelemetryEventLine,
+	serializeTelemetryFileHeaderLine,
+} from "@/telemetry/wireFormat";
 
 import { createTelemetryEventFactory } from "../../../mocks/telemetry";
 
@@ -66,18 +69,18 @@ describe("listTelemetryFilesForRange", () => {
 describe("streamTelemetryEventsSorted", () => {
 	it("returns a timestamp-sorted stream with deterministic session-id ties", async () => {
 		writeFiles({
-			"telemetry-2026-05-12-cccccccc.jsonl": serializeTelemetryEventLine(
+			"telemetry-2026-05-12-cccccccc.jsonl": sessionFileContent([
 				makeSessionEvent("session-c", 0, "2026-05-12T10:00:00.000Z"),
-			),
-			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
+			]),
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": sessionFileContent([
 				makeSessionEvent("session-a", 10, "2026-05-12T10:00:00.000Z"),
-			),
-			"telemetry-2026-05-12-bbbbbbbb.jsonl": serializeTelemetryEventLine(
+			]),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl": sessionFileContent([
 				makeSessionEvent("session-b", 0, "2026-05-12T10:01:00.000Z"),
-			),
-			"telemetry-2026-05-12-aaaaaaaa.1.jsonl": serializeTelemetryEventLine(
+			]),
+			"telemetry-2026-05-12-aaaaaaaa.1.jsonl": sessionFileContent([
 				makeSessionEvent("session-a", 11, "2026-05-12T10:02:00.000Z"),
-			),
+			]),
 		});
 
 		const events = await collectSorted([
@@ -103,19 +106,14 @@ describe("streamTelemetryEventsSorted", () => {
 
 	it("filters by range and preserves backward session timestamps", async () => {
 		writeFiles({
-			"telemetry-2026-05-12-aaaaaaaa.jsonl":
-				serializeTelemetryEventLine(
-					makeSessionEvent("session-a", 0, "2026-05-11T23:59:59.999Z"),
-				) +
-				serializeTelemetryEventLine(
-					makeSessionEvent("session-a", 1, "2026-05-12T10:02:00.000Z"),
-				) +
-				serializeTelemetryEventLine(
-					makeSessionEvent("session-a", 2, "2026-05-12T10:00:00.000Z"),
-				),
-			"telemetry-2026-05-12-bbbbbbbb.jsonl": serializeTelemetryEventLine(
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": sessionFileContent([
+				makeSessionEvent("session-a", 0, "2026-05-11T23:59:59.999Z"),
+				makeSessionEvent("session-a", 1, "2026-05-12T10:02:00.000Z"),
+				makeSessionEvent("session-a", 2, "2026-05-12T10:00:00.000Z"),
+			]),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl": sessionFileContent([
 				makeSessionEvent("session-b", 0, "2026-05-12T10:01:00.000Z"),
-			),
+			]),
 		});
 
 		const events = await collectSorted([
@@ -128,6 +126,37 @@ describe("streamTelemetryEventsSorted", () => {
 			"2026-05-12T10:02:00.000Z",
 			"2026-05-12T10:00:00.000Z",
 		]);
+	});
+
+	it("combines each file's header with its rows across multiple files", async () => {
+		const first = makeEvent({ timestamp: "2026-05-12T01:00:00.000Z" });
+		const second = makeEvent({
+			timestamp: "2026-05-12T02:00:00.000Z",
+			context: { ...first.context, sessionId: "other-session" },
+		});
+		writeFiles({
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": sessionFileContent([first]),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl": sessionFileContent([second]),
+		});
+
+		const events = await collectSorted([
+			"telemetry-2026-05-12-aaaaaaaa.jsonl",
+			"telemetry-2026-05-12-bbbbbbbb.jsonl",
+		]);
+
+		expect(events).toEqual([first, second]);
+	});
+
+	it("rejects a file whose rows precede its header", async () => {
+		writeFiles({
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
+				makeEvent({ timestamp: "2026-05-12T01:00:00.000Z" }),
+			),
+		});
+
+		await expect(
+			collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]),
+		).rejects.toThrow(/expected a file header before event rows/);
 	});
 
 	it("surfaces parse errors with file:line context", async () => {
@@ -147,6 +176,14 @@ function writeFiles(files: Record<string, string>): void {
 	for (const [name, content] of Object.entries(files)) {
 		vol.writeFileSync(`${DIR}/${name}`, content);
 	}
+}
+
+/** A file's wire content: its header from the first event's context, then rows. */
+function sessionFileContent(events: readonly TelemetryEvent[]): string {
+	return (
+		serializeTelemetryFileHeaderLine(events[0].context) +
+		events.map(serializeTelemetryEventLine).join("")
+	);
 }
 
 function makeSessionEvent(

--- a/test/unit/telemetry/export/files.test.ts
+++ b/test/unit/telemetry/export/files.test.ts
@@ -83,7 +83,7 @@ describe("streamTelemetryEventsSorted", () => {
 			]),
 		});
 
-		const events = await collectSorted([
+		const events = await drain([
 			"telemetry-2026-05-12-aaaaaaaa.1.jsonl",
 			"telemetry-2026-05-12-bbbbbbbb.jsonl",
 			"telemetry-2026-05-12-cccccccc.jsonl",
@@ -116,7 +116,7 @@ describe("streamTelemetryEventsSorted", () => {
 			]),
 		});
 
-		const events = await collectSorted([
+		const events = await drain([
 			"telemetry-2026-05-12-aaaaaaaa.jsonl",
 			"telemetry-2026-05-12-bbbbbbbb.jsonl",
 		]);
@@ -139,7 +139,7 @@ describe("streamTelemetryEventsSorted", () => {
 			"telemetry-2026-05-12-bbbbbbbb.jsonl": sessionFileContent([second]),
 		});
 
-		const events = await collectSorted([
+		const events = await drain([
 			"telemetry-2026-05-12-aaaaaaaa.jsonl",
 			"telemetry-2026-05-12-bbbbbbbb.jsonl",
 		]);
@@ -147,28 +147,94 @@ describe("streamTelemetryEventsSorted", () => {
 		expect(events).toEqual([first, second]);
 	});
 
-	it("rejects a file whose rows precede its header", async () => {
+	it("skips a file whose rows precede its header and reports it", async () => {
 		writeFiles({
 			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
 				makeEvent({ timestamp: "2026-05-12T01:00:00.000Z" }),
 			),
 		});
+		const onFileError = vi.fn();
 
-		await expect(
-			collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]),
-		).rejects.toThrow(/expected a file header before event rows/);
+		const events = await drain(
+			["telemetry-2026-05-12-aaaaaaaa.jsonl"],
+			onFileError,
+		);
+
+		expect(events).toEqual([]);
+		expect(onFileError).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: expect.stringMatching(
+					/expected a file header before event rows/,
+				),
+			}),
+			"telemetry-2026-05-12-aaaaaaaa.jsonl",
+		);
 	});
 
-	it("surfaces parse errors with file:line context", async () => {
+	it("reports parse errors with file:line context", async () => {
 		writeFiles({
 			"telemetry-2026-05-12-aaaaaaaa.jsonl": "{not-json}\n",
 		});
+		const onFileError = vi.fn();
 
-		await expect(
-			collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]),
-		).rejects.toThrow(
-			/Failed to parse telemetry file telemetry-2026-05-12-aaaaaaaa\.jsonl:1/,
+		await drain(["telemetry-2026-05-12-aaaaaaaa.jsonl"], onFileError);
+
+		expect(onFileError).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: expect.stringMatching(
+					/Failed to parse telemetry file telemetry-2026-05-12-aaaaaaaa\.jsonl:1/,
+				),
+			}),
+			"telemetry-2026-05-12-aaaaaaaa.jsonl",
 		);
+	});
+
+	it("skips a file that cannot be opened and reports it", async () => {
+		const onFileError = vi.fn();
+
+		const events = await drain(
+			["telemetry-2026-05-12-gone0000.jsonl"],
+			onFileError,
+		);
+
+		expect(events).toEqual([]);
+		expect(onFileError).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: expect.stringMatching(
+					/Failed to read telemetry file telemetry-2026-05-12-gone0000\.jsonl/,
+				),
+			}),
+			"telemetry-2026-05-12-gone0000.jsonl",
+		);
+	});
+
+	it("keeps a corrupt file's earlier events and continues with later files", async () => {
+		const first = makeEvent({ timestamp: "2026-05-12T01:00:00.000Z" });
+		const lost = makeEvent({ timestamp: "2026-05-12T02:00:00.000Z" });
+		const second = makeEvent({ timestamp: "2026-05-12T03:00:00.000Z" });
+		writeFiles({
+			"telemetry-2026-05-12-aaaaaaaa.jsonl":
+				serializeTelemetryFileHeaderLine(first.context) +
+				serializeTelemetryEventLine(first) +
+				"{not-json}\n" +
+				serializeTelemetryEventLine(lost),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl":
+				serializeTelemetryFileHeaderLine(second.context) +
+				serializeTelemetryEventLine(second),
+		});
+		const onFileError = vi.fn();
+
+		const events = await drain(
+			[
+				"telemetry-2026-05-12-aaaaaaaa.jsonl",
+				"telemetry-2026-05-12-bbbbbbbb.jsonl",
+			],
+			onFileError,
+		);
+
+		// The rest of the corrupt file is dropped; events already parsed stay.
+		expect(events).toEqual([first, second]);
+		expect(onFileError).toHaveBeenCalledOnce();
 	});
 });
 
@@ -206,13 +272,18 @@ function makeLogFile(name: string): TelemetryLogFile {
 	return { path: `${DIR}/${name}`, ...parsed };
 }
 
-async function collectSorted(
+/** `onFileError` defaults to rethrowing so a happy-path test cannot skip silently. */
+async function drain(
 	names: readonly string[],
+	onFileError: (err: Error, fileName: string) => void = (err) => {
+		throw err;
+	},
 ): Promise<TelemetryEvent[]> {
 	const events: TelemetryEvent[] = [];
 	for await (const event of streamTelemetryEventsSorted(
 		names.map(makeLogFile),
 		createCustomDateRange("2026-05-12", "2026-05-12"),
+		onFileError,
 	)) {
 		events.push(event);
 	}

--- a/test/unit/telemetry/export/pipeline.test.ts
+++ b/test/unit/telemetry/export/pipeline.test.ts
@@ -71,6 +71,7 @@ function setup(
 		flushTelemetry,
 		report: vi.fn(),
 		onFlushIncomplete: vi.fn(),
+		onFileSkipped: vi.fn(),
 		onCleanupError: vi.fn(),
 	};
 	const request: ExportRequest = {
@@ -120,7 +121,10 @@ describe("collectTelemetryExport", () => {
 	it("returns 0 and never writes when no files cover the range", async () => {
 		const { run, writer } = setup({ files: [] });
 
-		await expect(run()).resolves.toBe(0);
+		await expect(run()).resolves.toEqual({
+			eventCount: 0,
+			skippedFileCount: 0,
+		});
 		expect(writer).not.toHaveBeenCalled();
 		expect(fsp.rm).not.toHaveBeenCalled();
 	});
@@ -128,7 +132,29 @@ describe("collectTelemetryExport", () => {
 	it("returns the writer's event count", async () => {
 		const { run } = setup({ writeCount: 5 });
 
-		await expect(run()).resolves.toBe(5);
+		await expect(run()).resolves.toEqual({
+			eventCount: 5,
+			skippedFileCount: 0,
+		});
+	});
+
+	it("counts files the stream skips and notifies the host of each", async () => {
+		const { run, runtime } = setup({ writeCount: 1 });
+		vi.mocked(files.streamTelemetryEventsSorted).mockImplementation(
+			(_files, _range, onFileError) => {
+				onFileError(new Error("corrupt"), "a.jsonl");
+				return asyncIterable([makeEvent()]);
+			},
+		);
+
+		await expect(run()).resolves.toEqual({
+			eventCount: 1,
+			skippedFileCount: 1,
+		});
+		expect(runtime.onFileSkipped).toHaveBeenCalledWith(
+			expect.any(Error),
+			"a.jsonl",
+		);
 	});
 
 	it("passes the descriptor, output path, signal, and cleanup handler to the writer", async () => {
@@ -147,7 +173,7 @@ describe("collectTelemetryExport", () => {
 	it("removes the empty output file when the writer wrote nothing", async () => {
 		const { run } = setup({ writeCount: 0 });
 
-		await expect(run()).resolves.toBe(0);
+		await expect(run()).resolves.toMatchObject({ eventCount: 0 });
 		expect(fsp.rm).toHaveBeenCalledWith(OUTPUT_PATH, { force: true });
 	});
 
@@ -163,7 +189,7 @@ describe("collectTelemetryExport", () => {
 		const { run, runtime } = setup({ writeCount: 0 });
 		vi.mocked(fsp.rm).mockRejectedValue(new Error("EACCES"));
 
-		await expect(run()).resolves.toBe(0);
+		await expect(run()).resolves.toMatchObject({ eventCount: 0 });
 		expect(runtime.onCleanupError).toHaveBeenCalledWith(
 			expect.any(Error),
 			OUTPUT_PATH,

--- a/test/unit/telemetry/export/writers/otlp/__golden__/envelope-logs.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/envelope-logs.json
@@ -106,24 +106,6 @@
                   "value": {
                     "doubleValue": 842
                   }
-                },
-                {
-                  "key": "coder.event.extension_version",
-                  "value": {
-                    "stringValue": "1.14.5"
-                  }
-                },
-                {
-                  "key": "coder.event.session_id",
-                  "value": {
-                    "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                  }
-                },
-                {
-                  "key": "coder.event.deployment_url",
-                  "value": {
-                    "stringValue": "https://dev.coder.com"
-                  }
                 }
               ]
             },
@@ -170,24 +152,6 @@
                   "key": "exception.code",
                   "value": {
                     "stringValue": "ECONNREFUSED"
-                  }
-                },
-                {
-                  "key": "coder.event.extension_version",
-                  "value": {
-                    "stringValue": "1.14.5"
-                  }
-                },
-                {
-                  "key": "coder.event.session_id",
-                  "value": {
-                    "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                  }
-                },
-                {
-                  "key": "coder.event.deployment_url",
-                  "value": {
-                    "stringValue": "https://dev.coder.com"
                   }
                 }
               ]

--- a/test/unit/telemetry/export/writers/otlp/__golden__/envelope-metrics.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/envelope-metrics.json
@@ -101,24 +101,6 @@
                         "value": {
                           "stringValue": "http.requests"
                         }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
-                        }
                       }
                     ],
                     "startTimeUnixNano": "1777918320000000000",
@@ -154,24 +136,6 @@
                         "key": "coder.event_name",
                         "value": {
                           "stringValue": "http.requests"
-                        }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
                         }
                       }
                     ],
@@ -209,24 +173,6 @@
                         "value": {
                           "stringValue": "http.requests"
                         }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
-                        }
                       }
                     ],
                     "startTimeUnixNano": "1777918320000000000",
@@ -260,24 +206,6 @@
                         "key": "coder.event_name",
                         "value": {
                           "stringValue": "http.requests"
-                        }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
                         }
                       }
                     ],
@@ -313,24 +241,6 @@
                         "value": {
                           "stringValue": "http.requests"
                         }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
-                        }
                       }
                     ],
                     "startTimeUnixNano": "1777918320000000000",
@@ -364,24 +274,6 @@
                         "key": "coder.event_name",
                         "value": {
                           "stringValue": "http.requests"
-                        }
-                      },
-                      {
-                        "key": "coder.event.extension_version",
-                        "value": {
-                          "stringValue": "1.14.5"
-                        }
-                      },
-                      {
-                        "key": "coder.event.session_id",
-                        "value": {
-                          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                        }
-                      },
-                      {
-                        "key": "coder.event.deployment_url",
-                        "value": {
-                          "stringValue": "https://dev.coder.com"
                         }
                       }
                     ],

--- a/test/unit/telemetry/export/writers/otlp/__golden__/envelope-traces.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/envelope-traces.json
@@ -99,24 +99,6 @@
                   "value": {
                     "stringValue": "remote.setup.workspace_ready"
                   }
-                },
-                {
-                  "key": "coder.event.extension_version",
-                  "value": {
-                    "stringValue": "1.14.5"
-                  }
-                },
-                {
-                  "key": "coder.event.session_id",
-                  "value": {
-                    "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                  }
-                },
-                {
-                  "key": "coder.event.deployment_url",
-                  "value": {
-                    "stringValue": "https://dev.coder.com"
-                  }
                 }
               ],
               "status": {
@@ -154,24 +136,6 @@
                   "key": "coder.event_name",
                   "value": {
                     "stringValue": "remote.ssh.connect"
-                  }
-                },
-                {
-                  "key": "coder.event.extension_version",
-                  "value": {
-                    "stringValue": "1.14.5"
-                  }
-                },
-                {
-                  "key": "coder.event.session_id",
-                  "value": {
-                    "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-                  }
-                },
-                {
-                  "key": "coder.event.deployment_url",
-                  "value": {
-                    "stringValue": "https://dev.coder.com"
                   }
                 },
                 {

--- a/test/unit/telemetry/export/writers/otlp/__golden__/log-records.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/log-records.json
@@ -31,24 +31,6 @@
         "value": {
           "doubleValue": 842
         }
-      },
-      {
-        "key": "coder.event.extension_version",
-        "value": {
-          "stringValue": "1.14.5"
-        }
-      },
-      {
-        "key": "coder.event.session_id",
-        "value": {
-          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-        }
-      },
-      {
-        "key": "coder.event.deployment_url",
-        "value": {
-          "stringValue": "https://dev.coder.com"
-        }
       }
     ]
   },
@@ -95,24 +77,6 @@
         "key": "exception.code",
         "value": {
           "stringValue": "ECONNREFUSED"
-        }
-      },
-      {
-        "key": "coder.event.extension_version",
-        "value": {
-          "stringValue": "1.14.5"
-        }
-      },
-      {
-        "key": "coder.event.session_id",
-        "value": {
-          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-        }
-      },
-      {
-        "key": "coder.event.deployment_url",
-        "value": {
-          "stringValue": "https://dev.coder.com"
         }
       }
     ]

--- a/test/unit/telemetry/export/writers/otlp/__golden__/metric-records.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/metric-records.json
@@ -26,24 +26,6 @@
               "value": {
                 "stringValue": "http.requests"
               }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
-              }
             }
           ],
           "startTimeUnixNano": "1777918320000000000",
@@ -79,24 +61,6 @@
               "key": "coder.event_name",
               "value": {
                 "stringValue": "http.requests"
-              }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
               }
             }
           ],
@@ -134,24 +98,6 @@
               "value": {
                 "stringValue": "http.requests"
               }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
-              }
             }
           ],
           "startTimeUnixNano": "1777918320000000000",
@@ -185,24 +131,6 @@
               "key": "coder.event_name",
               "value": {
                 "stringValue": "http.requests"
-              }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
               }
             }
           ],
@@ -238,24 +166,6 @@
               "value": {
                 "stringValue": "http.requests"
               }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
-              }
             }
           ],
           "startTimeUnixNano": "1777918320000000000",
@@ -289,24 +199,6 @@
               "key": "coder.event_name",
               "value": {
                 "stringValue": "http.requests"
-              }
-            },
-            {
-              "key": "coder.event.extension_version",
-              "value": {
-                "stringValue": "1.14.5"
-              }
-            },
-            {
-              "key": "coder.event.session_id",
-              "value": {
-                "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-              }
-            },
-            {
-              "key": "coder.event.deployment_url",
-              "value": {
-                "stringValue": "https://dev.coder.com"
               }
             }
           ],

--- a/test/unit/telemetry/export/writers/otlp/__golden__/span-records.json
+++ b/test/unit/telemetry/export/writers/otlp/__golden__/span-records.json
@@ -24,24 +24,6 @@
         "value": {
           "stringValue": "remote.setup.workspace_ready"
         }
-      },
-      {
-        "key": "coder.event.extension_version",
-        "value": {
-          "stringValue": "1.14.5"
-        }
-      },
-      {
-        "key": "coder.event.session_id",
-        "value": {
-          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-        }
-      },
-      {
-        "key": "coder.event.deployment_url",
-        "value": {
-          "stringValue": "https://dev.coder.com"
-        }
       }
     ],
     "status": {
@@ -79,24 +61,6 @@
         "key": "coder.event_name",
         "value": {
           "stringValue": "remote.ssh.connect"
-        }
-      },
-      {
-        "key": "coder.event.extension_version",
-        "value": {
-          "stringValue": "1.14.5"
-        }
-      },
-      {
-        "key": "coder.event.session_id",
-        "value": {
-          "stringValue": "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
-        }
-      },
-      {
-        "key": "coder.event.deployment_url",
-        "value": {
-          "stringValue": "https://dev.coder.com"
         }
       },
       {

--- a/test/unit/telemetry/export/writers/otlp/envelope.test.ts
+++ b/test/unit/telemetry/export/writers/otlp/envelope.test.ts
@@ -53,39 +53,68 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe("openEnvelopeFile", () => {
-	it("writes only the prefix and suffix when no values are appended", async () => {
-		const env = await openEnvelopeFile("/x.json", "PRE", "SUF");
+	it("writes only the file prefix and suffix when no block is opened", async () => {
+		const env = await openEnvelopeFile("/x.json", "PRE", "END", "SUF");
 		await env.close();
 		expect(stream.chunks.join("")).toBe("PRESUF");
 	});
 
-	it("serializes appended values as JSON, comma-separated", async () => {
-		const env = await openEnvelopeFile("/x.json", "[", "]");
+	it("serializes appended values as JSON, comma-separated, inside a block", async () => {
+		const env = await openEnvelopeFile("/x.json", "[", "}", "]");
+		await env.openBlock("{");
 		await env.append({ a: 1 });
 		await env.append("two");
 		await env.append([3, 4]);
 		await env.close();
-		expect(stream.chunks.join("")).toBe('[{"a":1},"two",[3,4]]');
+		expect(stream.chunks.join("")).toBe('[{{"a":1},"two",[3,4]}]');
 	});
 
 	it("inserts commas between values but not before the first", async () => {
-		const env = await openEnvelopeFile("/x.json", "[", "]");
+		const env = await openEnvelopeFile("/x.json", "[", "}", "]");
+		await env.openBlock("{");
 		await env.append(1);
 		await env.append(2);
 		await env.close();
-		expect(stream.chunks).toEqual(["[", "1", ",2", "]"]);
+		expect(stream.chunks).toEqual(["[", "{", "1", ",2", "}]"]);
+	});
+
+	it("closes the previous block, separates blocks with a comma, and restarts comma separation", async () => {
+		const env = await openEnvelopeFile("/x.json", "[", "}", "]");
+		await env.openBlock("{");
+		await env.append(1);
+		await env.openBlock("{");
+		await env.append(2);
+		await env.append(3);
+		await env.close();
+		expect(stream.chunks).toEqual(["[", "{", "1", "},{", "2", ",3", "}]"]);
+	});
+
+	it("rejects appends when no block is open", async () => {
+		const env = await openEnvelopeFile("/x.json", "[", "}", "]");
+		await expect(env.append(1)).rejects.toThrow(
+			"No open block to append to in /x.json",
+		);
 	});
 
 	it("wraps prefix-write failures with the file path and releases the fd", async () => {
 		stream.writeFailMsg = "disk full";
-		await expect(openEnvelopeFile("/foo.json", "[", "]")).rejects.toThrow(
+		await expect(openEnvelopeFile("/foo.json", "[", "}", "]")).rejects.toThrow(
 			"Failed to write /foo.json: disk full",
 		);
 		expect(stream.destroyed).toBe(1);
 	});
 
+	it("wraps block-open write failures with the file path", async () => {
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
+		stream.writeFailMsg = "disk full";
+		await expect(env.openBlock("{")).rejects.toThrow(
+			"Failed to write /foo.json: disk full",
+		);
+	});
+
 	it("wraps append-time write failures with the file path", async () => {
-		const env = await openEnvelopeFile("/foo.json", "[", "]");
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
+		await env.openBlock("{");
 		stream.writeFailMsg = "disk full";
 		await expect(env.append({ a: 1 })).rejects.toThrow(
 			"Failed to write /foo.json: disk full",
@@ -93,7 +122,7 @@ describe("openEnvelopeFile", () => {
 	});
 
 	it("wraps suffix-write failures during close as a close failure and releases the fd", async () => {
-		const env = await openEnvelopeFile("/foo.json", "[", "]");
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
 		stream.writeFailMsg = "disk full";
 		await expect(env.close()).rejects.toThrow(
 			"Failed to close /foo.json: disk full",
@@ -102,7 +131,7 @@ describe("openEnvelopeFile", () => {
 	});
 
 	it("wraps stream.end failures with the file path and releases the fd", async () => {
-		const env = await openEnvelopeFile("/foo.json", "[", "]");
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
 		stream.endFailMsg = "stream gone";
 		await expect(env.close()).rejects.toThrow(
 			"Failed to close /foo.json: stream gone",
@@ -111,7 +140,8 @@ describe("openEnvelopeFile", () => {
 	});
 
 	it("rejects subsequent writes after the stream emits 'error'", async () => {
-		const env = await openEnvelopeFile("/foo.json", "[", "]");
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
+		await env.openBlock("{");
 		stream.emit("error", new Error("ENOENT"));
 		await expect(env.append({ a: 1 })).rejects.toThrow(
 			"Failed to write /foo.json: ENOENT",
@@ -119,7 +149,7 @@ describe("openEnvelopeFile", () => {
 	});
 
 	it("is idempotent: calling close() twice is safe", async () => {
-		const env = await openEnvelopeFile("/foo.json", "[", "]");
+		const env = await openEnvelopeFile("/foo.json", "[", "}", "]");
 		await env.close();
 		// Second close is a no-op and does not double-write the suffix.
 		await env.close();

--- a/test/unit/telemetry/export/writers/otlp/helpers.ts
+++ b/test/unit/telemetry/export/writers/otlp/helpers.ts
@@ -113,10 +113,17 @@ export function attrs(raw: unknown): Record<string, string | number> {
 	);
 }
 
-export interface ParsedEnvelope {
+/** One resource block of an OTLP/JSON envelope. */
+export interface ParsedBlock {
 	resource: { attributes: unknown };
 	schemaUrl: unknown;
 	scope: { name: string; version: string };
+	records: unknown[];
+}
+
+export interface ParsedEnvelope {
+	blocks: ParsedBlock[];
+	/** Records of all blocks, flattened in file order. */
 	records: unknown[];
 }
 
@@ -128,12 +135,14 @@ export function parseEnvelope(
 	const env = ENVELOPES[signal];
 	type Rec = Record<string, unknown>;
 	const json = JSON.parse(new TextDecoder().decode(files[env.file])) as Rec;
-	const wrapper = (json[env.resourceKey] as Rec[])[0];
-	const scopeWrapper = (wrapper[env.scopeKey] as Rec[])[0];
-	return {
-		resource: wrapper.resource as { attributes: unknown },
-		schemaUrl: wrapper.schemaUrl,
-		scope: scopeWrapper.scope as { name: string; version: string },
-		records: scopeWrapper[env.recordsKey] as unknown[],
-	};
+	const blocks = (json[env.resourceKey] as Rec[]).map((wrapper) => {
+		const scopeWrapper = (wrapper[env.scopeKey] as Rec[])[0];
+		return {
+			resource: wrapper.resource as { attributes: unknown },
+			schemaUrl: wrapper.schemaUrl,
+			scope: scopeWrapper.scope as { name: string; version: string },
+			records: scopeWrapper[env.recordsKey] as unknown[],
+		};
+	});
+	return { blocks, records: blocks.flatMap((block) => block.records) };
 }

--- a/test/unit/telemetry/export/writers/otlp/metricBlockBuffer.test.ts
+++ b/test/unit/telemetry/export/writers/otlp/metricBlockBuffer.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { MetricBlockBuffer } from "@/telemetry/export/writers/otlp/metricBlockBuffer";
+import {
+	type CumulativeState,
+	metricRecords,
+	newCumulativeState,
+} from "@/telemetry/export/writers/otlp/records";
+
+import { createTelemetryEventFactory } from "../../../../../mocks/telemetry";
+
+import type { MetricMeasurement } from "@/telemetry/export/metrics";
+
+const makeEvent = createTelemetryEventFactory();
+
+const gauge = (name: string, value: number, unit = "1"): MetricMeasurement => ({
+	name,
+	value,
+	kind: "gauge",
+	unit,
+});
+const counter = (
+	name: string,
+	value: number,
+	unit = "{request}",
+): MetricMeasurement => ({ name, value, kind: "counter", unit });
+
+const windowed = (
+	timestamp: string,
+	measurements: MetricMeasurement[],
+	state: CumulativeState,
+) =>
+	metricRecords(
+		makeEvent({ eventName: "http.requests", timestamp }),
+		{ windowSeconds: 60, measurements },
+		state,
+	);
+
+describe("MetricBlockBuffer", () => {
+	it("groups data points under one metric per series in first-seen order", () => {
+		const state = newCumulativeState();
+		const buffer = new MetricBlockBuffer();
+		buffer.add(
+			windowed(
+				"2026-05-04T12:01:00.000Z",
+				[counter("count.2xx", 2), gauge("p95_duration_ms", 10, "ms")],
+				state,
+			),
+		);
+		buffer.add(
+			windowed(
+				"2026-05-04T12:02:00.000Z",
+				[counter("count.2xx", 3), gauge("p95_duration_ms", 20, "ms")],
+				state,
+			),
+		);
+
+		const drained = buffer.drain();
+
+		expect(drained.map((r) => r.name)).toEqual([
+			"http.requests.count.2xx",
+			"http.requests.p95_duration_ms",
+		]);
+		expect(drained[0].sum!.dataPoints.map((p) => p.asInt)).toEqual(["2", "5"]);
+		expect(drained[1].gauge!.dataPoints.map((p) => p.asDouble)).toEqual([
+			10, 20,
+		]);
+		// Draining clears the buffer.
+		expect(buffer.drain()).toEqual([]);
+	});
+
+	it("keeps series with the same name but different units apart", () => {
+		const buffer = new MetricBlockBuffer();
+		const event = makeEvent({ eventName: "ssh.network.sampled" });
+		buffer.add(
+			metricRecords(
+				event,
+				{ measurements: [gauge("latency", 1, "ms")] },
+				newCumulativeState(),
+			),
+		);
+		buffer.add(
+			metricRecords(
+				event,
+				{ measurements: [gauge("latency", 2, "s")] },
+				newCumulativeState(),
+			),
+		);
+
+		expect(buffer.drain().map((r) => [r.name, r.unit])).toEqual([
+			["ssh.network.sampled.latency", "ms"],
+			["ssh.network.sampled.latency", "s"],
+		]);
+	});
+});

--- a/test/unit/telemetry/export/writers/otlp/records.test.ts
+++ b/test/unit/telemetry/export/writers/otlp/records.test.ts
@@ -21,13 +21,6 @@ import { GOLDEN_EVENTS, TRACE_ID, attrs } from "./helpers";
 
 const makeEvent = createTelemetryEventFactory();
 
-/** Per-event identity that every record carries, derived from the factory defaults. */
-const EVENT_CONTEXT_ATTRS = {
-	"coder.event.extension_version": "1.14.5",
-	"coder.event.session_id": "session-id",
-	"coder.event.deployment_url": "https://coder.example.com",
-} as const;
-
 const makeSpanEvent = (overrides: Parameters<typeof makeEvent>[0] = {}) => ({
 	...makeEvent({ traceId: TRACE_ID, ...overrides }),
 	traceId: TRACE_ID,
@@ -89,7 +82,6 @@ describe("logRecord", () => {
 		});
 		expect(record.timeUnixNano).toBe(record.observedTimeUnixNano);
 		expect(attrs(record.attributes)).toEqual({
-			...EVENT_CONTEXT_ATTRS,
 			source: "unit",
 			count: 3,
 		});
@@ -110,28 +102,14 @@ describe("logRecord", () => {
 			"exception.code": "E_RANGE",
 		});
 		expect(attrs(minimal.attributes)).toEqual({
-			...EVENT_CONTEXT_ATTRS,
 			"exception.message": "boom",
 		});
 	});
 
-	it("stamps each event's own context onto its record", () => {
-		const base = makeEvent();
-		const record = logRecord({
-			...base,
-			context: {
-				...base.context,
-				extensionVersion: "0.9.0",
-				sessionId: "older-session",
-				deploymentUrl: "https://prev.coder.example.com",
-			},
-		});
+	it("carries no per-record provenance; identity lives on the block resource", () => {
+		const record = logRecord(makeEvent());
 
-		expect(attrs(record.attributes)).toMatchObject({
-			"coder.event.extension_version": "0.9.0",
-			"coder.event.session_id": "older-session",
-			"coder.event.deployment_url": "https://prev.coder.example.com",
-		});
+		expect(attrs(record.attributes)).toEqual({});
 	});
 
 	it("links span-attached logs to their parent span", () => {
@@ -180,7 +158,6 @@ describe("spanRecord", () => {
 		);
 		expect(attrs(span.attributes)).toEqual({
 			"coder.event_name": "remote.setup.workspace_ready",
-			...EVENT_CONTEXT_ATTRS,
 			result: "success",
 			route: "/api",
 			retries: 2,

--- a/test/unit/telemetry/export/writers/otlp/writer.test.ts
+++ b/test/unit/telemetry/export/writers/otlp/writer.test.ts
@@ -1,10 +1,11 @@
-import { unzipSync } from "fflate";
+import { unzipSync, type DeflateOptions } from "fflate";
 import { vol } from "memfs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ENVELOPES } from "@/telemetry/export/writers/otlp/records";
 import {
+	MAX_BUFFERED_METRIC_POINTS,
 	type OtlpExportCounts,
 	writeOtlpZipExport,
 } from "@/telemetry/export/writers/otlp/writer";
@@ -33,6 +34,21 @@ vi.mock("node:os", async () => {
 	return { ...actual, tmpdir: () => "/tmp" };
 });
 
+/** Constructor options of every ZipDeflate created during a test. */
+const zipDeflateOptions = vi.hoisted(() => ({
+	current: [] as Array<{ level?: number } | undefined>,
+}));
+vi.mock("fflate", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fflate")>();
+	class RecordingZipDeflate extends actual.ZipDeflate {
+		constructor(filename: string, opts?: DeflateOptions) {
+			super(filename, opts);
+			zipDeflateOptions.current.push(opts);
+		}
+	}
+	return { ...actual, ZipDeflate: RecordingZipDeflate };
+});
+
 const OUT = "/exports/telemetry.otlp.zip";
 /** Matches what writer.ts passes to fs.mkdtemp on every platform. */
 const STAGING_PREFIX = path.join("/tmp", "coder-telemetry-otlp-");
@@ -50,10 +66,18 @@ const DESCRIPTOR: ExportDescriptor = {
 const makeEvent = createTelemetryEventFactory();
 const { context } = makeEvent();
 
+/** Shape of a grouped metric record as read back from `metrics.json`. */
+interface MetricRecord {
+	name: string;
+	sum?: { dataPoints: Array<{ asInt: string }> };
+	gauge?: { dataPoints: Array<{ asDouble: number }> };
+}
+
 beforeEach(() => {
 	vol.reset();
 	vol.mkdirSync("/exports", { recursive: true });
 	vol.mkdirSync("/tmp", { recursive: true });
+	zipDeflateOptions.current = [];
 });
 
 afterEach(() => vol.reset());
@@ -106,13 +130,13 @@ describe("writeOtlpZipExport", () => {
 		}
 	});
 
-	it("produces three empty-array envelopes for an empty event stream", async () => {
+	it("produces envelopes with no resource blocks for an empty event stream", async () => {
 		const { counts, logs, traces, metrics } = await exportAndRead([]);
 
 		expect(counts).toEqual({ logs: 0, traces: 0, metrics: 0 });
-		expect(logs.records).toEqual([]);
-		expect(traces.records).toEqual([]);
-		expect(metrics.records).toEqual([]);
+		expect(logs.blocks).toEqual([]);
+		expect(traces.blocks).toEqual([]);
+		expect(metrics.blocks).toEqual([]);
 	});
 
 	it("routes metric-named events to metrics even when a traceId is present", async () => {
@@ -171,16 +195,158 @@ describe("writeOtlpZipExport", () => {
 		]);
 
 		for (const other of [traces, metrics]) {
-			expect(other.resource).toEqual(logs.resource);
-			expect(other.scope).toEqual(logs.scope);
-			expect(other.schemaUrl).toBe(logs.schemaUrl);
+			expect(other.blocks[0].resource).toEqual(logs.blocks[0].resource);
+			expect(other.blocks[0].scope).toEqual(logs.blocks[0].scope);
+			expect(other.blocks[0].schemaUrl).toBe(logs.blocks[0].schemaUrl);
 		}
 		// Spot-check the resource carries the extension identity; full shape is
 		// asserted in records.test.ts.
-		expect(attrs(logs.resource.attributes)).toMatchObject({
+		expect(attrs(logs.blocks[0].resource.attributes)).toMatchObject({
 			"service.name": "coder-vscode-extension",
 			"service.version": "1.14.5",
 		});
+	});
+
+	it("starts a new resource block when the producing session changes", async () => {
+		const withSession = (sessionId: string) =>
+			makeEvent({ context: { ...context, sessionId } });
+		const { logs } = await exportAndRead([
+			withSession("session-a"),
+			withSession("session-a"),
+			withSession("session-b"),
+		]);
+
+		expect(logs.blocks).toHaveLength(2);
+		expect(logs.blocks[0].records).toHaveLength(2);
+		expect(logs.blocks[1].records).toHaveLength(1);
+		expect(
+			logs.blocks.map(
+				(block) => attrs(block.resource.attributes)["service.instance.id"],
+			),
+		).toEqual(["session-a", "session-b"]);
+	});
+
+	it("attributes each block to the producing event's context, not the exporter's", async () => {
+		const producer = {
+			...context,
+			extensionVersion: "0.9.0",
+			sessionId: "older-session",
+			deploymentUrl: "https://prev.coder.example.com",
+		};
+		// exportAndRead exports with the factory-default context as the exporter.
+		const { logs } = await exportAndRead([makeEvent({ context: producer })]);
+
+		expect(attrs(logs.blocks[0].resource.attributes)).toMatchObject({
+			"service.version": "0.9.0",
+			"service.instance.id": "older-session",
+			"coder.deployment.url": "https://prev.coder.example.com",
+		});
+		// The scope still identifies the exporting extension.
+		expect(logs.blocks[0].scope.version).toBe("1.14.5");
+	});
+
+	it("starts a new resource block when the event date changes within a session", async () => {
+		const { logs } = await exportAndRead([
+			makeEvent({ timestamp: "2026-05-04T23:59:00.000Z" }),
+			makeEvent({ timestamp: "2026-05-05T00:01:00.000Z" }),
+		]);
+
+		expect(logs.blocks).toHaveLength(2);
+		expect(logs.blocks[1].resource).toEqual(logs.blocks[0].resource);
+	});
+
+	it("groups metric data points under one metric per series within a block", async () => {
+		const { counts, metrics } = await exportAndRead([
+			makeEvent({
+				eventName: "http.requests",
+				timestamp: "2026-05-04T12:01:00.000Z",
+				measurements: {
+					window_seconds: 60,
+					"count.2xx": 2,
+					"duration.p95_ms": 5,
+				},
+			}),
+			makeEvent({
+				eventName: "http.requests",
+				timestamp: "2026-05-04T12:02:00.000Z",
+				measurements: {
+					window_seconds: 60,
+					"count.2xx": 3,
+					"duration.p95_ms": 7,
+				},
+			}),
+		]);
+
+		expect(counts.metrics).toBe(2);
+		expect(metrics.blocks).toHaveLength(1);
+		const records = metrics.blocks[0].records as MetricRecord[];
+		const byName = new Map(records.map((r) => [r.name, r]));
+		expect(records).toHaveLength(2);
+		expect(
+			byName
+				.get("http.requests.count.2xx")!
+				.sum!.dataPoints.map((p) => p.asInt),
+		).toEqual(["2", "5"]);
+		expect(
+			byName
+				.get("http.requests.duration.p95")!
+				.gauge!.dataPoints.map((p) => p.asDouble),
+		).toEqual([5, 7]);
+	});
+
+	it("force-flushes the metric buffer at the point cap within one block", async () => {
+		const events = Array.from({ length: MAX_BUFFERED_METRIC_POINTS + 1 }, () =>
+			makeEvent({
+				eventName: "http.requests",
+				timestamp: "2026-05-04T12:01:00.000Z",
+				measurements: { window_seconds: 60, "count.2xx": 1 },
+			}),
+		);
+
+		const { metrics } = await exportAndRead(events);
+
+		// The capped series splits into a second entry in the same block.
+		expect(metrics.blocks).toHaveLength(1);
+		const records = metrics.blocks[0].records as MetricRecord[];
+		expect(records.map((r) => r.name)).toEqual([
+			"http.requests.count.2xx",
+			"http.requests.count.2xx",
+		]);
+		expect(records.flatMap((r) => r.sum!.dataPoints)).toHaveLength(
+			MAX_BUFFERED_METRIC_POINTS + 1,
+		);
+	});
+
+	it("resets cumulative counter totals at each block boundary", async () => {
+		const httpEvent = (sessionId: string, timestamp: string, count: number) =>
+			makeEvent({
+				eventName: "http.requests",
+				timestamp,
+				context: { ...context, sessionId },
+				measurements: { window_seconds: 60, "count.2xx": count },
+			});
+		const { metrics } = await exportAndRead([
+			httpEvent("session-a", "2026-05-04T12:01:00.000Z", 2),
+			httpEvent("session-a", "2026-05-04T12:02:00.000Z", 3),
+			httpEvent("session-b", "2026-05-04T12:03:00.000Z", 7),
+		]);
+
+		expect(metrics.blocks).toHaveLength(2);
+		const [a] = metrics.blocks[0].records as MetricRecord[];
+		const [b] = metrics.blocks[1].records as MetricRecord[];
+		expect(a.sum!.dataPoints.map((p) => p.asInt)).toEqual(["2", "5"]);
+		// Session B starts its own total instead of inheriting session A's 5.
+		expect(b.sum!.dataPoints.map((p) => p.asInt)).toEqual(["7"]);
+	});
+
+	it("compresses every zip entry at maximum deflate level", async () => {
+		await writeZip([makeEvent()]);
+
+		// Three envelopes plus the manifest.
+		expect(zipDeflateOptions.current).toHaveLength(4);
+		for (const options of zipDeflateOptions.current) {
+			expect(options).toEqual({ level: 9 });
+		}
 	});
 
 	it("propagates midstream iterator errors", async () => {

--- a/test/unit/telemetry/sinks/localJsonlSink.test.ts
+++ b/test/unit/telemetry/sinks/localJsonlSink.test.ts
@@ -7,6 +7,11 @@ import {
 	type LocalSinkConfig,
 } from "@/settings/telemetry";
 import { LocalJsonlSink } from "@/telemetry/sinks/localJsonlSink";
+import {
+	serializeTelemetryEventLine,
+	serializeTelemetryFileHeaderLine,
+	type SessionContext,
+} from "@/telemetry/wireFormat";
 
 import { createTelemetryEventFactory } from "../../../mocks/telemetry";
 import {
@@ -20,6 +25,17 @@ vi.mock("node:fs/promises", async () => (await import("memfs")).fs.promises);
 const BASE_DIR = "/telemetry";
 const SESSION_ID = "12345678-aaaa-bbbb-cccc-dddddddddddd";
 const SESSION_SLUG = "12345678";
+
+const sessionContext = (sessionId: string): SessionContext => ({
+	extensionVersion: "1.14.5",
+	machineId: "machine-id",
+	sessionId,
+	osType: "linux",
+	osVersion: "6.0.0",
+	hostArch: "x64",
+	platformName: "Visual Studio Code",
+	platformVersion: "1.106.0",
+});
 
 const todayUtc = (): string => new Date().toISOString().slice(0, 10);
 
@@ -36,6 +52,13 @@ const readJsonl = (filePath: string): Array<Record<string, unknown>> =>
 		.split("\n")
 		.filter((l) => l.length > 0)
 		.map((l) => JSON.parse(l));
+
+/** Event rows only, with header lines filtered out. */
+const readRows = (filePath: string): Array<Record<string, unknown>> =>
+	readJsonl(filePath).filter((l) => l.kind === undefined);
+
+const readHeaders = (filePath: string): Array<Record<string, unknown>> =>
+	readJsonl(filePath).filter((l) => l.kind === "header");
 
 describe("LocalJsonlSink", () => {
 	let active: LocalJsonlSink[];
@@ -65,7 +88,10 @@ describe("LocalJsonlSink", () => {
 			...config,
 		});
 		const logger = createMockLogger();
-		const sink = LocalJsonlSink.start({ baseDir: BASE_DIR, sessionId }, logger);
+		const sink = LocalJsonlSink.start(
+			{ baseDir: BASE_DIR, session: sessionContext(sessionId) },
+			logger,
+		);
 		active.push(sink);
 
 		return { sink, logger, makeEvent: createTelemetryEventFactory() };
@@ -80,7 +106,42 @@ describe("LocalJsonlSink", () => {
 		expect(vol.existsSync(todaysFile())).toBe(false);
 
 		await vi.advanceTimersByTimeAsync(1000);
-		expect(readJsonl(todaysFile())).toHaveLength(2);
+		expect(readRows(todaysFile())).toHaveLength(2);
+	});
+
+	it("writes the session header as the first line of a new file", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-04T12:00:00.000Z"));
+		const { sink, makeEvent } = setup();
+
+		sink.write(makeEvent());
+		await sink.flush();
+
+		// The header shape itself is locked by the wireFormat tests.
+		const [first, ...rest] = readJsonl(todaysFile());
+		expect(first).toEqual(
+			JSON.parse(serializeTelemetryFileHeaderLine(sessionContext(SESSION_ID))),
+		);
+		expect(rest).toHaveLength(1);
+	});
+
+	it("appends rows without a second header when the file already has bytes", async () => {
+		// A prior flush in the same session (simulated on disk) already wrote
+		// the header; seeding from disk must not repeat it.
+		const priorEvents = createTelemetryEventFactory();
+		vol.fromJSON({
+			[todaysFile()]:
+				serializeTelemetryFileHeaderLine(sessionContext(SESSION_ID)) +
+				serializeTelemetryEventLine(priorEvents()),
+		});
+		const { sink, makeEvent } = setup();
+
+		sink.write(makeEvent());
+		await sink.flush();
+
+		expect(readHeaders(todaysFile())).toHaveLength(1);
+		expect(readRows(todaysFile())).toHaveLength(2);
+		expect(readJsonl(todaysFile())[0].kind).toBe("header");
 	});
 
 	it("flushes early once the buffer reaches flushBatchSize", async () => {
@@ -92,7 +153,7 @@ describe("LocalJsonlSink", () => {
 
 		sink.write(makeEvent());
 		await vi.waitFor(() => expect(vol.existsSync(todaysFile())).toBe(true));
-		expect(readJsonl(todaysFile())).toHaveLength(3);
+		expect(readRows(todaysFile())).toHaveLength(3);
 	});
 
 	it("drops the oldest events when the buffer exceeds bufferLimit", async () => {
@@ -106,7 +167,7 @@ describe("LocalJsonlSink", () => {
 		}
 		await sink.flush();
 
-		expect(readJsonl(todaysFile()).map((l) => l.event_sequence)).toEqual([
+		expect(readRows(todaysFile()).map((l) => l.event_sequence)).toEqual([
 			3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
 		]);
 	});
@@ -155,7 +216,7 @@ describe("LocalJsonlSink", () => {
 
 		await sink.dispose();
 
-		expect(readJsonl(todaysFile())).toHaveLength(2);
+		expect(readRows(todaysFile())).toHaveLength(2);
 	});
 
 	it("ignores writes after dispose", async () => {
@@ -167,11 +228,12 @@ describe("LocalJsonlSink", () => {
 		sink.write(makeEvent());
 		sink.write(makeEvent());
 
-		expect(readJsonl(todaysFile())).toHaveLength(2);
+		expect(readRows(todaysFile())).toHaveLength(2);
 	});
 
 	it("rotates to a numbered segment once maxFileBytes is exceeded", async () => {
-		// Padded events are ~2000 bytes; 4500 holds 2 events but not 3.
+		// Header + padded rows are ~2000 bytes each; 4500 holds the header and
+		// 2 rows but not 3.
 		const { sink, makeEvent } = setup({ maxFileBytes: 4500 });
 		const padded = () => makeEvent({ properties: { pad: "x".repeat(1500) } });
 
@@ -180,8 +242,11 @@ describe("LocalJsonlSink", () => {
 			await sink.flush();
 		}
 
-		expect(readJsonl(todaysFile(SESSION_SLUG, 0))).toHaveLength(2);
-		expect(readJsonl(todaysFile(SESSION_SLUG, 1))).toHaveLength(1);
+		expect(readRows(todaysFile(SESSION_SLUG, 0))).toHaveLength(2);
+		expect(readRows(todaysFile(SESSION_SLUG, 1))).toHaveLength(1);
+		// Every segment is independently readable: each opens with a header.
+		expect(readJsonl(todaysFile(SESSION_SLUG, 0))[0].kind).toBe("header");
+		expect(readJsonl(todaysFile(SESSION_SLUG, 1))[0].kind).toBe("header");
 	});
 
 	it("keeps a single oversized payload in segment 0 instead of rotating", async () => {
@@ -192,11 +257,11 @@ describe("LocalJsonlSink", () => {
 		sink.write(makeEvent({ properties: { huge: "x".repeat(5000) } }));
 		await sink.flush();
 
-		expect(readJsonl(todaysFile(SESSION_SLUG, 0))).toHaveLength(1);
+		expect(readRows(todaysFile(SESSION_SLUG, 0))).toHaveLength(1);
 		expect(vol.existsSync(todaysFile(SESSION_SLUG, 1))).toBe(false);
 	});
 
-	it("starts a fresh file on UTC date rollover", async () => {
+	it("starts a fresh file with its own header on UTC date rollover", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date("2026-05-04T23:59:00.000Z"));
 		const { sink, makeEvent } = setup();
@@ -208,8 +273,10 @@ describe("LocalJsonlSink", () => {
 		sink.write(makeEvent());
 		await sink.flush();
 
-		expect(readJsonl(fileFor("2026-05-04"))).toHaveLength(1);
-		expect(readJsonl(fileFor("2026-05-05"))).toHaveLength(1);
+		for (const date of ["2026-05-04", "2026-05-05"]) {
+			expect(readRows(fileFor(date))).toHaveLength(1);
+			expect(readJsonl(fileFor(date))[0].kind).toBe("header");
+		}
 	});
 
 	it("deletes telemetry files older than maxAgeDays at startup", async () => {
@@ -272,7 +339,7 @@ describe("LocalJsonlSink", () => {
 		);
 	});
 
-	it("emits valid snake_case JSONL with optional fields when set, omitting when not", async () => {
+	it("emits valid snake_case JSONL rows with optional fields when set, omitting when not", async () => {
 		const { sink, makeEvent } = setup();
 
 		sink.write(makeEvent());
@@ -288,10 +355,11 @@ describe("LocalJsonlSink", () => {
 		);
 		await sink.dispose();
 
-		const [bare, full] = readJsonl(todaysFile());
+		const [bare, full] = readRows(todaysFile());
 		expect(bare).not.toHaveProperty("trace_id");
 		expect(bare).not.toHaveProperty("parent_event_id");
 		expect(bare).not.toHaveProperty("error");
+		expect(bare).not.toHaveProperty("context");
 		expect(full).toMatchObject({
 			event_id: expect.any(String),
 			event_name: "remote.connect",
@@ -299,11 +367,7 @@ describe("LocalJsonlSink", () => {
 			trace_id: "trace-1",
 			parent_event_id: "parent-1",
 			error: { message: "nope", type: "TypeError", code: "E_FAIL" },
-			context: {
-				extension_version: "1.14.5",
-				deployment_url: "https://coder.example.com",
-				platform_name: "Visual Studio Code",
-			},
+			deployment_url: "https://coder.example.com",
 			properties: { result: "success" },
 			measurements: { durationMs: 12.5 },
 		});
@@ -318,7 +382,11 @@ describe("LocalJsonlSink", () => {
 
 		sink.write(makeEvent());
 		await sink.flush();
-		expect(readJsonl(todaysFile())).toHaveLength(1);
+		// The failed append did not advance file state, so the retry still
+		// opens the file with exactly one header.
+		expect(readHeaders(todaysFile())).toHaveLength(1);
+		expect(readJsonl(todaysFile())[0].kind).toBe("header");
+		expect(readRows(todaysFile())).toHaveLength(1);
 	});
 
 	it("drops the oldest events once the buffer overflows", async () => {
@@ -333,7 +401,7 @@ describe("LocalJsonlSink", () => {
 		await sink.flush();
 
 		// 13 written, 3 oldest dropped to honor bufferLimit.
-		expect(readJsonl(todaysFile())).toHaveLength(10);
+		expect(readRows(todaysFile())).toHaveLength(10);
 	});
 
 	it("two sinks with different sessions write to disjoint files", async () => {
@@ -346,8 +414,8 @@ describe("LocalJsonlSink", () => {
 		}
 		await Promise.all([a.sink.flush(), b.sink.flush()]);
 
-		expect(readJsonl(todaysFile(SESSION_SLUG))).toHaveLength(5);
-		expect(readJsonl(todaysFile("ffeeddcc"))).toHaveLength(5);
+		expect(readRows(todaysFile(SESSION_SLUG))).toHaveLength(5);
+		expect(readRows(todaysFile("ffeeddcc"))).toHaveLength(5);
 	});
 
 	it("coalesces concurrent flushes so events write exactly once", async () => {
@@ -385,7 +453,7 @@ describe("LocalJsonlSink", () => {
 		releaseFirst();
 		await Promise.all([inFlight, queuedA, queuedB]);
 
-		expect(readJsonl(todaysFile()).map((l) => l.event_sequence)).toEqual([
+		expect(readRows(todaysFile()).map((l) => l.event_sequence)).toEqual([
 			0, 1, 2,
 		]);
 		// One in-flight + at most one queued; multiple flush() calls do not
@@ -407,7 +475,7 @@ describe("LocalJsonlSink", () => {
 		sink.write(makeEvent());
 
 		await vi.waitFor(() => expect(vol.existsSync(todaysFile())).toBe(true));
-		expect(readJsonl(todaysFile())).toHaveLength(3);
+		expect(readRows(todaysFile())).toHaveLength(3);
 	});
 
 	it("write() does not throw when an event cannot be serialized", async () => {
@@ -419,6 +487,6 @@ describe("LocalJsonlSink", () => {
 
 		sink.write(makeEvent());
 		await sink.flush();
-		expect(readJsonl(todaysFile())).toHaveLength(1);
+		expect(readRows(todaysFile())).toHaveLength(1);
 	});
 });

--- a/test/unit/telemetry/sinks/localJsonlSink.test.ts
+++ b/test/unit/telemetry/sinks/localJsonlSink.test.ts
@@ -13,7 +13,10 @@ import {
 	type SessionContext,
 } from "@/telemetry/wireFormat";
 
-import { createTelemetryEventFactory } from "../../../mocks/telemetry";
+import {
+	createTelemetryEventFactory,
+	TEST_SESSION_CONTEXT,
+} from "../../../mocks/telemetry";
 import {
 	createMockLogger,
 	MockConfigurationProvider,
@@ -27,14 +30,8 @@ const SESSION_ID = "12345678-aaaa-bbbb-cccc-dddddddddddd";
 const SESSION_SLUG = "12345678";
 
 const sessionContext = (sessionId: string): SessionContext => ({
-	extensionVersion: "1.14.5",
-	machineId: "machine-id",
+	...TEST_SESSION_CONTEXT,
 	sessionId,
-	osType: "linux",
-	osVersion: "6.0.0",
-	hostArch: "x64",
-	platformName: "Visual Studio Code",
-	platformVersion: "1.106.0",
 });
 
 const todayUtc = (): string => new Date().toISOString().slice(0, 10);
@@ -232,8 +229,7 @@ describe("LocalJsonlSink", () => {
 	});
 
 	it("rotates to a numbered segment once maxFileBytes is exceeded", async () => {
-		// Header + padded rows are ~2000 bytes each; 4500 holds the header and
-		// 2 rows but not 3.
+		// ~300B header + ~1700B rows: 4500 holds the header and 2 rows, not 3.
 		const { sink, makeEvent } = setup({ maxFileBytes: 4500 });
 		const padded = () => makeEvent({ properties: { pad: "x".repeat(1500) } });
 

--- a/test/unit/telemetry/wireFormat.test.ts
+++ b/test/unit/telemetry/wireFormat.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
 	CURRENT_TELEMETRY_SCHEMA_VERSION,
-	parseTelemetryEventLine,
 	serializeTelemetryEvent,
+	serializeTelemetryEventLine,
+	serializeTelemetryFileHeaderLine,
 	TelemetryFileParseError,
+	TelemetryFileParser,
 } from "@/telemetry/wireFormat";
 
 import { createTelemetryEventFactory } from "../../mocks/telemetry";
@@ -13,8 +15,68 @@ import type { TelemetryEvent } from "@/telemetry/event";
 
 const makeEvent = createTelemetryEventFactory();
 
+/** Header line for the factory's session context. */
+const headerLineFor = (event: TelemetryEvent): string =>
+	serializeTelemetryFileHeaderLine(event.context);
+
+afterEach(() => vi.useRealTimers());
+
+describe("serializeTelemetryFileHeaderLine", () => {
+	it("writes kind, schema version, timestamp, and the snake_case session context", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-05-04T12:00:00.000Z"));
+		const header = JSON.parse(headerLineFor(makeEvent()));
+
+		// Exact match: also proves the mutable deployment URL is not written.
+		expect(header).toEqual({
+			kind: "header",
+			schema_version: CURRENT_TELEMETRY_SCHEMA_VERSION,
+			timestamp: "2026-05-04T12:00:00.000Z",
+			context: {
+				extension_version: "1.14.5",
+				machine_id: "machine-id",
+				session_id: "session-id",
+				os_type: "linux",
+				os_version: "6.0.0",
+				host_arch: "x64",
+				platform_name: "Visual Studio Code",
+				platform_version: "1.106.0",
+			},
+		});
+	});
+});
+
+describe("serializeTelemetryEventLine", () => {
+	it("writes snake_case per-event fields plus the deployment URL", () => {
+		const row = JSON.parse(
+			serializeTelemetryEventLine(
+				makeEvent({ traceId: "trace-1", parentEventId: "parent-1" }),
+			),
+		);
+
+		expect(row).toMatchObject({
+			event_id: expect.any(String),
+			event_name: "test.event",
+			event_sequence: expect.any(Number),
+			deployment_url: "https://coder.example.com",
+			trace_id: "trace-1",
+			parent_event_id: "parent-1",
+		});
+	});
+
+	it("omits the session context, schema version, and unset optional fields", () => {
+		const row = JSON.parse(serializeTelemetryEventLine(makeEvent()));
+
+		expect(row).not.toHaveProperty("context");
+		expect(row).not.toHaveProperty("schema_version");
+		expect(row).not.toHaveProperty("trace_id");
+		expect(row).not.toHaveProperty("parent_event_id");
+		expect(row).not.toHaveProperty("error");
+	});
+});
+
 describe("serializeTelemetryEvent", () => {
-	it("writes snake_case keys at the top level and inside context", () => {
+	it("writes the self-contained export shape with context and schema version", () => {
 		const wire = serializeTelemetryEvent(
 			makeEvent({ traceId: "trace-1", parentEventId: "parent-1" }),
 		);
@@ -23,6 +85,7 @@ describe("serializeTelemetryEvent", () => {
 			event_id: expect.any(String),
 			event_name: "test.event",
 			event_sequence: expect.any(Number),
+			schema_version: CURRENT_TELEMETRY_SCHEMA_VERSION,
 			trace_id: "trace-1",
 			parent_event_id: "parent-1",
 			context: {
@@ -31,14 +94,6 @@ describe("serializeTelemetryEvent", () => {
 				deployment_url: "https://coder.example.com",
 			},
 		});
-	});
-
-	it("omits trace_id, parent_event_id, and error when unset", () => {
-		const wire = serializeTelemetryEvent(makeEvent());
-
-		expect(wire).not.toHaveProperty("trace_id");
-		expect(wire).not.toHaveProperty("parent_event_id");
-		expect(wire).not.toHaveProperty("error");
 	});
 
 	it("passes properties and measurements through unchanged", () => {
@@ -52,37 +107,85 @@ describe("serializeTelemetryEvent", () => {
 		expect(wire.properties).toEqual({ user_id: "alice", camelCase: "kept" });
 		expect(wire.measurements).toEqual({ duration_ms: 42 });
 	});
-
-	it("stamps the current schema version on every row", () => {
-		const wire = serializeTelemetryEvent(makeEvent());
-
-		expect(wire.schema_version).toBe(CURRENT_TELEMETRY_SCHEMA_VERSION);
-	});
 });
 
-describe("parseTelemetryEventLine", () => {
-	it("round-trips serialize -> parse to the original event", () => {
+describe("TelemetryFileParser", () => {
+	const parse = (
+		lines: readonly string[],
+	): Array<TelemetryEvent | undefined> => {
+		const parser = new TelemetryFileParser("<test>");
+		return lines.map((line, i) => parser.parseLine(line, i + 1));
+	};
+
+	it("round-trips header + row back to the original event", () => {
 		const event = makeEvent({
 			traceId: "trace-1",
 			parentEventId: "parent-1",
 			error: { message: "boom", type: "Error", code: "E_BOOM" },
-			properties: { a: "1" },
-			measurements: { b: 2 },
+			// Snake and camel keys prove caller-supplied property/measurement
+			// keys survive the structural key renaming untouched.
+			properties: { user_id: "alice", camelCase: "kept" },
+			measurements: { duration_ms: 42 },
 		});
 
-		const parsed = parseTelemetryEventLine(
-			JSON.stringify(serializeTelemetryEvent(event)),
-			"<test>",
-			1,
-		);
+		const [header, parsed] = parse([
+			headerLineFor(event),
+			serializeTelemetryEventLine(event),
+		]);
 
+		expect(header).toBeUndefined();
 		expect(parsed).toEqual(event);
+	});
+
+	it("applies the header's schema version and context to every row", () => {
+		const first = makeEvent();
+		const second = makeEvent({
+			context: { ...first.context, deploymentUrl: "https://other.example" },
+		});
+
+		const [, a, b] = parse([
+			headerLineFor(first),
+			serializeTelemetryEventLine(first),
+			serializeTelemetryEventLine(second),
+		]);
+
+		expect(a?.schemaVersion).toBe(CURRENT_TELEMETRY_SCHEMA_VERSION);
+		expect(a?.context.deploymentUrl).toBe("https://coder.example.com");
+		expect(b?.context).toEqual({
+			...first.context,
+			deploymentUrl: "https://other.example",
+		});
+	});
+
+	it("accepts a header with no rows as a valid, empty file", () => {
+		expect(parse([headerLineFor(makeEvent())])).toEqual([undefined]);
+	});
+
+	it("rejects rows that appear before any header", () => {
+		expect(() => parse([serializeTelemetryEventLine(makeEvent())])).toThrow(
+			/expected a file header before event rows/,
+		);
+	});
+
+	it("rejects a second header in the same file", () => {
+		const header = headerLineFor(makeEvent());
+
+		expect(() => parse([header, header])).toThrow(
+			/unexpected second file header/,
+		);
+	});
+
+	it("rejects lines with an unknown kind", () => {
+		expect(() => parse(['{"kind":"trailer"}'])).toThrow(
+			TelemetryFileParseError,
+		);
 	});
 
 	it("throws TelemetryFileParseError tagged with source:lineNumber", () => {
 		expect.assertions(3);
+		const parser = new TelemetryFileParser("events.jsonl");
 		try {
-			parseTelemetryEventLine("{not-json}", "events.jsonl", 7);
+			parser.parseLine("{not-json}", 7);
 		} catch (err) {
 			expect(err).toBeInstanceOf(TelemetryFileParseError);
 			expect((err as Error).message).toMatch(/events\.jsonl:7/);
@@ -90,50 +193,23 @@ describe("parseTelemetryEventLine", () => {
 		}
 	});
 
-	it("rejects events with timestamps that are not valid ISO datetimes", () => {
-		const wire = serializeTelemetryEvent(
-			makeEvent({ timestamp: "2026-02-30T00:00:00.000Z" }),
-		);
+	it("rejects rows with timestamps that are not valid ISO datetimes", () => {
+		const event = makeEvent({ timestamp: "2026-02-30T00:00:00.000Z" });
 
 		expect(() =>
-			parseTelemetryEventLine(JSON.stringify(wire), "<test>", 1),
+			parse([headerLineFor(event), serializeTelemetryEventLine(event)]),
 		).toThrow(TelemetryFileParseError);
 	});
 
 	it("rejects rows missing required structural fields", () => {
-		const wire = serializeTelemetryEvent(makeEvent());
-		delete wire.context;
+		const row = JSON.parse(serializeTelemetryEventLine(makeEvent())) as Record<
+			string,
+			unknown
+		>;
+		delete row.deployment_url;
 
 		expect(() =>
-			parseTelemetryEventLine(JSON.stringify(wire), "<test>", 1),
+			parse([headerLineFor(makeEvent()), JSON.stringify(row)]),
 		).toThrow(TelemetryFileParseError);
-	});
-
-	it("rejects rows without a schema version", () => {
-		const wire = serializeTelemetryEvent(makeEvent());
-		delete wire.schema_version;
-
-		expect(() =>
-			parseTelemetryEventLine(JSON.stringify(wire), "<test>", 1),
-		).toThrow(TelemetryFileParseError);
-	});
-
-	it("preserves arbitrary keys in properties and measurements", () => {
-		const event: TelemetryEvent = makeEvent({
-			properties: { user_id: "alice", camelCase: "kept" },
-			measurements: { duration_ms: 42 },
-		});
-
-		const parsed = parseTelemetryEventLine(
-			JSON.stringify(serializeTelemetryEvent(event)),
-			"<test>",
-			1,
-		);
-
-		expect(parsed.properties).toEqual({
-			user_id: "alice",
-			camelCase: "kept",
-		});
-		expect(parsed.measurements).toEqual({ duration_ms: 42 });
 	});
 });

--- a/test/unit/telemetry/wireFormat.test.ts
+++ b/test/unit/telemetry/wireFormat.test.ts
@@ -175,10 +175,33 @@ describe("TelemetryFileParser", () => {
 		);
 	});
 
-	it("rejects lines with an unknown kind", () => {
+	it("rejects lines with an unknown kind before the header", () => {
 		expect(() => parse(['{"kind":"trailer"}'])).toThrow(
-			TelemetryFileParseError,
+			/unknown kind "trailer"/,
 		);
+	});
+
+	it("rejects lines with an unknown kind after the header", () => {
+		expect(() =>
+			parse([headerLineFor(makeEvent()), '{"kind":"trailer"}']),
+		).toThrow(/unknown kind "trailer"/);
+	});
+
+	it("reuses one context object across rows with the same deployment URL", () => {
+		const event = makeEvent();
+		const otherUrl = makeEvent({
+			context: { ...event.context, deploymentUrl: "https://other.example" },
+		});
+
+		const [, a, b, c] = parse([
+			headerLineFor(event),
+			serializeTelemetryEventLine(event),
+			serializeTelemetryEventLine(event),
+			serializeTelemetryEventLine(otherUrl),
+		]);
+
+		expect(a?.context).toBe(b?.context);
+		expect(c?.context).not.toBe(a?.context);
 	});
 
 	it("throws TelemetryFileParseError tagged with source:lineNumber", () => {


### PR DESCRIPTION
Cuts local telemetry disk usage roughly in half, caps the noisiest emitter, and restructures the OTLP export to follow OTLP standards. All telemetry is in the unreleased pre-release channel, so the JSONL wire shape changes in place (`schema_version` stays `1`).

One commit per change:

1. **JSONL per-file session header** — the 8 session-constant context fields and `schema_version` move to a header line written once per file; rows keep only the mutable `deployment_url`. Every rolling file stays independently readable (header re-written on rotation/rollover, counted in rotation sizing, never torn from its rows). Saves ~330 B/row, ~45% of file bytes at the observed profile.
2. **`http.requests` omits zero counters** — `count.*` keys are emitted only when > 0 (~8% of file bytes). OTLP parity is automatic since the exporter already suppresses zero-total series.
3. **`ssh.network.sampled` floor + cooldown** — latency changes must clear both the 25 ms absolute and 20% relative thresholds (previously either, so 2 ms jitter on a 10 ms link emitted every 3 s poll), and all change triggers share a 15 s cooldown. Suppressed changes coalesce instead of vanishing; the 60 s heartbeat is unchanged. Worst case 28.8k → 5.76k events/day per connection.
4. **OTLP restructuring** — one resource block per producing session and UTC date with the resource built from the *producing* event's context (fixes attribution for multi-session exports; previously all records claimed the exporting session's resource), per-record `coder.event.*` provenance removed, metric data points grouped under one `metrics[]` entry per (name, unit), cumulative counters reset per block (how OTel models process restarts), and zip entries deflate at level 9.

### Measurements (audit of a real session's JSONL)

| What | Share of file bytes |
| --- | --- |
| Duplicated per-row context + schema_version | 49.5% |
| Zero-valued `count.*` fields | 7.9% |
| `http.requests` events overall | 76% |

`EVENTS.md` and the changelog are updated; pre-change dev files fail with a clear parse error naming the file (accepted: no dual-read for unreleased data).

<details>
<summary>Implementation plan (as reviewed)</summary>

```markdown
# Telemetry quick wins: storage format + emission rates + OTLP export

One PR. Grounded in the audit of `main` (2db4027) and a real JSONL sample:
context duplication is 49.5% of file bytes, zero-valued `count.*` fields are
7.9%, `http.requests` is 76% of all bytes.

Decisions from review:

- No v1/v2 dual-read and no version bump: unreleased, so the JSONL shape
  changes in place and `schema_version` stays `1`. Pre-change dev files fail
  with a clear parse error naming the file.
- Header carries only session-constant fields; `deployment_url` stays
  per-row. No mid-file re-headers.
- SSH change-emission cooldown 15s (Prometheus-standard fast scrape
  resolution; the 60s heartbeat matches Prometheus's default interval).
- OTLP export optimizations are in scope and must follow OTLP standards.

## 1. JSONL: per-file session header

First line of every file:

{"kind":"header","schema_version":1,"context":{...8 snake_case SessionContext fields...}}

`context` here is exactly `SessionContext` (the 8 immutable fields). Event
rows lose `context` and `schema_version` and gain top-level
`deployment_url` (mutable per event). Net ~330B/row saved (~45% of file
bytes at the observed profile).

Rolling-file guarantees: a header precedes the first payload appended to any
file whose seeded size is 0, in the same appendFile call as that payload (no
header-only files, no torn header/rows split). Covers first flush, size-cap
rotation (header bytes count toward the cap), date rollover, seeded append,
and failed-flush retry. Stateful per-file parser replaces the bare line
parser; errors on row-before-header, duplicate header, unknown kind.

## 2. `http.requests`: omit zero counters

Emit `count.*` keys only when > 0 (`window_seconds`, `duration.p*` always).
OTLP parity is automatic.

## 3. `ssh.network.sampled`: floor + cooldown

- `hasMeaningfulLatencyChange`: absolute >= 25ms AND relative >= 20%.
- All change triggers gated by a 15s cooldown since the last emission; 60s
  heartbeat unchanged. Suppression does not update the last sample, so
  changes coalesce, not vanish. Worst case 28.8k/day -> 5.76k/day.

## 4. OTLP export (standards-compliant restructuring)

### 4a. Per-session resource blocks; drop per-record provenance

`resourceLogs`/`resourceSpans`/`resourceMetrics` are repeated fields in the
OTLP proto. The writer starts a new resource block whenever the event's
session context (incl. `deployment_url`) or UTC date changes, building the
resource from the producing event's context. Removes the 3 `coder.event.*`
attributes from every record.

### 4b. Metrics: data points grouped under one metric per (name, unit)

Within a resource block, group data points in memory per metric series;
write the block's `metrics[]` on block close. Memory bounded by one
session-day of points.

### 4c. Cumulative counters reset per resource block

Series identity in OTel is resource + metric + point attributes; resetting
per block means a new session no longer inherits the previous session's
totals. This is exactly how OTel models process restarts.

### 4d. Zip compression level

`ZipDeflate` at level 9 (export is on-demand; CPU cost irrelevant).

## Considered and rejected

- Widening the `http.requests` window: loses 1-min percentile resolution.
- Rounding float measurements: 0.4% of bytes.
- Epoch-ms timestamps in JSONL: hurts human readability in support bundles.
- Per-metric staging files for 4b: more fs juggling than the bounded
  in-memory block needs.
```

</details>

---

*This PR was generated by Coder Agents on behalf of @EhabY.*
