### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -16,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
 
@@ -48,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
 
@@ -71,6 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
 
@@ -88,6 +97,8 @@ jobs:
     if: github.repository_owner == 'coder' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
 
@@ -107,6 +118,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
 

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -5,9 +5,7 @@ on:
       - "v*-pre"
 
 permissions:
-  # Required to publish a release
-  contents: write
-  pull-requests: read
+  contents: read
 
 jobs:
   package:
@@ -17,6 +15,16 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag is on main
+        run: |
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Error: Pre-release tags must be pushed from the main branch"
+            exit 1
+          fi
 
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup
@@ -65,6 +73,10 @@ jobs:
   publish:
     name: Publish Extension and Create Pre-Release
     needs: package
+    permissions:
+      # Required to create the GitHub release
+      contents: write
+      pull-requests: read
     uses: ./.github/workflows/publish-extension.yaml
     with:
       version: ${{ needs.package.outputs.version }}

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -16,15 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           persist-credentials: false
-
-      - name: Verify tag is on main
-        run: |
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "Error: Pre-release tags must be pushed from the main branch"
-            exit 1
-          fi
 
       - name: Setup pnpm, Node.js, and dependencies
         uses: ./.github/actions/setup

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -22,12 +22,16 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     outputs:
       packageName: ${{ steps.package.outputs.packageName }}
       hasVscePat: ${{ steps.check-secrets.outputs.hasVscePat }}
       hasOvsxPat: ${{ steps.check-secrets.outputs.hasOvsxPat }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -58,6 +62,11 @@ jobs:
     name: Publish to VS Marketplace
     needs: setup
     runs-on: ubuntu-24.04
+    # Protected environment: configure required reviewers and (ideally) move
+    # VSCE_PAT/OVSX_PAT into it so publishing needs an explicit approval.
+    environment: publish
+    permissions:
+      contents: read
     if: ${{ needs.setup.outputs.hasVscePat == 'true' }}
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -65,25 +74,33 @@ jobs:
           node-version: "22"
 
       - name: Install vsce
-        run: npm install -g @vscode/vsce
+        # Pinned to the version locked in pnpm-lock.yaml; keep in sync.
+        run: npm install -g @vscode/vsce@3.9.2
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: extension-${{ inputs.version }}
 
       - name: Publish to VS Marketplace
+        env:
+          # vsce reads VSCE_PAT from the environment; never pass tokens as
+          # command-line arguments (visible in process listings).
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           echo "Publishing version ${{ inputs.version }} to VS Marketplace"
           if [ "${{ inputs.isPreRelease }}" = "true" ]; then
-            vsce publish --pre-release --packagePath "./${{ needs.setup.outputs.packageName }}" -p ${{ secrets.VSCE_PAT }}
+            vsce publish --pre-release --packagePath "./${{ needs.setup.outputs.packageName }}"
           else
-            vsce publish --packagePath "./${{ needs.setup.outputs.packageName }}" -p ${{ secrets.VSCE_PAT }}
+            vsce publish --packagePath "./${{ needs.setup.outputs.packageName }}"
           fi
 
   publishOVSX:
     name: Publish to Open VSX
     needs: setup
     runs-on: ubuntu-24.04
+    environment: publish
+    permissions:
+      contents: read
     if: ${{ needs.setup.outputs.hasOvsxPat == 'true' }}
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -91,25 +108,33 @@ jobs:
           node-version: "22"
 
       - name: Install ovsx
-        run: npm install -g ovsx
+        run: npm install -g ovsx@1.0.2
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: extension-${{ inputs.version }}
 
       - name: Publish to Open VSX
+        env:
+          # ovsx reads OVSX_PAT from the environment; never pass tokens as
+          # command-line arguments (visible in process listings).
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           echo "Publishing version ${{ inputs.version }} to Open VSX"
           if [ "${{ inputs.isPreRelease }}" = "true" ]; then
-            ovsx publish "./${{ needs.setup.outputs.packageName }}" --pre-release -p ${{ secrets.OVSX_PAT }}
+            ovsx publish "./${{ needs.setup.outputs.packageName }}" --pre-release
           else
-            ovsx publish "./${{ needs.setup.outputs.packageName }}" -p ${{ secrets.OVSX_PAT }}
+            ovsx publish "./${{ needs.setup.outputs.packageName }}"
           fi
 
   publishGH:
     name: Create GitHub ${{ inputs.isPreRelease && 'Pre-' || '' }}Release
     needs: setup
     runs-on: ubuntu-24.04
+    permissions:
+      # Required to create the release and generate release notes
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/publish-extension.yaml
+++ b/.github/workflows/publish-extension.yaml
@@ -26,6 +26,7 @@ jobs:
       contents: read
     outputs:
       packageName: ${{ steps.package.outputs.packageName }}
+      vsceVersion: ${{ steps.versions.outputs.vsceVersion }}
       hasVscePat: ${{ steps.check-secrets.outputs.hasVscePat }}
       hasOvsxPat: ${{ steps.check-secrets.outputs.hasOvsxPat }}
     steps:
@@ -49,6 +50,15 @@ jobs:
           echo "packageName=$PACKAGE_NAME" >> $GITHUB_OUTPUT
           echo "Package name: $PACKAGE_NAME"
 
+      - name: Determine vsce version from lockfile
+        id: versions
+        # Explicit bash enables pipefail: an extraction miss fails the job
+        # instead of silently installing latest.
+        shell: bash
+        run: |
+          VSCE_VERSION="$(grep -m 1 -o "@vscode/vsce@[0-9][^'(]*" pnpm-lock.yaml | cut -d @ -f 3)"
+          echo "vsceVersion=$VSCE_VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Check secrets
         id: check-secrets
         env:
@@ -62,8 +72,6 @@ jobs:
     name: Publish to VS Marketplace
     needs: setup
     runs-on: ubuntu-24.04
-    # Protected environment: configure required reviewers and (ideally) move
-    # VSCE_PAT/OVSX_PAT into it so publishing needs an explicit approval.
     environment: publish
     permissions:
       contents: read
@@ -74,8 +82,9 @@ jobs:
           node-version: "22"
 
       - name: Install vsce
-        # Pinned to the version locked in pnpm-lock.yaml; keep in sync.
-        run: npm install -g @vscode/vsce@3.9.2
+        env:
+          VSCE_VERSION: ${{ needs.setup.outputs.vsceVersion }}
+        run: npm install -g "@vscode/vsce@${VSCE_VERSION}"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -83,8 +92,6 @@ jobs:
 
       - name: Publish to VS Marketplace
         env:
-          # vsce reads VSCE_PAT from the environment; never pass tokens as
-          # command-line arguments (visible in process listings).
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           echo "Publishing version ${{ inputs.version }} to VS Marketplace"
@@ -116,8 +123,6 @@ jobs:
 
       - name: Publish to Open VSX
         env:
-          # ovsx reads OVSX_PAT from the environment; never pass tokens as
-          # command-line arguments (visible in process listings).
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           echo "Publishing version ${{ inputs.version }} to Open VSX"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,7 @@ on:
       - "!v*-pre"
 
 permissions:
-  # Required to publish a release
-  contents: write
-  pull-requests: read
+  contents: read
 
 jobs:
   package:
@@ -20,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify tag is on main
         run: |
@@ -74,6 +73,10 @@ jobs:
   publish:
     name: Publish Extension and Create Release
     needs: package
+    permissions:
+      # Required to create the GitHub release
+      contents: write
+      pull-requests: read
     uses: ./.github/workflows/publish-extension.yaml
     with:
       version: ${{ needs.package.outputs.version }}


### PR DESCRIPTION
> Review priority: 2/10. Fast review, config only; hardens the pipeline every later release ships through.
> Diff: CI config +62/-12, no production or test code

Hardens the GitHub Actions release/publish pipeline. No runtime code changes; nothing changes on today's happy path.

**Changes**
- Least-privilege `GITHUB_TOKEN`: workflows default to `contents: read`; only the release-creating job keeps `contents: write` + `pull-requests: read` (same scopes as before, now job-scoped). All checkouts set `persist-credentials: false`; no job pushes or fetches after checkout, and pnpm clones the `github:coder/coder` dependency anonymously in its own store, so this is inert.
- Marketplace/OpenVSX publish jobs run in a `publish` environment as an attachment point for approval gating.
- No more `install -g` latest at publish time: the locked `@vscode/vsce` version is extracted from `pnpm-lock.yaml` (fails closed on a miss), so packaging and publishing run the same tool version. `ovsx` is pinned to `1.0.2` (today's latest; not a project dependency, so no lockfile to sync against).
- PATs passed via `VSCE_PAT`/`OVSX_PAT` env vars (read natively by both tools) instead of `-p <token>` argv, which is world-readable via `/proc`.

**Alternatives considered**
- Full checkout + `pnpm install` in the publish job to run `pnpm vsce publish` directly. Pro: zero version extraction. Con: installs hundreds of packages into the one job holding marketplace PATs; larger exfiltration surface. Rejected.
- Hardcoded vsce version pin. Pro: simplest. Con: drifts from the lockfile silently. Replaced by lockfile extraction.

> [!IMPORTANT]
> Admin follow-up: the `publish` environment auto-creates on first run with no protection rules, so it blocks nothing by itself. Add required reviewers, and ideally move `VSCE_PAT`/`OVSX_PAT` into environment secrets so only approved runs can read them.

Intentionally unchanged: pre-release tags remain buildable off `main` (used for testing); dev-only `pnpm audit` findings (mocha transitives, unreachable from the shipped extension) are deferred. Dependency provenance for the `coder` git dependency is handled in #1053.