### PR TITLE
feat(telemetry): stamp export filenames with absolute dates

### DIFF
--- a/src/telemetry/export/range.ts
+++ b/src/telemetry/export/range.ts
@@ -60,7 +60,8 @@ export function createPresetDateRange(
 	id: TelemetryRangePresetId,
 	now: Date = new Date(),
 ): TelemetryDateRange {
-	const { label, filenamePart, durationMs } = PRESETS[id];
+	const { label, durationMs } = PRESETS[id];
+	const filenamePart = `${PRESETS[id].filenamePart}-${toUtcDateString(now)}`;
 	if (durationMs === undefined) {
 		return { label, filenamePart };
 	}
@@ -83,7 +84,7 @@ export function createCustomDateRange(
 	}
 	return {
 		label: `${startDate} to ${endDate}`,
-		filenamePart: `${startDate}_to_${endDate}`,
+		filenamePart: `${startDate}-to-${endDate}`,
 		startMs: startDateMs,
 		endMs: endDateMs + DAY_MS,
 	};

--- a/test/unit/telemetry/export/prompts.test.ts
+++ b/test/unit/telemetry/export/prompts.test.ts
@@ -64,7 +64,7 @@ describe("promptForExport", () => {
 
 		expect(choice?.range).toMatchObject({
 			label: "2026-01-01 to 2026-01-31",
-			filenamePart: "2026-01-01_to_2026-01-31",
+			filenamePart: "2026-01-01-to-2026-01-31",
 		});
 	});
 

--- a/test/unit/telemetry/export/range.test.ts
+++ b/test/unit/telemetry/export/range.test.ts
@@ -13,7 +13,7 @@ describe("telemetry export ranges", () => {
 
 		expect(range).toMatchObject({
 			label: "2026-05-12 to 2026-05-13",
-			filenamePart: "2026-05-12_to_2026-05-13",
+			filenamePart: "2026-05-12-to-2026-05-13",
 		});
 		expect(isTimestampInRange("2026-05-12T00:00:00.000Z", range)).toBe(true);
 		expect(isTimestampInRange("2026-05-13T23:59:59.999Z", range)).toBe(true);
@@ -32,6 +32,7 @@ describe("telemetry export ranges", () => {
 			new Date("2026-05-13T12:00:00.000Z"),
 		);
 
+		expect(range.filenamePart).toBe("last-24-hours-2026-05-13");
 		expect(fileDateCanContainRangeEvent("2026-05-11", range)).toBe(false);
 		expect(fileDateCanContainRangeEvent("2026-05-12", range)).toBe(true);
 		expect(fileDateCanContainRangeEvent("2026-05-13", range)).toBe(true);


### PR DESCRIPTION
Preset export names were relative (`coder-telemetry-last-7-days.json`), so the file stopped saying what it covered once saved, and exports from different days collided on the same default name.

Now every default filename carries an absolute UTC date, and all names are hyphen-separated:

- `coder-telemetry-last-7-days-2026-06-12.json`
- `coder-telemetry-all-time-2026-06-12.json`
- `coder-telemetry-2026-06-01-to-2026-06-10.json` (custom, was `_to_`)