### PR TITLE
chore: release v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
      from published versions since it shows up in the VS Code extension changelog
      tab and is confusing to users. Add it back between releases if needed. -->
 
-## Unreleased
+## [v1.15.1](https://github.com/coder/vscode-coder/releases/tag/v1.15.1) 2026-06-26
 
 ### Added
 
@@ -27,6 +27,12 @@
 - File-based credentials are now written and cleared through `coder login` and
   `coder logout` rather than by the extension directly. The minimum supported
   Coder version is now v0.25.0.
+
+### Changed
+
+- Workspace opens and `coder://` URI handling now log more diagnostics (target
+  workspace, agent, and handoff) to make failed opens easier to trace. URI
+  parameter values, including tokens, are never logged.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "coder-remote",
 	"displayName": "Coder",
-	"version": "1.15.0",
+	"version": "1.15.1",
 	"description": "Open any workspace with a single click.",
 	"categories": [
 		"Other"


### PR DESCRIPTION
Cuts the v1.15.1 patch release.

### Changes
- Bump version `1.15.0` → `1.15.1`.
- Consolidate the `Unreleased` changelog into a dated `v1.15.1` section.
- Add a changelog entry for the workspace-open / `coder://` URI diagnostics (#1015), which was the only user-facing change since v1.15.0 not yet documented.

### Coverage since v1.15.0
- Network Check command (#1002) — already in `Added`
- Proxy settings propagation (#1012) — already in `Fixed`
- Workspace-open authority diagnostics (#1015) — added under `Changed`
- Dependency bumps and demo GIF — not user-facing, omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)