### PR TITLE
fix: eliminate Vite config loader warning in tests

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 const webviewSharedAlias = path.resolve(
-	__dirname,
+	import.meta.dirname,
 	"packages/webview-shared/src",
 );
 
@@ -24,9 +24,12 @@ export default defineConfig({
 				},
 				resolve: {
 					alias: {
-						"@": path.resolve(__dirname, "src"),
+						"@": path.resolve(import.meta.dirname, "src"),
 						"@repo/webview-shared": webviewSharedAlias,
-						vscode: path.resolve(__dirname, "test/mocks/vscode.runtime.ts"),
+						vscode: path.resolve(
+							import.meta.dirname,
+							"test/mocks/vscode.runtime.ts",
+						),
 					},
 				},
 			},
@@ -43,11 +46,17 @@ export default defineConfig({
 				resolve: {
 					alias: {
 						"@repo/webview-shared": webviewSharedAlias,
-						"@repo/tasks": path.resolve(__dirname, "packages/tasks/src"),
-						"@repo/ui": path.resolve(__dirname, "packages/ui/src"),
-						"@repo/netcheck": path.resolve(__dirname, "packages/netcheck/src"),
+						"@repo/tasks": path.resolve(
+							import.meta.dirname,
+							"packages/tasks/src",
+						),
+						"@repo/ui": path.resolve(import.meta.dirname, "packages/ui/src"),
+						"@repo/netcheck": path.resolve(
+							import.meta.dirname,
+							"packages/netcheck/src",
+						),
 						"@repo/speedtest": path.resolve(
-							__dirname,
+							import.meta.dirname,
 							"packages/speedtest/src",
 						),
 					},


### PR DESCRIPTION
## What

`pnpm test` printed a Vite config loader warning (3x): `vitest.config.ts` uses ESM syntax but the root `package.json` has `"type": "commonjs"`, so Vite loads it as CJS and warns about the upcoming `configLoader: "native"` default.

## Changes

- Rename `vitest.config.ts` → `vitest.config.mts` and replace `__dirname` with `import.meta.dirname`. This makes the config unambiguously ESM, silencing the warning.

> Note: this PR originally also fixed React act() warnings in `useVscodeTheme.test.ts`. That fix landed on `main` via #1047, so it dropped out of this diff on rebase.

## Verification

- All 153 test files / 2367 tests pass with **zero warnings** in the output.
- `pnpm typecheck`, `pnpm lint`, and `pnpm format:check` pass.

---

Generated by [Coder Agents](https://coder.com)