### PR TITLE
chore: pin coder dependency to an immutable commit SHA

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     coder:
-      specifier: github:coder/coder#v2.34.1
+      specifier: github:coder/coder#2e8d80abf74d655b54ace1533b6c13102ea8d549
       version: 0.0.0
     date-fns:
       specifier: ^4.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,8 @@ catalog:
   "@vscode-elements/react-elements": ^2.4.0
   "@vscode/codicons": 0.0.46-24
   babel-plugin-react-compiler: ^1.0.0
-  coder: github:coder/coder#v2.34.1
+  # v2.34.1, pinned to the commit SHA so the ref is immutable (tags can be re-pointed).
+  coder: github:coder/coder#2e8d80abf74d655b54ace1533b6c13102ea8d549
   date-fns: ^4.4.0
   react: ^19.2.8
   react-dom: ^19.2.8


### PR DESCRIPTION
> Review priority: 3/10. One-minute review: immutability pin, resolution unchanged.
> Diff: manifest/lockfile +3/-2, no production or test code

Pins the `coder` git dependency to the commit SHA that `v2.34.1` points at, instead of the tag name.

Git tags are mutable and git-hosted dependencies are the one class of lockfile entry with no `integrity:` hash to catch a re-pointed ref. The lockfile already resolves to this exact commit (`2e8d80a`, verified to be the tag's target via the GitHub API), so resolution is byte-identical; this makes the manifest itself immutable too. The comment keeps the human-readable version mapping.

**Alternatives considered**
- Consume the needed types/helpers from a published npm package. Pro: integrity hashes and normal release review. Con: requires upstream packaging work; not available today.
- Vendor the small amount of imported code. Pro: no external fetch at all. Con: manual sync burden on every coder/coder bump; easy to fall behind.
- SHA pin (chosen): immutable with zero workflow change. Con: bumps must update SHA and comment together, verifying the SHA against the release tag.