### PR TITLE
fix(cli): ignore SemVer build metadata in cache checks

### DIFF
--- a/src/core/cliManager.ts
+++ b/src/core/cliManager.ts
@@ -56,6 +56,16 @@ type SingleVerifyResult =
 	| { kind: "bypassed" }
 	| { kind: "sig_unavailable"; status: number };
 
+function versionsMatch(actual: string, expected: string): boolean {
+	const actualVersion = semver.valid(actual);
+	const expectedVersion = semver.valid(expected);
+	return (
+		actualVersion !== null &&
+		expectedVersion !== null &&
+		semver.eq(actualVersion, expectedVersion)
+	);
+}
+
 export class CliManager {
 	private readonly binaryLock: BinaryLock;
 	private readonly cliTelemetry: CliTelemetry;
@@ -166,7 +176,10 @@ export class CliManager {
 				this.checkResolvedBinary(restClient, resolved),
 			);
 
-		if (existingVersion === buildInfo.version) {
+		if (
+			existingVersion !== null &&
+			versionsMatch(existingVersion, buildInfo.version)
+		) {
 			this.output.debug("Existing binary matches server version");
 			trace.setOutcome("cache_hit");
 			return resolved.binPath;
@@ -263,7 +276,9 @@ export class CliManager {
 				parsedVersion,
 				existingVersion,
 				downloadReason: "version_mismatch",
-				outcome: existingVersion === buildInfo.version ? "match" : "mismatch",
+				outcome: versionsMatch(existingVersion, buildInfo.version)
+					? "match"
+					: "mismatch",
 			};
 		} catch (error) {
 			this.output.warn(
@@ -425,7 +440,7 @@ export class CliManager {
 			const version = await cliVersion(binPath);
 			return {
 				version,
-				matches: version === expectedVersion,
+				matches: versionsMatch(version, expectedVersion),
 			};
 		} catch (error) {
 			this.output.warn(`Unable to get version of binary: ${errToStr(error)}`);

--- a/test/unit/core/cliManager.test.ts
+++ b/test/unit/core/cliManager.test.ts
@@ -378,6 +378,17 @@ describe("CliManager", () => {
 			expect(memfs.existsSync(BINARY_PATH)).toBe(true);
 		});
 
+		it("reuses a binary when only SemVer build metadata differs", async () => {
+			const { manager, mockApi, mockAxios, withExistingBinary } =
+				setupCliManager();
+			mockApi.getBuildInfo = vi
+				.fn()
+				.mockResolvedValue({ version: "v2.34.0+3006da5" });
+			withExistingBinary("v2.34.0");
+			expectPathsEqual(await manager.fetchBinary(mockApi), BINARY_PATH);
+			expect(mockAxios.get).not.toHaveBeenCalled();
+		});
+
 		it("downloads when versions differ", async () => {
 			const { manager, mockApi, withExistingBinary, withSuccessfulDownload } =
 				setupCliManager();


### PR DESCRIPTION
## Summary

- compare cached CLI and server versions with SemVer equality instead of raw string equality
- ignore SemVer build metadata while still requiring the same major, minor, patch, and prerelease identifiers
- use the same comparison in initial cache lookup, telemetry outcome, and post-lock/download race checks
- add regression coverage for a release CLI matching a server version that includes source-revision metadata

## Problem

Coder server builds can report a release version with source metadata, for example:

```text
server: v2.34.0+3006da5
CLI:    v2.34.0
```

These versions have the same SemVer precedence and represent the same release, but `CliManager` currently compares their raw strings in three places. The extension therefore treats a valid cached CLI as stale and downloads it again on every connection.

We encountered this while using a reproducibly built and signed CLI from the same Coder v2.34.0 release source as the server. The unnecessary download was approximately 56 MB each time and materially delayed VS Code Remote startup. This can also affect any release packaging where one artifact retains VCS build metadata and another does not.

## Behavior

`versionsMatch` validates both strings and delegates equality to `semver.eq`, whose equality semantics ignore build metadata:

- `v2.34.0` matches `v2.34.0+3006da5`
- `v2.34.0-rc.1` matches `v2.34.0-rc.1+3006da5`
- `v2.34.0` does not match `v2.34.1`
- invalid versions do not match

The existing server-version validation remains unchanged. Signature verification and download behavior are also unchanged; this only prevents a download when an executable cached CLI is already the same SemVer release.

## Tests

- `node node_modules/vitest/vitest.mjs --run test/unit/core/cliManager.test.ts test/unit/core/cliManager.telemetry.test.ts test/unit/core/cliManager.concurrent.test.ts` — 88 passed
- `pnpm exec prettier --check src/core/cliManager.ts test/unit/core/cliManager.test.ts`
- `pnpm exec eslint src/core/cliManager.ts test/unit/core/cliManager.test.ts`