### PR TITLE
feat: sort telemetry exports by timestamp

### DIFF
--- a/src/telemetry/export/command.ts
+++ b/src/telemetry/export/command.ts
@@ -29,6 +29,8 @@ const PROGRESS_OPTIONS = {
 	cancellable: true,
 } as const;
 
+type ExportWarning = Parameters<ExportRuntime["onWarning"]>[0];
+
 /**
  * Outcome hooks for the caller's telemetry span. `DiagnosticTrace` satisfies
  * this shape, so command callers can pass their trace directly.
@@ -87,7 +89,20 @@ function exportRuntime(
 			),
 		onCleanupError: (err, target) =>
 			logger.warn("Failed to clean up after telemetry export", target, err),
+		onWarning: (warning) => logExportWarning(logger, warning),
 	};
+}
+
+function logExportWarning(logger: Logger, warning: ExportWarning): void {
+	switch (warning.code) {
+		case "invalidTelemetryFilePath":
+			logger.warn(
+				"Skipping invalid telemetry file during export",
+				warning.filePath,
+				warning.error,
+			);
+			return;
+	}
 }
 
 /** Turns the export result into the matching user-facing notification. */

--- a/src/telemetry/export/command.ts
+++ b/src/telemetry/export/command.ts
@@ -29,8 +29,6 @@ const PROGRESS_OPTIONS = {
 	cancellable: true,
 } as const;
 
-type ExportWarning = Parameters<ExportRuntime["onWarning"]>[0];
-
 /**
  * Outcome hooks for the caller's telemetry span. `DiagnosticTrace` satisfies
  * this shape, so command callers can pass their trace directly.
@@ -89,20 +87,7 @@ function exportRuntime(
 			),
 		onCleanupError: (err, target) =>
 			logger.warn("Failed to clean up after telemetry export", target, err),
-		onWarning: (warning) => logExportWarning(logger, warning),
 	};
-}
-
-function logExportWarning(logger: Logger, warning: ExportWarning): void {
-	switch (warning.code) {
-		case "invalidTelemetryFilePath":
-			logger.warn(
-				"Skipping invalid telemetry file during export",
-				warning.filePath,
-				warning.error,
-			);
-			return;
-	}
 }
 
 /** Turns the export result into the matching user-facing notification. */

