### PR TITLE
fix: ignore the SSH config file setting where ssh never reads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,10 @@
 
 ### Fixed
 
-- Write the SSH config to the file the active Remote-SSH extension actually
-  reads. Windsurf/Devin and Antigravity renamed the whole `remote.SSH` settings
-  section, so a custom config file set as `remote.devinSSH.configFile`,
-  `remote.windsurfSSH.configFile`, or `remote.antigravitySSH.configFile` was
-  ignored and the workspace host was written to `~/.ssh/config` instead, where
-  those editors never looked for it.
+- Ignore the SSH config file setting on Antigravity and Windsurf/Devin. They
+  launch ssh without pointing it at a config file, so it always reads
+  `~/.ssh/config`, and honoring the setting wrote the workspace host where the
+  connection never looked.
 - Apply a 60-second default timeout to REST requests, so requests hung on a
   half-open TCP connection don't stall pollers forever.
 - Change `coder.binarySource`, `coder.binaryDestination`, `coder.headerCommand`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,13 @@ Host coder-vscode.dev.coder.com--*
 	LogLevel ERROR
 ```
 
+Which file that entry goes in depends on the Remote - SSH extension. Microsoft's
+and Cursor's pass `remote.SSH.configFile` to ssh with `-F`, and VSCodium's parses
+the file itself instead of running ssh, so all three connect through it.
+Antigravity and Windsurf/Devin renamed the setting but spawn ssh without `-F`, so
+ssh reads `~/.ssh/config` regardless; we ignore it there rather than write the
+host where the connection never looks.
+
 If any step fails, we show an error message. Once the error message is closed
 we close the remote so the Remote - SSH connection does not continue to
 connection. Otherwise, we yield, which lets the Remote - SSH continue.

--- a/src/remote/remote.ts
+++ b/src/remote/remote.ts
@@ -55,7 +55,7 @@ import {
 	parseCoderSshOptions,
 	parseSshConfig,
 } from "./sshConfig";
-import { getRemoteSshSetting } from "./sshExtension";
+import { getRemoteSshConfigFile } from "./sshExtension";
 import { applySettingOverrides, buildSshOverrides } from "./sshOverrides";
 import { SshProcessMonitor } from "./sshProcess";
 import { computeSshProperties, sshSupportsSetEnv } from "./sshSupport";
@@ -919,7 +919,7 @@ export class Remote {
 	}
 
 	private getSshConfigPath(): string {
-		const configured = getRemoteSshSetting("configFile");
+		const configured = getRemoteSshConfigFile();
 		return expandPath(configured || path.join("~", ".ssh", "config"));
 	}
 

--- a/src/remote/sshExtension.ts
+++ b/src/remote/sshExtension.ts
@@ -11,31 +11,25 @@ export const REMOTE_SSH_EXTENSION_IDS = [
 export type RemoteSshExtensionId = (typeof REMOTE_SSH_EXTENSION_IDS)[number];
 
 /**
- * Sections each extension reads, in order. The rebranded forks renamed the
- * whole `remote.SSH` section, so reading it directly misses them.
+ * Extensions that spawn ssh without `-F`, so it reads ~/.ssh/config whatever
+ * their renamed setting says. Honoring one would write the workspace host
+ * where the connection never looks.
  */
-const SETTING_SECTIONS: Readonly<
-	Record<RemoteSshExtensionId, readonly string[]>
-> = {
-	"jeanp413.open-remote-ssh": ["remote.SSH"],
-	// Windsurf became Devin and reads both, preferring the new name.
-	"codeium.windsurf-remote-openssh": ["remote.devinSSH", "remote.windsurfSSH"],
-	"anysphere.remote-ssh": ["remote.SSH"],
-	"ms-vscode-remote.remote-ssh": ["remote.SSH"],
-	"google.antigravity-remote-openssh": ["remote.antigravitySSH"],
-};
+const IGNORED_CONFIG_FILE: readonly RemoteSshExtensionId[] = [
+	"google.antigravity-remote-openssh",
+	"codeium.windsurf-remote-openssh",
+];
 
-/** First non-empty value for a string setting, e.g. `configFile`. */
-export function getRemoteSshSetting(key: string): string | undefined {
+/** The SSH config file the active extension connects through, if configured. */
+export function getRemoteSshConfigFile(): string | undefined {
 	const id = getRemoteSshExtension()?.id;
-	const sections = id ? SETTING_SECTIONS[id] : ["remote.SSH"];
-	for (const section of sections) {
-		const value = vscode.workspace.getConfiguration(section).get<string>(key);
-		if (value) {
-			return value;
-		}
+	if (id && IGNORED_CONFIG_FILE.includes(id)) {
+		return undefined;
 	}
-	return undefined;
+	return (
+		vscode.workspace.getConfiguration("remote.SSH").get<string>("configFile") ||
+		undefined
+	);
 }
 
 /**

--- a/test/unit/remote/sshExtension.test.ts
+++ b/test/unit/remote/sshExtension.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import * as vscode from "vscode";
 
-import { getRemoteSshSetting } from "@/remote/sshExtension";
+import { getRemoteSshConfigFile } from "@/remote/sshExtension";
 
 import { config, type Settings } from "../../mocks/testHelpers";
 
@@ -13,47 +13,41 @@ function setup(extensionId: string, settings: Settings = {}): void {
 	);
 }
 
-describe("getRemoteSshSetting", () => {
+describe("getRemoteSshConfigFile", () => {
 	it.each([
-		["ms-vscode-remote.remote-ssh", "remote.SSH.configFile"],
-		["anysphere.remote-ssh", "remote.SSH.configFile"],
-		["jeanp413.open-remote-ssh", "remote.SSH.configFile"],
+		"ms-vscode-remote.remote-ssh",
+		"anysphere.remote-ssh",
+		"jeanp413.open-remote-ssh",
+	])("reads the configured file for %s", (extensionId) => {
+		setup(extensionId, { "remote.SSH.configFile": "/custom/config" });
+
+		expect(getRemoteSshConfigFile()).toBe("/custom/config");
+	});
+
+	it.each([
 		["google.antigravity-remote-openssh", "remote.antigravitySSH.configFile"],
 		["codeium.windsurf-remote-openssh", "remote.devinSSH.configFile"],
-	])("reads the section %s uses", (extensionId, settingKey) => {
-		setup(extensionId, { [settingKey]: "/custom/config" });
+	])(
+		"ignores the file %s never connects through",
+		(extensionId, settingKey) => {
+			setup(extensionId, {
+				[settingKey]: "/custom/config",
+				"remote.SSH.configFile": "/stale/config",
+			});
 
-		expect(getRemoteSshSetting("configFile")).toBe("/custom/config");
-	});
+			expect(getRemoteSshConfigFile()).toBeUndefined();
+		},
+	);
 
-	it("falls back to the legacy Windsurf section", () => {
-		setup("codeium.windsurf-remote-openssh", {
-			"remote.windsurfSSH.configFile": "/legacy/config",
-		});
-
-		expect(getRemoteSshSetting("configFile")).toBe("/legacy/config");
-	});
-
-	it("prefers the Devin section over the legacy Windsurf one", () => {
-		setup("codeium.windsurf-remote-openssh", {
-			"remote.devinSSH.configFile": "/devin/config",
-			"remote.windsurfSSH.configFile": "/legacy/config",
-		});
-
-		expect(getRemoteSshSetting("configFile")).toBe("/devin/config");
-	});
-
-	it("ignores another extension's section", () => {
-		setup("google.antigravity-remote-openssh", {
-			"remote.SSH.configFile": "/custom/config",
-		});
-
-		expect(getRemoteSshSetting("configFile")).toBeUndefined();
-	});
-
-	it("defaults to remote.SSH when no extension is installed", () => {
+	it("reads remote.SSH when no extension is installed", () => {
 		setup("", { "remote.SSH.configFile": "/custom/config" });
 
-		expect(getRemoteSshSetting("configFile")).toBe("/custom/config");
+		expect(getRemoteSshConfigFile()).toBe("/custom/config");
+	});
+
+	it("returns undefined when nothing is configured", () => {
+		setup("ms-vscode-remote.remote-ssh");
+
+		expect(getRemoteSshConfigFile()).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Follow-up to #1060, which shipped an incorrect premise.

## Problem

#1060 assumed every Remote-SSH extension connects through the config file its `configFile` setting names. Two of them do not.

Antigravity and Windsurf/Devin spawn ssh as `-v -T [-o RemoteCommand=none] -D <port> <dest> bash -s` — **no `-F`** anywhere in either bundle (the only `-F` token is a `grep -F` in their remote install script). Their `getSSHConfigPath()` feeds the host tree, the file watcher and the "Open SSH Configuration File" command, and nothing else. ssh therefore reads its own default `~/.ssh/config` no matter what `remote.antigravitySSH.configFile` or `remote.devinSSH.configFile` says.

So after #1060, a user who set one of those got the workspace host written to a file the connection never reads, and the connection failed. Before #1060 that user had a cosmetic mismatch only. The same applies to a stale `remote.SSH.configFile` synced in from VS Code, which those editors also never pass to ssh.

## Change

Ignore the setting on those two extensions and read `remote.SSH.configFile` everywhere else, because the three extensions that genuinely connect through it all use that name:

| Extension | Connects through the setting? |
|---|---|
| `ms-vscode-remote.remote-ssh` | yes, passes it with `-F` |
| `anysphere.remote-ssh` | yes, passes it with `-F` |
| `jeanp413.open-remote-ssh` | yes, parses the file itself (bundles `ssh2`, never runs ssh) |
| `google.antigravity-remote-openssh` | no |
| `codeium.windsurf-remote-openssh` | no |

That makes #1060's per-extension section map inert, so it is removed: the renamed sections belong exclusively to extensions we now skip. The rule is documented in `CONTRIBUTING.md` next to the SSH config flow.

Known cosmetic trade-off: on those two editors, a user pointing the setting elsewhere will not see Coder workspaces in the extension's host tree. Their own hosts in that file are equally unreachable for the same upstream reason, so this restores the pre-#1060 behaviour rather than introducing a new gap.

## Testing

`getRemoteSshConfigFile` is covered for the three honouring extensions, for both ignoring ones (including with a stale `remote.SSH.configFile` present), for no extension installed, and for nothing configured. Full suite passes, plus lint and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)