### PR TITLE
test: deflake concurrent CLI and Windows ssh unit tests

### DIFF
--- a/test/unit/core/cliManager.concurrent.test.ts
+++ b/test/unit/core/cliManager.concurrent.test.ts
@@ -92,6 +92,17 @@ function setupManager(testDir: string): CliManager {
 	);
 }
 
+/**
+ * Asserts the lock and progress files are removed. The lock directory can
+ * briefly reappear while a peer re-acquires and releases it, so poll until gone.
+ */
+async function expectLockFilesRemoved(binaryPath: string): Promise<void> {
+	await vi.waitFor(async () => {
+		await expect(fs.access(binaryPath + ".lock")).rejects.toThrow();
+		await expect(fs.access(binaryPath + ".progress.log")).rejects.toThrow();
+	});
+}
+
 describe("CliManager Concurrent Downloads", () => {
 	let testDir: string;
 
@@ -124,10 +135,9 @@ describe("CliManager Concurrent Downloads", () => {
 			expect(result).toBe(binaryPath);
 		}
 
-		// Verify binary exists, and lock/progress files are cleaned up
+		// Verify binary exists, and lock/progress files are cleaned up.
 		await expect(fs.access(binaryPath)).resolves.toBeUndefined();
-		await expect(fs.access(binaryPath + ".lock")).rejects.toThrow();
-		await expect(fs.access(binaryPath + ".progress.log")).rejects.toThrow();
+		await expectLockFilesRemoved(binaryPath);
 	});
 
 	it("redownloads when version mismatch is detected concurrently", async () => {
@@ -167,8 +177,7 @@ describe("CliManager Concurrent Downloads", () => {
 		await expect(fs.access(binaryPath)).resolves.toBeUndefined();
 		const finalContent = await fs.readFile(binaryPath, "utf8");
 		expect(finalContent).toContain("v2.0.0");
-		await expect(fs.access(binaryPath + ".lock")).rejects.toThrow();
-		await expect(fs.access(binaryPath + ".progress.log")).rejects.toThrow();
+		await expectLockFilesRemoved(binaryPath);
 	});
 
 	it.each([

--- a/test/unit/remote/sshSupport.test.ts
+++ b/test/unit/remote/sshSupport.test.ts
@@ -22,9 +22,16 @@ Object.entries(supports).forEach(([version, expected]) => {
 	});
 });
 
-it("current shell supports ssh", () => {
-	expect(sshSupportsSetEnv()).toBeTruthy();
-});
+/**
+ * Spawning real `ssh` is slow on Windows CI runners, so allow a larger budget there.
+ */
+it(
+	"current shell supports ssh",
+	{ timeout: process.platform === "win32" ? 30_000 : undefined },
+	() => {
+		expect(sshSupportsSetEnv()).toBeTruthy();
+	},
+);
 
 describe("computeSshProperties", () => {
 	it("computes the config for a host", () => {


### PR DESCRIPTION
Fixes two flaky unit tests seen on CI.

- `cliManager.concurrent.test.ts`: the lock/progress cleanup assertions raced the library's peer re-acquire window — a waiter can recreate the `.lock` dir after the first downloader releases it, so the one-shot `fs.access(...).rejects.toThrow()` intermittently failed. Assert **eventual** removal via a `vi.waitFor` helper (`expectLockFilesRemoved`).
- `sshSupport.test.ts > "current shell supports ssh"`: spawns the real `ssh -V`, which took >10s on the Windows runner and hit the 10s `testTimeout`. Kept it end-to-end; bumped the timeout to 30s on Windows only.

Both remain behavior tests (no mocking).

Generated by Coder Agents on behalf of @EhabY.