### PR TITLE
fix: set a default timeout for REST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
      from published versions since it shows up in the VS Code extension changelog
      tab and is confusing to users. Add it back between releases if needed. -->
 
+## Unreleased
+
+### Fixed
+
+- Apply a 60-second default timeout to REST requests, so requests hung on a
+  half-open TCP connection don't stall pollers forever.
+
 ## [v1.15.2](https://github.com/coder/vscode-coder/releases/tag/v1.15.2) 2026-06-30
 
 > **Breaking:** API requests now respect `http.proxySupport: off`. Previously

--- a/src/api/coderApi.ts
+++ b/src/api/coderApi.ts
@@ -71,6 +71,18 @@ import type {
 const coderSessionTokenHeader = "Coder-Session-Token";
 
 /**
+ * Default timeout for REST requests. Prevents requests from hanging
+ * forever on half-open TCP connections (e.g. after system sleep or a
+ * network drop), which would otherwise silently kill pollers that only
+ * reschedule after the previous request settles.
+ *
+ * For streaming responses (`responseType: "stream"`, e.g. SSE and the
+ * CLI binary download) axios only enforces this until response headers
+ * arrive; it never aborts an in-flight stream body.
+ */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+/**
  * Configuration settings that affect WebSocket connections.
  * Changes to these settings will trigger WebSocket reconnection.
  */
@@ -130,6 +142,7 @@ export class CoderApi extends Api implements vscode.Disposable {
 			httpRequestsTelemetry,
 			authConfigTracker,
 		);
+		client.getAxiosInstance().defaults.timeout = DEFAULT_REQUEST_TIMEOUT_MS;
 		client.setCredentials(baseUrl, token);
 
 		setupInterceptors(client, output, httpRequestsTelemetry, authConfigTracker);

--- a/src/api/coderApi.ts
+++ b/src/api/coderApi.ts
@@ -71,14 +71,10 @@ import type {
 const coderSessionTokenHeader = "Coder-Session-Token";
 
 /**
- * Default timeout for REST requests. Prevents requests from hanging
- * forever on half-open TCP connections (e.g. after system sleep or a
- * network drop), which would otherwise silently kill pollers that only
- * reschedule after the previous request settles.
- *
- * For streaming responses (`responseType: "stream"`, e.g. SSE and the
- * CLI binary download) axios only enforces this until response headers
- * arrive; it never aborts an in-flight stream body.
+ * Default timeout for REST requests, so requests hung on half-open TCP
+ * connections (e.g. after system sleep) don't stall pollers forever.
+ * Streaming responses are only bounded until response headers arrive;
+ * axios never aborts an in-flight stream body.
  */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 

--- a/test/unit/api/coderApi.test.ts
+++ b/test/unit/api/coderApi.test.ts
@@ -21,7 +21,7 @@ import {
 	getRefreshCommand,
 	refreshCertificates,
 } from "@/api/certificateRefresh";
-import { CoderApi } from "@/api/coderApi";
+import { CoderApi, DEFAULT_REQUEST_TIMEOUT_MS } from "@/api/coderApi";
 import { createHttpAgent } from "@/api/utils";
 import { CONFIG_CHANGE_DEBOUNCE_MS } from "@/configWatcher";
 import { ClientCertificateError } from "@/error/clientCertificateError";
@@ -131,6 +131,30 @@ describe("CoderApi", () => {
 	});
 
 	describe("HTTP Interceptors", () => {
+		it("sets a default request timeout on the axios instance", () => {
+			api = createApi();
+
+			expect(api.getAxiosInstance().defaults.timeout).toBe(
+				DEFAULT_REQUEST_TIMEOUT_MS,
+			);
+		});
+
+		it("applies the default timeout to requests", async () => {
+			api = createApi();
+			const response = await api.getAxiosInstance().get("/api/v2/users/me");
+
+			expect(response.config.timeout).toBe(DEFAULT_REQUEST_TIMEOUT_MS);
+		});
+
+		it("allows per-request timeout overrides", async () => {
+			api = createApi();
+			const response = await api
+				.getAxiosInstance()
+				.get("/api/v2/users/me", { timeout: 0 });
+
+			expect(response.config.timeout).toBe(0);
+		});
+
 		it("adds custom headers and HTTP agent to requests", async () => {
 			const mockAgent = new ProxyAgent();
 			vi.mocked(createHttpAgent).mockResolvedValue(mockAgent);


### PR DESCRIPTION
Closes #1024

Requests through the `CoderApi` axios instance had no timeout, so a request hung on a half-open TCP connection (network drop, system sleep) never settled — silently killing every poller that only reschedules after the previous request settles (announcements refresh, workspaces tree poll, OAuth token refresh).

## Changes

- `defaults.timeout = 60_000` on the shared axios instance in `CoderApi.create`.
- Unit tests for the default and per-request overrides.

## Why no stream exemptions

The issue proposed `{ timeout: 0 }` opt-outs for streaming calls, but they aren't needed: in axios's Node adapter, `responseType: "stream"` requests are marked done once response headers arrive, so the timeout only bounds the connect/header phase and never aborts an in-flight stream body. SSE streams and CLI downloads just get a bounded connect phase, which is desirable. Build endpoints return as soon as the build is queued, so nothing REST-side legitimately exceeds 60s.

Timeouts surface as regular axios network errors, handled by existing `errToStr`/retry paths.

<details>
<summary>Decision log</summary>

- No standard to inherit: `coder/coder` site sets no axios timeout, and Go `codersdk` uses a bare `http.Client{}` bounded by per-request contexts.
- 60s over 30s for headroom on slow deployments while still recovering pollers within a minute.
- TCP keepalive on HTTP agents (faster dead-socket detection) deferred as a follow-up.
- A `coder.requestTimeout` setting rejected as premature configurability.

</details>

---

🤖 Generated by Coder Agents on behalf of @EhabY