--- a/src/telemetry/export/files.ts
+++ b/src/telemetry/export/files.ts
@@ -19,38 +19,24 @@ import {
 
 import type { TelemetryEvent } from "../event";
 
-interface TelemetryLogFile {
+export interface TelemetryLogFile {
 	readonly path: string;
 	readonly date: string;
 	readonly session: string;
 	readonly part: number;
 }
 
-interface QueuedTelemetryEvent {
+interface EventCursor {
 	readonly event: TelemetryEvent;
 	readonly timestampMs: number;
-}
-
-interface EventCursor {
-	readonly queued: QueuedTelemetryEvent;
 	readonly iterator: AsyncIterator<TelemetryEvent>;
 }
 
-export interface TelemetryExportWarning {
-	readonly code: "invalidTelemetryFilePath";
-	readonly filePath: string;
-	readonly error: Error;
-}
-
-export interface TelemetryExportWarningSink {
-	readonly onWarning: (warning: TelemetryExportWarning) => void;
-}
-
-/** Log files whose dates could overlap `range`. */
+/** Log files whose dates could overlap `range`, in (date, session, part) order. */
 export async function listTelemetryFilesForRange(
 	telemetryDir: string,
 	range: TelemetryDateRange,
-): Promise<string[]> {
+): Promise<TelemetryLogFile[]> {
 	let names: string[];
 	try {
 		names = await fs.readdir(telemetryDir);
@@ -67,28 +53,31 @@ export async function listTelemetryFilesForRange(
 			(file): file is TelemetryLogFile =>
 				file !== undefined && fileDateCanContainRangeEvent(file.date, range),
 		)
-		.sort(compareLogFiles)
-		.map(({ path: filePath }) => filePath);
+		.sort(compareLogFiles);
 }
 
 /**
- * Merge range-filtered, per-session event streams by timestamp. This stays
- * globally sorted while each session's timestamps are monotonic; if a session's
- * clock moves backward, that session's append order is preserved.
+ * Merge per-session event streams by timestamp, keeping only events whose
+ * timestamp falls inside `range`. Output stays globally sorted while each
+ * session's timestamps are monotonic; if a session's clock moves backward,
+ * that session's append order is preserved.
  */
 export async function* streamTelemetryEventsSorted(
-	filePaths: readonly string[],
+	files: readonly TelemetryLogFile[],
 	range: TelemetryDateRange,
-	warningSink: TelemetryExportWarningSink,
 ): AsyncIterable<TelemetryEvent> {
-	const iterators: Array<AsyncIterator<TelemetryEvent>> = [];
+	const iterators = groupFilesBySession(files).map((sessionFiles) =>
+		streamTelemetryEventsFromFiles(sessionFiles, range),
+	);
 	const frontier: EventCursor[] = [];
 	try {
-		await seedFrontier(frontier, iterators, filePaths, range, warningSink);
+		for (const iterator of iterators) {
+			await advanceCursor(frontier, iterator);
+		}
 		while (frontier.length > 0) {
 			const cursor = takeNextCursor(frontier);
-			yield cursor.queued.event;
-			await advanceCursor(frontier, cursor);
+			yield cursor.event;
+			await advanceCursor(frontier, cursor.iterator);
 		}
 	} finally {
 		await closeIterators(iterators);
@@ -98,7 +87,7 @@ export async function* streamTelemetryEventsSorted(
 async function* streamTelemetryEventsFromFiles(
 	files: readonly TelemetryLogFile[],
 	range: TelemetryDateRange,
-): AsyncIterable<TelemetryEvent> {
+): AsyncGenerator<TelemetryEvent> {
 	for (const file of files) {
 		const name = path.basename(file.path);
 		const stream = createReadStream(file.path, { encoding: "utf8" });
@@ -138,53 +127,15 @@ async function* streamTelemetryEventsFromFiles(
 }
 
 function groupFilesBySession(
-	filePaths: readonly string[],
-	warningSink: TelemetryExportWarningSink,
+	files: readonly TelemetryLogFile[],
 ): TelemetryLogFile[][] {
-	const files = parseLogFilePaths(filePaths, warningSink).sort(compareLogFiles);
-	return [...Map.groupBy(files, (file) => file.session).values()];
-}
-
-function parseLogFilePaths(
-	filePaths: readonly string[],
-	warningSink: TelemetryExportWarningSink,
-): TelemetryLogFile[] {
-	const files: TelemetryLogFile[] = [];
-	for (const filePath of filePaths) {
-		const file = parseLogFilePath(filePath);
-		if (!file) {
-			emitWarning(warningSink, invalidTelemetryFilePathWarning(filePath));
-			continue;
-		}
-		files.push(file);
-	}
-	return files;
+	const sorted = [...files].sort(compareLogFiles);
+	return [...Map.groupBy(sorted, (file) => file.session).values()];
 }
 
 function parseLogFilePath(filePath: string): TelemetryLogFile | undefined {
 	const parsed = localJsonlFiles.parseFileName(path.basename(filePath));
 	return parsed ? { path: filePath, ...parsed } : undefined;
-}
-
-function invalidTelemetryFilePathWarning(
-	filePath: string,
-): TelemetryExportWarning {
-	return {
-		code: "invalidTelemetryFilePath",
-		filePath,
-		error: new Error(`Invalid telemetry file path: ${path.basename(filePath)}`),
-	};
-}
-
-function emitWarning(
-	warningSink: TelemetryExportWarningSink,
-	warning: TelemetryExportWarning,
-): void {
-	try {
-		warningSink.onWarning(warning);
-	} catch {
-		// Warning observers must not fail the export.
-	}
 }
 
 function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
@@ -195,31 +146,16 @@ function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
 	);
 }
 
-async function seedFrontier(
-	frontier: EventCursor[],
-	iterators: Array<AsyncIterator<TelemetryEvent>>,
-	filePaths: readonly string[],
-	range: TelemetryDateRange,
-	warningSink: TelemetryExportWarningSink,
-): Promise<void> {
-	for (const files of groupFilesBySession(filePaths, warningSink)) {
-		const iterator = streamTelemetryEventsFromFiles(files, range)[
-			Symbol.asyncIterator
-		]();
-		iterators.push(iterator);
-		await advanceCursor(frontier, { iterator });
-	}
-}
-
 async function advanceCursor(
 	frontier: EventCursor[],
-	cursor: Pick<EventCursor, "iterator">,
+	iterator: AsyncIterator<TelemetryEvent>,
 ): Promise<void> {
-	const next = await cursor.iterator.next();
+	const next = await iterator.next();
 	if (!next.done) {
 		frontier.push({
-			queued: queueEvent(next.value),
-			iterator: cursor.iterator,
+			event: next.value,
+			timestampMs: parseTelemetryTimestampMs(next.value.timestamp),
+			iterator,
 		});
 	}
 }
@@ -234,16 +170,10 @@ async function closeIterators(
 	);
 }
 
-function queueEvent(event: TelemetryEvent): QueuedTelemetryEvent {
-	return { event, timestampMs: parseTelemetryTimestampMs(event.timestamp) };
-}
-
 function takeNextCursor(frontier: EventCursor[]): EventCursor {
 	let nextIndex = 0;
 	for (let i = 1; i < frontier.length; i += 1) {
-		if (
-			compareQueuedEvents(frontier[i].queued, frontier[nextIndex].queued) < 0
-		) {
+		if (compareCursors(frontier[i], frontier[nextIndex]) < 0) {
 			nextIndex = i;
 		}
 	}
@@ -252,10 +182,7 @@ function takeNextCursor(frontier: EventCursor[]): EventCursor {
 	return cursor;
 }
 
-function compareQueuedEvents(
-	a: QueuedTelemetryEvent,
-	b: QueuedTelemetryEvent,
-): number {
+function compareCursors(a: EventCursor, b: EventCursor): number {
 	return (
 		a.timestampMs - b.timestampMs ||
 		a.event.context.sessionId.localeCompare(b.event.context.sessionId)

--- a/src/telemetry/export/files.ts
+++ b/src/telemetry/export/files.ts
@@ -26,15 +26,24 @@ interface TelemetryLogFile {
 	readonly part: number;
 }
 
-interface TelemetryEventEntry {
+interface QueuedTelemetryEvent {
 	readonly event: TelemetryEvent;
-	readonly file: TelemetryLogFile;
-	readonly lineNumber: number;
+	readonly timestampMs: number;
 }
 
 interface EventCursor {
-	readonly entry: TelemetryEventEntry;
-	readonly iterator: AsyncIterator<TelemetryEventEntry>;
+	readonly queued: QueuedTelemetryEvent;
+	readonly iterator: AsyncIterator<TelemetryEvent>;
+}
+
+export interface TelemetryExportWarning {
+	readonly code: "invalidTelemetryFilePath";
+	readonly filePath: string;
+	readonly error: Error;
+}
+
+export interface TelemetryExportWarningSink {
+	readonly onWarning: (warning: TelemetryExportWarning) => void;
 }
 
 /** Log files whose dates could overlap `range`. */
@@ -62,41 +71,34 @@ export async function listTelemetryFilesForRange(
 		.map(({ path: filePath }) => filePath);
 }
 
-/** Merge per-session append streams by timestamp, buffering one event per session. */
+/**
+ * Merge range-filtered, per-session event streams by timestamp. This stays
+ * globally sorted while each session's timestamps are monotonic; if a session's
+ * clock moves backward, that session's append order is preserved.
+ */
 export async function* streamTelemetryEventsSorted(
 	filePaths: readonly string[],
 	range: TelemetryDateRange,
+	warningSink: TelemetryExportWarningSink,
 ): AsyncIterable<TelemetryEvent> {
+	const iterators: Array<AsyncIterator<TelemetryEvent>> = [];
 	const frontier: EventCursor[] = [];
-	for (const files of sessionFileGroups(filePaths)) {
-		const iterator = streamTelemetryEventEntries(files, range)[
-			Symbol.asyncIterator
-		]();
-		const next = await iterator.next();
-		if (!next.done) {
-			frontier.push({ entry: next.value, iterator });
+	try {
+		await seedFrontier(frontier, iterators, filePaths, range, warningSink);
+		while (frontier.length > 0) {
+			const cursor = takeNextCursor(frontier);
+			yield cursor.queued.event;
+			await advanceCursor(frontier, cursor);
 		}
-	}
-
-	while (frontier.length > 0) {
-		frontier.sort((a, b) => compareEventEntries(a.entry, b.entry));
-		const cursor = frontier.shift();
-		if (!cursor) {
-			return;
-		}
-		yield cursor.entry.event;
-
-		const next = await cursor.iterator.next();
-		if (!next.done) {
-			frontier.push({ entry: next.value, iterator: cursor.iterator });
-		}
+	} finally {
+		await closeIterators(iterators);
 	}
 }
 
-async function* streamTelemetryEventEntries(
+async function* streamTelemetryEventsFromFiles(
 	files: readonly TelemetryLogFile[],
 	range: TelemetryDateRange,
-): AsyncIterable<TelemetryEventEntry> {
+): AsyncIterable<TelemetryEvent> {
 	for (const file of files) {
 		const name = path.basename(file.path);
 		const stream = createReadStream(file.path, { encoding: "utf8" });
@@ -113,7 +115,7 @@ async function* streamTelemetryEventEntries(
 				}
 				const event = parseTelemetryEventLine(line, name, lineNumber);
 				if (isTimestampInRange(event.timestamp, range)) {
-					yield { event, file, lineNumber };
+					yield event;
 				}
 			}
 		} catch (err) {
@@ -135,29 +137,54 @@ async function* streamTelemetryEventEntries(
 	}
 }
 
-function sessionFileGroups(filePaths: readonly string[]): TelemetryLogFile[][] {
-	const groups = new Map<string, TelemetryLogFile[]>();
-	for (const file of parseLogFilePaths(filePaths).sort(compareLogFiles)) {
-		const group = groups.get(file.session);
-		if (group) {
-			group.push(file);
-		} else {
-			groups.set(file.session, [file]);
-		}
-	}
-	return [...groups.values()];
+function groupFilesBySession(
+	filePaths: readonly string[],
+	warningSink: TelemetryExportWarningSink,
+): TelemetryLogFile[][] {
+	const files = parseLogFilePaths(filePaths, warningSink).sort(compareLogFiles);
+	return [...Map.groupBy(files, (file) => file.session).values()];
 }
 
-function parseLogFilePaths(filePaths: readonly string[]): TelemetryLogFile[] {
-	return filePaths.flatMap((filePath) => {
+function parseLogFilePaths(
+	filePaths: readonly string[],
+	warningSink: TelemetryExportWarningSink,
+): TelemetryLogFile[] {
+	const files: TelemetryLogFile[] = [];
+	for (const filePath of filePaths) {
 		const file = parseLogFilePath(filePath);
-		return file ? [file] : [];
-	});
+		if (!file) {
+			emitWarning(warningSink, invalidTelemetryFilePathWarning(filePath));
+			continue;
+		}
+		files.push(file);
+	}
+	return files;
 }
 
 function parseLogFilePath(filePath: string): TelemetryLogFile | undefined {
 	const parsed = localJsonlFiles.parseFileName(path.basename(filePath));
 	return parsed ? { path: filePath, ...parsed } : undefined;
+}
+
+function invalidTelemetryFilePathWarning(
+	filePath: string,
+): TelemetryExportWarning {
+	return {
+		code: "invalidTelemetryFilePath",
+		filePath,
+		error: new Error(`Invalid telemetry file path: ${path.basename(filePath)}`),
+	};
+}
+
+function emitWarning(
+	warningSink: TelemetryExportWarningSink,
+	warning: TelemetryExportWarning,
+): void {
+	try {
+		warningSink.onWarning(warning);
+	} catch {
+		// Warning observers must not fail the export.
+	}
 }
 
 function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
@@ -168,15 +195,69 @@ function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
 	);
 }
 
-function compareEventEntries(
-	a: TelemetryEventEntry,
-	b: TelemetryEventEntry,
+async function seedFrontier(
+	frontier: EventCursor[],
+	iterators: Array<AsyncIterator<TelemetryEvent>>,
+	filePaths: readonly string[],
+	range: TelemetryDateRange,
+	warningSink: TelemetryExportWarningSink,
+): Promise<void> {
+	for (const files of groupFilesBySession(filePaths, warningSink)) {
+		const iterator = streamTelemetryEventsFromFiles(files, range)[
+			Symbol.asyncIterator
+		]();
+		iterators.push(iterator);
+		await advanceCursor(frontier, { iterator });
+	}
+}
+
+async function advanceCursor(
+	frontier: EventCursor[],
+	cursor: Pick<EventCursor, "iterator">,
+): Promise<void> {
+	const next = await cursor.iterator.next();
+	if (!next.done) {
+		frontier.push({
+			queued: queueEvent(next.value),
+			iterator: cursor.iterator,
+		});
+	}
+}
+
+async function closeIterators(
+	iterators: ReadonlyArray<AsyncIterator<TelemetryEvent>>,
+): Promise<void> {
+	await Promise.allSettled(
+		iterators.map(async (iterator) => {
+			await iterator.return?.();
+		}),
+	);
+}
+
+function queueEvent(event: TelemetryEvent): QueuedTelemetryEvent {
+	return { event, timestampMs: parseTelemetryTimestampMs(event.timestamp) };
+}
+
+function takeNextCursor(frontier: EventCursor[]): EventCursor {
+	let nextIndex = 0;
+	for (let i = 1; i < frontier.length; i += 1) {
+		if (
+			compareQueuedEvents(frontier[i].queued, frontier[nextIndex].queued) < 0
+		) {
+			nextIndex = i;
+		}
+	}
+	const cursor = frontier[nextIndex];
+	frontier.splice(nextIndex, 1);
+	return cursor;
+}
+
+function compareQueuedEvents(
+	a: QueuedTelemetryEvent,
+	b: QueuedTelemetryEvent,
 ): number {
-	const timestamp =
-		parseTelemetryTimestampMs(a.event.timestamp) -
-		parseTelemetryTimestampMs(b.event.timestamp);
 	return (
-		timestamp ||
+		a.timestampMs - b.timestampMs ||
 		a.event.context.sessionId.localeCompare(b.event.context.sessionId)
 	);
 }

--- a/src/telemetry/export/files.ts
+++ b/src/telemetry/export/files.ts
@@ -13,6 +13,7 @@ import {
 import {
 	fileDateCanContainRangeEvent,
 	isTimestampInRange,
+	parseTelemetryTimestampMs,
 	type TelemetryDateRange,
 } from "./range";
 
@@ -25,7 +26,18 @@ interface TelemetryLogFile {
 	readonly part: number;
 }
 
-/** Log files that could contain events in `range`, in chronological order. */
+interface TelemetryEventEntry {
+	readonly event: TelemetryEvent;
+	readonly file: TelemetryLogFile;
+	readonly lineNumber: number;
+}
+
+interface EventCursor {
+	readonly entry: TelemetryEventEntry;
+	readonly iterator: AsyncIterator<TelemetryEventEntry>;
+}
+
+/** Log files whose dates could overlap `range`. */
 export async function listTelemetryFilesForRange(
 	telemetryDir: string,
 	range: TelemetryDateRange,
@@ -41,7 +53,7 @@ export async function listTelemetryFilesForRange(
 	}
 
 	return names
-		.map((name) => parseLogFilename(telemetryDir, name))
+		.map((name) => parseLogFilePath(path.join(telemetryDir, name)))
 		.filter(
 			(file): file is TelemetryLogFile =>
 				file !== undefined && fileDateCanContainRangeEvent(file.date, range),
@@ -50,17 +62,44 @@ export async function listTelemetryFilesForRange(
 		.map(({ path: filePath }) => filePath);
 }
 
-/**
- * Yields events from `filePaths` in order, keeping only those whose timestamp
- * falls inside `range`. Reads line-by-line so memory stays flat on big files.
- */
-export async function* streamTelemetryEvents(
+/** Merge per-session append streams by timestamp, buffering one event per session. */
+export async function* streamTelemetryEventsSorted(
 	filePaths: readonly string[],
 	range: TelemetryDateRange,
 ): AsyncIterable<TelemetryEvent> {
-	for (const filePath of filePaths) {
-		const name = path.basename(filePath);
-		const stream = createReadStream(filePath, { encoding: "utf8" });
+	const frontier: EventCursor[] = [];
+	for (const files of sessionFileGroups(filePaths)) {
+		const iterator = streamTelemetryEventEntries(files, range)[
+			Symbol.asyncIterator
+		]();
+		const next = await iterator.next();
+		if (!next.done) {
+			frontier.push({ entry: next.value, iterator });
+		}
+	}
+
+	while (frontier.length > 0) {
+		frontier.sort((a, b) => compareEventEntries(a.entry, b.entry));
+		const cursor = frontier.shift();
+		if (!cursor) {
+			return;
+		}
+		yield cursor.entry.event;
+
+		const next = await cursor.iterator.next();
+		if (!next.done) {
+			frontier.push({ entry: next.value, iterator: cursor.iterator });
+		}
+	}
+}
+
+async function* streamTelemetryEventEntries(
+	files: readonly TelemetryLogFile[],
+	range: TelemetryDateRange,
+): AsyncIterable<TelemetryEventEntry> {
+	for (const file of files) {
+		const name = path.basename(file.path);
+		const stream = createReadStream(file.path, { encoding: "utf8" });
 		const lines = readline.createInterface({
 			input: stream,
 			crlfDelay: Infinity,
@@ -74,7 +113,7 @@ export async function* streamTelemetryEvents(
 				}
 				const event = parseTelemetryEventLine(line, name, lineNumber);
 				if (isTimestampInRange(event.timestamp, range)) {
-					yield event;
+					yield { event, file, lineNumber };
 				}
 			}
 		} catch (err) {
@@ -96,15 +135,29 @@ export async function* streamTelemetryEvents(
 	}
 }
 
-function parseLogFilename(
-	dir: string,
-	name: string,
-): TelemetryLogFile | undefined {
-	const parsed = localJsonlFiles.parseFileName(name);
-	if (!parsed) {
-		return undefined;
+function sessionFileGroups(filePaths: readonly string[]): TelemetryLogFile[][] {
+	const groups = new Map<string, TelemetryLogFile[]>();
+	for (const file of parseLogFilePaths(filePaths).sort(compareLogFiles)) {
+		const group = groups.get(file.session);
+		if (group) {
+			group.push(file);
+		} else {
+			groups.set(file.session, [file]);
+		}
 	}
-	return { path: path.join(dir, name), ...parsed };
+	return [...groups.values()];
+}
+
+function parseLogFilePaths(filePaths: readonly string[]): TelemetryLogFile[] {
+	return filePaths.flatMap((filePath) => {
+		const file = parseLogFilePath(filePath);
+		return file ? [file] : [];
+	});
+}
+
+function parseLogFilePath(filePath: string): TelemetryLogFile | undefined {
+	const parsed = localJsonlFiles.parseFileName(path.basename(filePath));
+	return parsed ? { path: filePath, ...parsed } : undefined;
 }
 
 function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
@@ -112,5 +165,18 @@ function compareLogFiles(a: TelemetryLogFile, b: TelemetryLogFile): number {
 		a.date.localeCompare(b.date) ||
 		a.session.localeCompare(b.session) ||
 		a.part - b.part
+	);
+}
+
+function compareEventEntries(
+	a: TelemetryEventEntry,
+	b: TelemetryEventEntry,
+): number {
+	const timestamp =
+		parseTelemetryTimestampMs(a.event.timestamp) -
+		parseTelemetryTimestampMs(b.event.timestamp);
+	return (
+		timestamp ||
+		a.event.context.sessionId.localeCompare(b.event.context.sessionId)
 	);
 }

--- a/src/telemetry/export/pipeline.ts
+++ b/src/telemetry/export/pipeline.ts
@@ -2,7 +2,10 @@ import * as fs from "node:fs/promises";
 
 import { throwIfAborted } from "../../error/errorUtils";
 
-import { listTelemetryFilesForRange, streamTelemetryEvents } from "./files";
+import {
+	listTelemetryFilesForRange,
+	streamTelemetryEventsSorted,
+} from "./files";
 
 import type { TelemetryEvent } from "../event";
 import type { FlushStatus } from "../service";
@@ -58,7 +61,7 @@ export async function collectTelemetryExport(
 
 	runtime.report("Writing export...");
 	const events = abortable(
-		streamTelemetryEvents(filePaths, request.range),
+		streamTelemetryEventsSorted(filePaths, request.range),
 		runtime.signal,
 	);
 	const eventCount = await request.writer(

--- a/src/telemetry/export/pipeline.ts
+++ b/src/telemetry/export/pipeline.ts
@@ -5,7 +5,6 @@ import { throwIfAborted } from "../../error/errorUtils";
 import {
 	listTelemetryFilesForRange,
 	streamTelemetryEventsSorted,
-	type TelemetryExportWarningSink,
 } from "./files";
 
 import type { TelemetryEvent } from "../event";
@@ -25,7 +24,7 @@ export interface ExportRequest {
  * Host hooks the export needs: cancellation, flush, progress, and a cleanup
  * callback. Free of VS Code types so the pipeline is testable without a UI.
  */
-export interface ExportRuntime extends TelemetryExportWarningSink {
+export interface ExportRuntime {
 	readonly signal: AbortSignal;
 	readonly flushTelemetry: () => Promise<FlushStatus>;
 	readonly report: (message: string) => void;
@@ -52,23 +51,23 @@ export async function collectTelemetryExport(
 	}
 
 	runtime.report("Locating telemetry files...");
-	const filePaths = await listTelemetryFilesForRange(
+	const files = await listTelemetryFilesForRange(
 		request.telemetryDir,
 		request.range,
 	);
-	if (filePaths.length === 0) {
+	if (files.length === 0) {
 		return 0;
 	}
 
 	runtime.report("Writing export...");
 	const events = abortable(
-		streamTelemetryEventsSorted(filePaths, request.range, runtime),
+		streamTelemetryEventsSorted(files, request.range),
 		runtime.signal,
 	);
 	const eventCount = await request.writer(
 		request.outputPath,
 		events,
-		{ range: request.range, sourceFiles: filePaths.length },
+		{ range: request.range, sourceFiles: files.length },
 		{ signal: runtime.signal, onCleanupError: runtime.onCleanupError },
 	);
 	if (eventCount === 0) {

--- a/src/telemetry/export/pipeline.ts
+++ b/src/telemetry/export/pipeline.ts
@@ -5,6 +5,7 @@ import { throwIfAborted } from "../../error/errorUtils";
 import {
 	listTelemetryFilesForRange,
 	streamTelemetryEventsSorted,
+	type TelemetryExportWarningSink,
 } from "./files";
 
 import type { TelemetryEvent } from "../event";
@@ -24,7 +25,7 @@ export interface ExportRequest {
  * Host hooks the export needs: cancellation, flush, progress, and a cleanup
  * callback. Free of VS Code types so the pipeline is testable without a UI.
  */
-export interface ExportRuntime {
+export interface ExportRuntime extends TelemetryExportWarningSink {
 	readonly signal: AbortSignal;
 	readonly flushTelemetry: () => Promise<FlushStatus>;
 	readonly report: (message: string) => void;
@@ -61,7 +62,7 @@ export async function collectTelemetryExport(
 
 	runtime.report("Writing export...");
 	const events = abortable(
-		streamTelemetryEventsSorted(filePaths, request.range),
+		streamTelemetryEventsSorted(filePaths, request.range, runtime),
 		runtime.signal,
 	);
 	const eventCount = await request.writer(

--- a/test/unit/telemetry/export/command.test.ts
+++ b/test/unit/telemetry/export/command.test.ts
@@ -64,13 +64,15 @@ function setup(
 		error: vi.fn(),
 		succeedExport: vi.fn(),
 	};
+	const logger = createMockLogger();
 
 	return {
+		logger,
 		observer,
 		run: () =>
 			runExportTelemetryCommand(
 				TELEMETRY_DIR,
-				createMockLogger(),
+				logger,
 				vi.fn(() => Promise.resolve(OK_FLUSH)),
 				context,
 				observer,
@@ -124,6 +126,33 @@ describe("runExportTelemetryCommand", () => {
 
 		expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
 			expect.stringContaining("could not be flushed"),
+		);
+	});
+
+	it("logs invalid telemetry file warnings", async () => {
+		const { logger, run } = setup();
+		let onWarning:
+			| Parameters<typeof collectTelemetryExport>[1]["onWarning"]
+			| undefined;
+		const error = new Error("bad name");
+		vi.mocked(collectTelemetryExport).mockImplementation(
+			(_request, runtime) => {
+				onWarning = runtime.onWarning;
+				return Promise.resolve(2);
+			},
+		);
+
+		await run();
+		onWarning?.({
+			code: "invalidTelemetryFilePath",
+			filePath: "/tmp/telemetry/notes.jsonl",
+			error,
+		});
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Skipping invalid telemetry file during export",
+			"/tmp/telemetry/notes.jsonl",
+			error,
 		);
 	});
 

--- a/test/unit/telemetry/export/command.test.ts
+++ b/test/unit/telemetry/export/command.test.ts
@@ -64,15 +64,12 @@ function setup(
 		error: vi.fn(),
 		succeedExport: vi.fn(),
 	};
-	const logger = createMockLogger();
-
 	return {
-		logger,
 		observer,
 		run: () =>
 			runExportTelemetryCommand(
 				TELEMETRY_DIR,
-				logger,
+				createMockLogger(),
 				vi.fn(() => Promise.resolve(OK_FLUSH)),
 				context,
 				observer,
@@ -126,33 +123,6 @@ describe("runExportTelemetryCommand", () => {
 
 		expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
 			expect.stringContaining("could not be flushed"),
-		);
-	});
-
-	it("logs invalid telemetry file warnings", async () => {
-		const { logger, run } = setup();
-		let onWarning:
-			| Parameters<typeof collectTelemetryExport>[1]["onWarning"]
-			| undefined;
-		const error = new Error("bad name");
-		vi.mocked(collectTelemetryExport).mockImplementation(
-			(_request, runtime) => {
-				onWarning = runtime.onWarning;
-				return Promise.resolve(2);
-			},
-		);
-
-		await run();
-		onWarning?.({
-			code: "invalidTelemetryFilePath",
-			filePath: "/tmp/telemetry/notes.jsonl",
-			error,
-		});
-
-		expect(logger.warn).toHaveBeenCalledWith(
-			"Skipping invalid telemetry file during export",
-			"/tmp/telemetry/notes.jsonl",
-			error,
 		);
 	});
 

--- a/test/unit/telemetry/export/files.test.ts
+++ b/test/unit/telemetry/export/files.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
 	listTelemetryFilesForRange,
-	streamTelemetryEvents,
+	streamTelemetryEventsSorted,
 } from "@/telemetry/export/files";
 import { createCustomDateRange } from "@/telemetry/export/range";
 import { serializeTelemetryEventLine } from "@/telemetry/wireFormat";
@@ -61,28 +61,61 @@ describe("listTelemetryFilesForRange", () => {
 	});
 });
 
-describe("streamTelemetryEvents", () => {
-	it("yields only events whose timestamp falls inside the range", async () => {
+describe("streamTelemetryEventsSorted", () => {
+	it("returns a timestamp-sorted stream with deterministic session-id ties", async () => {
+		writeFiles({
+			"telemetry-2026-05-12-cccccccc.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-c", 0, "2026-05-12T10:00:00.000Z"),
+			),
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-a", 10, "2026-05-12T10:00:00.000Z"),
+			),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-b", 0, "2026-05-12T10:01:00.000Z"),
+			),
+			"telemetry-2026-05-12-aaaaaaaa.1.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-a", 11, "2026-05-12T10:02:00.000Z"),
+			),
+		});
+
+		const events = await collectSorted([
+			"telemetry-2026-05-12-aaaaaaaa.1.jsonl",
+			"telemetry-2026-05-12-bbbbbbbb.jsonl",
+			"telemetry-2026-05-12-cccccccc.jsonl",
+			"telemetry-2026-05-12-aaaaaaaa.jsonl",
+		]);
+
+		expect(
+			events.map((event) => [
+				event.timestamp,
+				event.context.sessionId,
+				event.eventSequence,
+			]),
+		).toEqual([
+			["2026-05-12T10:00:00.000Z", "session-a", 10],
+			["2026-05-12T10:00:00.000Z", "session-c", 0],
+			["2026-05-12T10:01:00.000Z", "session-b", 0],
+			["2026-05-12T10:02:00.000Z", "session-a", 11],
+		]);
+	});
+
+	it("preserves events when a session timestamp moves backward", async () => {
 		writeFiles({
 			"telemetry-2026-05-12-aaaaaaaa.jsonl":
 				serializeTelemetryEventLine(
-					makeEvent({ timestamp: "2026-05-11T23:59:59.999Z" }),
+					makeSessionEvent("session-a", 0, "2026-05-12T10:02:00.000Z"),
 				) +
 				serializeTelemetryEventLine(
-					makeEvent({ timestamp: "2026-05-12T00:00:00.000Z" }),
+					makeSessionEvent("session-a", 1, "2026-05-12T10:00:00.000Z"),
 				),
 		});
 
-		const events: TelemetryEvent[] = [];
-		for await (const event of streamTelemetryEvents(
-			[`${DIR}/telemetry-2026-05-12-aaaaaaaa.jsonl`],
-			createCustomDateRange("2026-05-12", "2026-05-12"),
-		)) {
-			events.push(event);
-		}
+		const events = await collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]);
 
-		expect(events).toHaveLength(1);
-		expect(events[0].timestamp).toBe("2026-05-12T00:00:00.000Z");
+		expect(events.map((event) => event.timestamp)).toEqual([
+			"2026-05-12T10:02:00.000Z",
+			"2026-05-12T10:00:00.000Z",
+		]);
 	});
 
 	it("surfaces parse errors with file:line context", async () => {
@@ -90,7 +123,9 @@ describe("streamTelemetryEvents", () => {
 			"telemetry-2026-05-12-aaaaaaaa.jsonl": "{not-json}\n",
 		});
 
-		await expect(drain("telemetry-2026-05-12-aaaaaaaa.jsonl")).rejects.toThrow(
+		await expect(
+			collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]),
+		).rejects.toThrow(
 			/Failed to parse telemetry file telemetry-2026-05-12-aaaaaaaa\.jsonl:1/,
 		);
 	});
@@ -102,11 +137,27 @@ function writeFiles(files: Record<string, string>): void {
 	}
 }
 
-async function drain(name: string): Promise<void> {
-	for await (const _ of streamTelemetryEvents(
-		[`${DIR}/${name}`],
+function makeSessionEvent(
+	sessionId: string,
+	eventSequence: number,
+	timestamp: string,
+): TelemetryEvent {
+	const event = makeEvent({ timestamp, eventSequence });
+	return {
+		...event,
+		context: { ...event.context, sessionId },
+	};
+}
+
+async function collectSorted(
+	names: readonly string[],
+): Promise<TelemetryEvent[]> {
+	const events: TelemetryEvent[] = [];
+	for await (const event of streamTelemetryEventsSorted(
+		names.map((name) => `${DIR}/${name}`),
 		createCustomDateRange("2026-05-12", "2026-05-12"),
 	)) {
-		// Pull the iterator to surface parse errors.
+		events.push(event);
 	}
+	return events;
 }

--- a/test/unit/telemetry/export/files.test.ts
+++ b/test/unit/telemetry/export/files.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	listTelemetryFilesForRange,
 	streamTelemetryEventsSorted,
+	type TelemetryExportWarningSink,
 } from "@/telemetry/export/files";
 import { createCustomDateRange } from "@/telemetry/export/range";
 import { serializeTelemetryEventLine } from "@/telemetry/wireFormat";
@@ -17,6 +18,9 @@ vi.mock("node:fs", async () => (await import("memfs")).fs);
 vi.mock("node:fs/promises", async () => (await import("memfs")).fs.promises);
 
 const DIR = "/telemetry";
+const IGNORE_WARNINGS: TelemetryExportWarningSink = {
+	onWarning: () => undefined,
+};
 
 let makeEvent: ReturnType<typeof createTelemetryEventFactory>;
 
@@ -99,20 +103,30 @@ describe("streamTelemetryEventsSorted", () => {
 		]);
 	});
 
-	it("preserves events when a session timestamp moves backward", async () => {
+	it("filters by range and preserves backward session timestamps", async () => {
 		writeFiles({
 			"telemetry-2026-05-12-aaaaaaaa.jsonl":
 				serializeTelemetryEventLine(
-					makeSessionEvent("session-a", 0, "2026-05-12T10:02:00.000Z"),
+					makeSessionEvent("session-a", 0, "2026-05-11T23:59:59.999Z"),
 				) +
 				serializeTelemetryEventLine(
-					makeSessionEvent("session-a", 1, "2026-05-12T10:00:00.000Z"),
+					makeSessionEvent("session-a", 1, "2026-05-12T10:02:00.000Z"),
+				) +
+				serializeTelemetryEventLine(
+					makeSessionEvent("session-a", 2, "2026-05-12T10:00:00.000Z"),
 				),
+			"telemetry-2026-05-12-bbbbbbbb.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-b", 0, "2026-05-12T10:01:00.000Z"),
+			),
 		});
 
-		const events = await collectSorted(["telemetry-2026-05-12-aaaaaaaa.jsonl"]);
+		const events = await collectSorted([
+			"telemetry-2026-05-12-aaaaaaaa.jsonl",
+			"telemetry-2026-05-12-bbbbbbbb.jsonl",
+		]);
 
 		expect(events.map((event) => event.timestamp)).toEqual([
+			"2026-05-12T10:01:00.000Z",
 			"2026-05-12T10:02:00.000Z",
 			"2026-05-12T10:00:00.000Z",
 		]);
@@ -128,6 +142,29 @@ describe("streamTelemetryEventsSorted", () => {
 		).rejects.toThrow(
 			/Failed to parse telemetry file telemetry-2026-05-12-aaaaaaaa\.jsonl:1/,
 		);
+	});
+
+	it("skips invalid telemetry file paths after reporting a warning", async () => {
+		writeFiles({
+			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
+				makeSessionEvent("session-a", 0, "2026-05-12T10:00:00.000Z"),
+			),
+		});
+		const onWarning = vi.fn();
+
+		const events = await collectSorted(
+			["telemetry-2026-05-12-aaaaaaaa.jsonl", "notes-2026-05-12.jsonl"],
+			{ onWarning },
+		);
+
+		expect(events.map((event) => event.context.sessionId)).toEqual([
+			"session-a",
+		]);
+		expect(onWarning).toHaveBeenCalledWith({
+			code: "invalidTelemetryFilePath",
+			filePath: `${DIR}/notes-2026-05-12.jsonl`,
+			error: expect.any(Error),
+		});
 	});
 });
 
@@ -151,11 +188,13 @@ function makeSessionEvent(
 
 async function collectSorted(
 	names: readonly string[],
+	warningSink: TelemetryExportWarningSink = IGNORE_WARNINGS,
 ): Promise<TelemetryEvent[]> {
 	const events: TelemetryEvent[] = [];
 	for await (const event of streamTelemetryEventsSorted(
 		names.map((name) => `${DIR}/${name}`),
 		createCustomDateRange("2026-05-12", "2026-05-12"),
+		warningSink,
 	)) {
 		events.push(event);
 	}

--- a/test/unit/telemetry/export/files.test.ts
+++ b/test/unit/telemetry/export/files.test.ts
@@ -5,9 +5,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	listTelemetryFilesForRange,
 	streamTelemetryEventsSorted,
-	type TelemetryExportWarningSink,
+	type TelemetryLogFile,
 } from "@/telemetry/export/files";
 import { createCustomDateRange } from "@/telemetry/export/range";
+import { parseFileName } from "@/telemetry/localJsonlFiles";
 import { serializeTelemetryEventLine } from "@/telemetry/wireFormat";
 
 import { createTelemetryEventFactory } from "../../../mocks/telemetry";
@@ -18,9 +19,6 @@ vi.mock("node:fs", async () => (await import("memfs")).fs);
 vi.mock("node:fs/promises", async () => (await import("memfs")).fs.promises);
 
 const DIR = "/telemetry";
-const IGNORE_WARNINGS: TelemetryExportWarningSink = {
-	onWarning: () => undefined,
-};
 
 let makeEvent: ReturnType<typeof createTelemetryEventFactory>;
 
@@ -49,7 +47,7 @@ describe("listTelemetryFilesForRange", () => {
 			createCustomDateRange("2026-05-12", "2026-05-13"),
 		);
 
-		expect(files.map((p) => path.basename(p))).toEqual([
+		expect(files.map((file) => path.basename(file.path))).toEqual([
 			"telemetry-2026-05-12-bbbbbbbb.jsonl",
 			"telemetry-2026-05-12-bbbbbbbb.1.jsonl",
 		]);
@@ -143,29 +141,6 @@ describe("streamTelemetryEventsSorted", () => {
 			/Failed to parse telemetry file telemetry-2026-05-12-aaaaaaaa\.jsonl:1/,
 		);
 	});
-
-	it("skips invalid telemetry file paths after reporting a warning", async () => {
-		writeFiles({
-			"telemetry-2026-05-12-aaaaaaaa.jsonl": serializeTelemetryEventLine(
-				makeSessionEvent("session-a", 0, "2026-05-12T10:00:00.000Z"),
-			),
-		});
-		const onWarning = vi.fn();
-
-		const events = await collectSorted(
-			["telemetry-2026-05-12-aaaaaaaa.jsonl", "notes-2026-05-12.jsonl"],
-			{ onWarning },
-		);
-
-		expect(events.map((event) => event.context.sessionId)).toEqual([
-			"session-a",
-		]);
-		expect(onWarning).toHaveBeenCalledWith({
-			code: "invalidTelemetryFilePath",
-			filePath: `${DIR}/notes-2026-05-12.jsonl`,
-			error: expect.any(Error),
-		});
-	});
 });
 
 function writeFiles(files: Record<string, string>): void {
@@ -186,15 +161,21 @@ function makeSessionEvent(
 	};
 }
 
+function makeLogFile(name: string): TelemetryLogFile {
+	const parsed = parseFileName(name);
+	if (!parsed) {
+		throw new Error(`Test file name does not parse: ${name}`);
+	}
+	return { path: `${DIR}/${name}`, ...parsed };
+}
+
 async function collectSorted(
 	names: readonly string[],
-	warningSink: TelemetryExportWarningSink = IGNORE_WARNINGS,
 ): Promise<TelemetryEvent[]> {
 	const events: TelemetryEvent[] = [];
 	for await (const event of streamTelemetryEventsSorted(
-		names.map((name) => `${DIR}/${name}`),
+		names.map(makeLogFile),
 		createCustomDateRange("2026-05-12", "2026-05-12"),
-		warningSink,
 	)) {
 		events.push(event);
 	}

--- a/test/unit/telemetry/export/pipeline.test.ts
+++ b/test/unit/telemetry/export/pipeline.test.ts
@@ -59,6 +59,7 @@ function setup(
 		report: vi.fn(),
 		onFlushIncomplete: vi.fn(),
 		onCleanupError: vi.fn(),
+		onWarning: vi.fn(),
 	};
 	const request: ExportRequest = {
 		telemetryDir: "/tmp/telemetry",
@@ -102,6 +103,32 @@ describe("collectTelemetryExport", () => {
 		await run();
 
 		expect(runtime.onFlushIncomplete).not.toHaveBeenCalled();
+	});
+
+	it("reports recoverable warnings from the event stream", async () => {
+		const warning = {
+			code: "invalidTelemetryFilePath" as const,
+			filePath: "/tmp/telemetry/notes.jsonl",
+			error: new Error("bad name"),
+		};
+		const { run, runtime, writer } = setup();
+		vi.mocked(files.streamTelemetryEventsSorted).mockImplementation(
+			async function* (_filePaths, _range, warningSink) {
+				await Promise.resolve();
+				warningSink.onWarning(warning);
+				yield makeEvent();
+			},
+		);
+		writer.mockImplementation(async (_outputPath, events) => {
+			for await (const _event of events) {
+				// Consume the stream so stream warnings surface.
+			}
+			return 1;
+		});
+
+		await run();
+
+		expect(runtime.onWarning).toHaveBeenCalledWith(warning);
 	});
 
 	it("returns 0 and never writes when no files cover the range", async () => {

--- a/test/unit/telemetry/export/pipeline.test.ts
+++ b/test/unit/telemetry/export/pipeline.test.ts
@@ -27,14 +27,27 @@ const RANGE: TelemetryDateRange = {
 	label: "Last 24 hours",
 	filenamePart: "last-24-hours",
 };
-const FILE_PATHS = ["/tmp/telemetry/a.jsonl", "/tmp/telemetry/b.jsonl"];
+const FILES: files.TelemetryLogFile[] = [
+	{
+		path: "/tmp/telemetry/telemetry-2026-05-12-aaaaaaaa.jsonl",
+		date: "2026-05-12",
+		session: "aaaaaaaa",
+		part: 0,
+	},
+	{
+		path: "/tmp/telemetry/telemetry-2026-05-12-bbbbbbbb.jsonl",
+		date: "2026-05-12",
+		session: "bbbbbbbb",
+		part: 0,
+	},
+];
 const OUTPUT_PATH = "/tmp/out.json";
 const OK_FLUSH: FlushStatus = { ok: true, sinks: [] };
 
 function setup(
 	opts: {
 		events?: readonly TelemetryEvent[];
-		filePaths?: readonly string[];
+		files?: readonly files.TelemetryLogFile[];
 		signal?: AbortSignal;
 		writeCount?: number;
 		flush?: FlushStatus;
@@ -43,7 +56,7 @@ function setup(
 	vi.resetAllMocks();
 	vi.mocked(fsp.rm).mockResolvedValue(undefined);
 	vi.mocked(files.listTelemetryFilesForRange).mockResolvedValue([
-		...(opts.filePaths ?? FILE_PATHS),
+		...(opts.files ?? FILES),
 	]);
 	vi.mocked(files.streamTelemetryEventsSorted).mockReturnValue(
 		asyncIterable(opts.events ?? [makeEvent()]),
@@ -59,7 +72,6 @@ function setup(
 		report: vi.fn(),
 		onFlushIncomplete: vi.fn(),
 		onCleanupError: vi.fn(),
-		onWarning: vi.fn(),
 	};
 	const request: ExportRequest = {
 		telemetryDir: "/tmp/telemetry",
@@ -105,34 +117,8 @@ describe("collectTelemetryExport", () => {
 		expect(runtime.onFlushIncomplete).not.toHaveBeenCalled();
 	});
 
-	it("reports recoverable warnings from the event stream", async () => {
-		const warning = {
-			code: "invalidTelemetryFilePath" as const,
-			filePath: "/tmp/telemetry/notes.jsonl",
-			error: new Error("bad name"),
-		};
-		const { run, runtime, writer } = setup();
-		vi.mocked(files.streamTelemetryEventsSorted).mockImplementation(
-			async function* (_filePaths, _range, warningSink) {
-				await Promise.resolve();
-				warningSink.onWarning(warning);
-				yield makeEvent();
-			},
-		);
-		writer.mockImplementation(async (_outputPath, events) => {
-			for await (const _event of events) {
-				// Consume the stream so stream warnings surface.
-			}
-			return 1;
-		});
-
-		await run();
-
-		expect(runtime.onWarning).toHaveBeenCalledWith(warning);
-	});
-
 	it("returns 0 and never writes when no files cover the range", async () => {
-		const { run, writer } = setup({ filePaths: [] });
+		const { run, writer } = setup({ files: [] });
 
 		await expect(run()).resolves.toBe(0);
 		expect(writer).not.toHaveBeenCalled();
@@ -153,7 +139,7 @@ describe("collectTelemetryExport", () => {
 		expect(writer).toHaveBeenCalledWith(
 			OUTPUT_PATH,
 			expect.anything(),
-			{ range: RANGE, sourceFiles: FILE_PATHS.length },
+			{ range: RANGE, sourceFiles: FILES.length },
 			{ signal: runtime.signal, onCleanupError: runtime.onCleanupError },
 		);
 	});

--- a/test/unit/telemetry/export/pipeline.test.ts
+++ b/test/unit/telemetry/export/pipeline.test.ts
@@ -18,7 +18,7 @@ import type { FlushStatus } from "@/telemetry/service";
 
 vi.mock("@/telemetry/export/files", () => ({
 	listTelemetryFilesForRange: vi.fn(),
-	streamTelemetryEvents: vi.fn(),
+	streamTelemetryEventsSorted: vi.fn(),
 }));
 vi.mock("node:fs/promises", () => ({ rm: vi.fn(() => Promise.resolve()) }));
 
@@ -45,7 +45,7 @@ function setup(
 	vi.mocked(files.listTelemetryFilesForRange).mockResolvedValue([
 		...(opts.filePaths ?? FILE_PATHS),
 	]);
-	vi.mocked(files.streamTelemetryEvents).mockReturnValue(
+	vi.mocked(files.streamTelemetryEventsSorted).mockReturnValue(
 		asyncIterable(opts.events ?? [makeEvent()]),
 	);
 


### PR DESCRIPTION
## Summary

Telemetry exports previously sorted same-day files by filename session slug, so events from different sessions on the same date could appear out of chronological order.

- Sort telemetry exports by event timestamp across same-day sessions instead of filename session slug.
- Keep export streaming by merging one event cursor per session.
- Preserve append order when a single session emits backward timestamps.
- Keep filename format, schema, retention, and support bundle behavior unchanged.

## Commits

- `feat: sort telemetry exports by timestamp`: initial behavior change.
- `fix: address telemetry export review feedback`: review fixes and test coverage cleanup.

## Validation

- `pnpm test:extension ./test/unit/telemetry/export/files.test.ts ./test/unit/telemetry/export/pipeline.test.ts`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`

Generated by Coder Agents.