### PR TITLE
fix: scope machine-only settings to application (#1032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 - Apply a 60-second default timeout to REST requests, so requests hung on a
   half-open TCP connection don't stall pollers forever.
+- Change `coder.binarySource`, `coder.binaryDestination`, `coder.headerCommand`,
+  `coder.tlsCertFile`, `coder.tlsKeyFile`, `coder.tlsCaFile`, `coder.tlsAltHost`,
+  `coder.tlsCertRefreshCommand`, `coder.proxyLogDirectory`, `coder.proxyBypass`,
+  `coder.sshConfig`, `coder.sshFlags`, and `coder.globalFlags` from `machine`
+  to `application` scope (still `ignoreSync`, unchanged from before). This
+  keeps workspace/folder `settings.json` from overriding them (the original
+  SEC-200 goal) while fixing #1032, where a `machine`-scoped value could
+  revert to its default in a remote window.
 
 ## [v1.15.2](https://github.com/coder/vscode-coder/releases/tag/v1.15.2) 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ Alternatively, manually install the VSIX from the
 All extension settings are under the `coder.*` namespace in the Settings UI.
 Paths in settings accept `~` and `${userHome}` from VS Code's
 [variables reference](https://code.visualstudio.com/docs/editor/variables-reference).
+Several `coder.*` settings (paths, commands, hostnames, and proxy bypass
+lists) are excluded from Settings Sync via `ignoreSync`, because their
+values can depend on the specific machine or network where they were set.
+
+> [!WARNING]
+> Do not give any `coder.*` setting `"scope": "machine"`. In a remote
+> window VS Code filters `machine`-scoped keys out of the local User
+> `settings.json`, so such a value only holds until the extension
+> registers its schema on activation. After that, the next re-parse of
+> `settings.json` (from an edit, a Settings Sync write, a profile switch,
+> or a `tasks.json` load) drops the value back to its default, with no
+> remote-side copy to fall back on. This intermittent revert is the cause
+> of #1032. Use `application` scope instead: it is honored in remote
+> windows regardless of timing. See #1034 for the mechanism and
+> reproduction.
 
 ## URI Handler
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
 						"type": "string",
 						"pattern": "^[a-zA-Z0-9-]+[=\\s].*$"
 					},
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.insecure": {
 					"markdownDescription": "If true, the extension will not verify the authenticity of the remote host. This is useful for self-signed certificates.",
@@ -66,13 +67,15 @@
 					"markdownDescription": "Used to download the Coder CLI which is necessary to make SSH connections. The If-None-Match header will be set to the SHA1 of the CLI and can be used for caching. Absolute URLs will be used as-is; otherwise this value will be resolved against the deployment domain. Defaults to downloading from the Coder deployment.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.binaryDestination": {
 					"markdownDescription": "The path to the Coder CLI binary or the directory containing it. When set to a file path (e.g., `/usr/bin/coder`), the extension checks its version and downloads a replacement if it does not match the server (and downloads are enabled). When set to a directory, the extension looks for the CLI inside it (downloading if enabled). Defaults to the value of `CODER_BINARY_DESTINATION` if not set, otherwise the extension's global storage directory.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.enableDownloads": {
 					"markdownDescription": "Allow the plugin to download the CLI when missing or out of date.",
@@ -84,50 +87,58 @@
 					"markdownDescription": "An external command that outputs additional HTTP headers added to all requests. The command must output each header as `key=value` on its own line. The following environment variables will be available to the process: `CODER_URL`. Defaults to the value of `CODER_HEADER_COMMAND` if not set.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.tlsCertFile": {
 					"markdownDescription": "Path to file for TLS client cert. When specified, token authorization will be skipped. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.tlsKeyFile": {
 					"markdownDescription": "Path to file for TLS client key. When specified, token authorization will be skipped. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.tlsCaFile": {
 					"markdownDescription": "Path to file for TLS certificate authority. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.tlsAltHost": {
 					"markdownDescription": "Alternative hostname to use for TLS verification. This is useful when the hostname in the certificate does not match the hostname used to connect.\n\nSupports `${env:VAR}` substitution.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.tlsCertRefreshCommand": {
 					"markdownDescription": "Command to run when TLS client certificate errors occur (e.g., expired, revoked, or rejected certificates). If configured, the extension will automatically execute this command and retry failed requests. `http.proxySupport` must be set to `on` or `off`, otherwise VS Code will override the proxy agent set by the plugin.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.proxyLogDirectory": {
 					"markdownDescription": "Directory where the Coder CLI outputs SSH connection logs for debugging. Defaults to the value of `CODER_SSH_LOG_DIR` if not set, otherwise the extension's global storage directory.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.proxyBypass": {
 					"markdownDescription": "If not set, will inherit from the `no_proxy` or `NO_PROXY` environment variables. Has no effect when `http.proxySupport` is set to `off`. With values other than `on`, VS Code will override the proxy agent set by the plugin.",
 					"markdownDeprecationMessage": "Deprecated: prefer `http.noProxy`.",
 					"type": "string",
 					"default": "",
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.defaultUrl": {
 					"markdownDescription": "This will be shown in the URL prompt, along with the CODER_URL environment variable if set, for the user to select when logging in.",
@@ -180,7 +191,8 @@
 					"default": [
 						"--disable-autostart"
 					],
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.globalFlags": {
 					"markdownDescription": "Global flags to pass to every Coder CLI invocation. Enter each flag as a separate array item, in order. Do **not** include the `coder` command itself. See the [CLI reference](https://coder.com/docs/reference/cli) for available global flags.\n\nSupports `${env:VAR}`, `${userHome}`, and a leading `~`. For `--flag=value` items the expansion applies to the value half, so `--cfg=~/coder` works.\n\nSet `--global-config` here to point the CLI at a shared config directory (e.g. `--global-config=~/.config/coderv2` to share login/auth with the Coder CLI); requires a deployment on 2.31.0+ and is ignored when `#coder.useKeyring#` is active. The `--use-keyring` flag is ignored; use `#coder.useKeyring#` instead.\n\nFor `--header-command`, precedence is: `#coder.headerCommand#` setting, then `CODER_HEADER_COMMAND` environment variable, then the value specified here.",
@@ -188,7 +200,8 @@
 					"items": {
 						"type": "string"
 					},
-					"scope": "machine"
+					"scope": "application",
+					"ignoreSync": true
 				},
 				"coder.useKeyring": {
 					"markdownDescription": "Store session tokens in the OS keyring (macOS Keychain, Windows Credential Manager) instead of plaintext files. Requires CLI >= 2.29.0 (>= 2.31.0 to sync login from CLI to VS Code). This will attempt to sync between the CLI and VS Code since they share the same keyring entry. It will log you out of the CLI if you log out of the IDE, and vice versa. Has no effect on Linux.",


### PR DESCRIPTION
Closes #1032

## Summary

Changes these settings from `"scope": "machine"` to `"scope": "application"` (all keep `ignoreSync: true`, so Settings Sync behavior is unchanged):

- `coder.binarySource`
- `coder.binaryDestination`
- `coder.headerCommand`
- `coder.tlsCertFile`
- `coder.tlsKeyFile`
- `coder.tlsCaFile`
- `coder.tlsAltHost`
- `coder.tlsCertRefreshCommand`
- `coder.proxyLogDirectory`
- `coder.proxyBypass` (deprecated in favor of `http.noProxy`)
- `coder.sshConfig`
- `coder.sshFlags`
- `coder.globalFlags`

Only the local-vs-remote read scope changes; sync behavior stays exactly as before. (We considered opting a few non-path settings into sync now that they are `application`-scoped, but held off: a download URL, a TLS hostname, a `no_proxy` list, or CLI flags can still be machine- or network-specific, and that is a separate decision from this fix.)

## Why

`machine` scope was introduced in #965 (SEC-200) to stop workspace and folder `settings.json` from overriding these settings. `application` scope preserves that goal: it can only be set in User settings, never overridden by workspace or folder settings.

But `machine` scope also makes VS Code stop honoring the User-configured value in a remote window. Reporters in #1032 saw the first connection work and later connections fail with no settings change; two independent users confirmed an `application`-scope build fixes it on Windows 11 and pinned the regression to v1.14.6, the release that shipped #965. All these settings are read at the same pre-connection point (right before SSH connects), so they share the exposure. Array settings (`sshFlags`/`globalFlags`) behave like the string ones, since scope resolution is per-key regardless of value type.

### The VS Code mechanism

In a remote window, `WorkspaceService` filters the local user configuration through `LOCAL_MACHINE_SCOPES = [APPLICATION, WINDOW, RESOURCE, LANGUAGE_OVERRIDABLE]` (`getLocalUserConfigurationScopes` in [`configurationService.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/configuration/browser/configurationService.ts)), which **excludes `MACHINE`** (see [`configuration.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/configuration/common/configuration.ts)). A `machine`-scoped value can then only come from the *remote* machine's settings file, not the local one where the user set it. This is deliberate, long-standing design:

- [microsoft/vscode-remote-release#2](https://github.com/microsoft/vscode-remote-release/issues/2): "machine settings scoped to a machine ... it makes sense to not to respect local machine settings configured in user settings in a remote window."
- [microsoft/vscode#177502](https://github.com/microsoft/vscode/issues/177502): the VS Code team hit this for a resolver reading `http.proxy` and fixed it the same way we do here: "Made proxy settings application scope by default. Once connected to remote, scope is changed accordingly."
- [`configurationService.test.ts` > `machine settings in local user settings does not override defaults`](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/services/configuration/test/browser/configurationService.test.ts): writes a `machine`-scoped key to the local user `settings.json`, constructs `WorkspaceService` with a `remoteAuthority`, and asserts `getValue()` returns the *default*.

### Reproduction (the "sometimes")

That unit test drops the value on a single connect because the schema is already registered when `WorkspaceService` is built. At runtime the extension registers its schema during activation, after the window's first parse, so the outcome is timing-dependent. The deciding logic is `shouldInclude` ([`configurationModels.ts`](https://github.com/microsoft/vscode/blob/main/src/vs/platform/configuration/common/configurationModels.ts)): an unregistered key (scope `undefined`) is kept, while a `machine`-registered key is dropped under `LOCAL_MACHINE_SCOPES`.

1. The remote window opens and parses `settings.json` before the extension activates, so the key is unregistered and **kept**.
2. The extension activates (`onResolveRemoteAuthority`) and registers its `machine`-scoped schema.
3. The next re-parse of `settings.json` (an edit, a Settings Sync write, a profile switch, or a `tasks.json` load) re-applies the filter, now sees `MACHINE`, and **drops the key** to its default. There is no remote fallback.

Reproduced with a source build of VS Code and a minimal UI extension (`scopetest.machineSetting`, `scope: machine`) on an SSH remote, with local settings `"scopetest.machineSetting": "value-from-USER-settings"` and no remote fallback. Editing `settings.json` after activation flips the resolved value:

| moment | schema registered | resolved scope | `getValue('scopetest.machineSetting')` |
| --- | --- | --- | --- |
| initial parse | no | (unregistered) | `"value-from-USER-settings"` |
| after edit / re-parse | yes | `MACHINE (2)` | `""` (default) |

`shouldInclude` logged the deciding step at each parse (`scopes` is `LOCAL_MACHINE_SCOPES` = `[1,4,5,6]`, no `MACHINE`):

```
shouldInclude key=scopetest.machineSetting propertySchema.scope=undefined options.scopes=[1,4,5,6]  -> included
shouldInclude key=scopetest.machineSetting propertySchema.scope=2         options.scopes=[1,4,5,6]  -> excluded
```

`APPLICATION` (1) is in `LOCAL_MACHINE_SCOPES`, so an `application`-scoped key is honored regardless of timing. That is the fix.

*This PR and investigation were assisted by Coder Agents on behalf of @EhabY.*
