### PR TITLE
feat(ui): serve tree and action-bar hovers from one native-style widget

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -140,6 +140,7 @@ flowchart LR
   Transition --> Adapter[useTreeAdapter.ts]
   Adapter --> Rows[Tree.tsx and TreeRow.tsx]
   Adapter --> Sticky[StickyScroll.tsx]
+  Rows --> Hover[TreeHover.tsx]
 ```
 
 The model, policy, and transitions stay pure. The adapter owns React and DOM
@@ -153,6 +154,15 @@ hover, selected ancestor paths stay active, and the focused path is active only
 while the tree has focus. The package default uses inset Modern UI rows;
 `data-ui-style="stable"` restores edge-to-edge square rows and stable focus
 styling.
+
+Labels hover with the node's text value, so truncated rows stay readable.
+Set `tooltip` for richer content or `null` to opt out. One bubble serves the
+whole tree, as in the native list: an invisible anchor moves to whatever the
+pointer reaches, taking its x from the cursor and its y from the target's box,
+the way a native hover placed at the mouse does. Each new target waits out the
+show delay, except within a row's action bar, where crossing between buttons is
+instant, the exception native grants a dense cluster of targets. Ctrl+K Ctrl+I opens the focused
+row's hover with no delay at all, and moving the focus closes it.
 
 ## Overlays
 
@@ -171,7 +181,18 @@ tooltips.
 `TooltipProvider` ancestor. Mount one provider per app so that a pointer
 moving between nearby triggers skips the show delay, like native hovers.
 The delay defaults to 500ms, matching VS Code's `workbench.hover.delay`,
-and tooltips stop growing at half the window height.
+and tooltips stop growing at half the window height. Components that own
+their hovers fall back to a private provider when the app has none, so
+`Tree` rows and `IconButton` work unwrapped. A private provider keeps its own
+skip-delay, though, so an app with several of them makes every hover wait out
+the full delay; mount one provider and they share it. `IconButton` hints with
+its label like a native action bar item; pass `tooltip` to say something else,
+or `null` for a button that stays quiet.
+
+`HoverDelegateScope` hands every `Tooltip` inside it to one shared bubble
+instead of a bubble each, the way a VS Code list serves its rows and their
+action bars from a single hover widget. `Tree` uses it, which is also what
+lets one place decide when a hover is instant rather than delayed.
 
 Overlay content is portalled to `body`, inherits webview typography from
 there, and shares the `.ui-overlay` base for stacking, border, shadow,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
 	"dependencies": {
 		"@radix-ui/react-context-menu": "^2.3.7",
 		"@radix-ui/react-dropdown-menu": "^2.1.24",
+		"@radix-ui/react-slot": "^1.3.3",
 		"@radix-ui/react-tooltip": "^1.2.16",
 		"@vscode/codicons": "catalog:"
 	},

--- a/packages/ui/src/components/IconButton/IconButton.tsx
+++ b/packages/ui/src/components/IconButton/IconButton.tsx
@@ -1,9 +1,10 @@
-import { type ComponentProps } from "react";
+import { type ComponentProps, type ReactNode } from "react";
 
 import { cx } from "#cx";
 
 import "../control.css";
 import { Icon } from "../Icon/Icon";
+import { Tooltip, TooltipScope } from "../Tooltip/Tooltip";
 
 import "./IconButton.css";
 
@@ -15,18 +16,20 @@ export interface IconButtonProps extends Omit<
 > {
 	icon: CodiconName;
 	label: string;
+	/** Hover content; defaults to the label, `null` opts out. */
+	tooltip?: ReactNode;
 }
 
-/* No default title: native toolbar buttons hint with the styled hover
-   widget, not the browser box. Wrap in Tooltip for that. */
+/* Hints through the hover widget, never the browser title box. */
 export function IconButton({
 	icon,
 	label,
+	tooltip = label,
 	className,
 	type = "button",
 	...props
 }: IconButtonProps): React.JSX.Element {
-	return (
+	const button = (
 		<button
 			{...props}
 			type={type}
@@ -35,5 +38,11 @@ export function IconButton({
 		>
 			<Icon name={icon} />
 		</button>
+	);
+	if (!tooltip) return button;
+	return (
+		<TooltipScope>
+			<Tooltip content={tooltip}>{button}</Tooltip>
+		</TooltipScope>
 	);
 }

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,13 @@
+import { Slot } from "@radix-ui/react-slot";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import {
+	createContext,
+	use,
+	type ComponentProps,
+	type ComponentPropsWithRef,
+	type PointerEvent,
+	type ReactNode,
+} from "react";
 
 import { cx } from "#cx";
 
@@ -6,21 +15,75 @@ import "../overlay.css";
 
 import "./Tooltip.css";
 
-import type { ComponentProps, ComponentPropsWithRef, ReactNode } from "react";
-
 export type TooltipProviderProps = ComponentProps<
 	typeof TooltipPrimitive.Provider
 >;
 
+/** VS Code's `workbench.hover.delay`. */
+const DEFAULT_DELAY_MS = 500;
+
 /**
  * App-level tooltip context; `Tooltip` throws without one. Sharing a single
  * provider lets a pointer moving between nearby triggers skip the show delay,
- * like native hovers. The default delay is VS Code's `workbench.hover.delay`.
+ * like native hovers.
  */
-export function TooltipProvider(
-	props: TooltipProviderProps,
-): React.JSX.Element {
-	return <TooltipPrimitive.Provider delayDuration={500} {...props} />;
+export function TooltipProvider({
+	delayDuration = DEFAULT_DELAY_MS,
+	...props
+}: TooltipProviderProps): React.JSX.Element {
+	return (
+		<TooltipContext value={delayDuration}>
+			<TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />
+		</TooltipContext>
+	);
+}
+
+const TooltipContext = createContext<number | null>(null);
+
+/** Owns tooltips without forcing a provider on consumers; defers to any app-level one. */
+export function TooltipScope({ children }: { children: ReactNode }): ReactNode {
+	return use(TooltipContext) === null ? (
+		<TooltipProvider>{children}</TooltipProvider>
+	) : (
+		children
+	);
+}
+
+/** The surrounding provider's show delay, for surfaces that time their own. */
+export function useTooltipDelay(): number {
+	return use(TooltipContext) ?? DEFAULT_DELAY_MS;
+}
+
+export interface HoverTarget {
+	readonly content: ReactNode;
+	readonly element: HTMLElement;
+}
+
+/** `immediate` skips the show delay. */
+export type HoverDelegate = (
+	target: HoverTarget | undefined,
+	immediate?: boolean,
+) => void;
+
+const HoverDelegateContext = createContext<HoverDelegate | undefined>(
+	undefined,
+);
+
+/**
+ * Hands every `Tooltip` inside to one shared bubble, the way a VS Code list
+ * serves its rows and their action bars from a single hover widget. Pass
+ * `undefined` to hand them back.
+ */
+export function HoverDelegateScope({
+	delegate,
+	children,
+}: {
+	delegate: HoverDelegate | undefined;
+	children: ReactNode;
+}): React.JSX.Element {
+	return (
+		<HoverDelegateContext value={delegate}>{children}</HoverDelegateContext>
+	);
 }
 
 export interface TooltipProps extends Omit<
@@ -30,6 +93,8 @@ export interface TooltipProps extends Omit<
 	content: ReactNode;
 	/** The trigger element; must accept a forwarded ref (asChild). */
 	children: ReactNode;
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
 }
 
 /** Hover bubble matching the native hover widget; requires a `TooltipProvider` ancestor. */
@@ -37,15 +102,32 @@ export function Tooltip({
 	content,
 	children,
 	className,
+	open,
+	onOpenChange,
 	...props
 }: TooltipProps): React.JSX.Element {
+	const delegate = use(HoverDelegateContext);
+	if (delegate) {
+		return (
+			<Slot
+				onPointerEnter={(event: PointerEvent<HTMLElement>) =>
+					delegate({ content, element: event.currentTarget })
+				}
+				onPointerLeave={() => delegate(undefined)}
+			>
+				{children}
+			</Slot>
+		);
+	}
 	return (
-		<TooltipPrimitive.Root>
+		<TooltipPrimitive.Root open={open} onOpenChange={onOpenChange}>
 			<TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
 			<TooltipPrimitive.Portal>
 				<TooltipPrimitive.Content
-					// Native hovers sit flush with the target, left-aligned
-					align="start"
+					// Native sits a hover 2px into the bottom edge of its target.
+					side="bottom"
+					sideOffset={-2}
+					align="center"
 					collisionPadding={8}
 					{...props}
 					className={cx("ui-overlay ui-tooltip", className)}

--- a/packages/ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip/Tooltip.tsx
@@ -59,7 +59,7 @@ export interface HoverTarget {
 	readonly element: HTMLElement;
 }
 
-/** `immediate` skips the show delay. */
+/** `immediate` skips the show delay or dismisses without a leave grace period. */
 export type HoverDelegate = (
 	target: HoverTarget | undefined,
 	immediate?: boolean,

--- a/packages/ui/src/components/Tree/Tree.css
+++ b/packages/ui/src/components/Tree/Tree.css
@@ -7,6 +7,7 @@
 .ui-tree {
 	--ui-tree-indent-size: 8px;
 	--ui-tree-row-height: 22px;
+	position: relative;
 	width: 100%;
 	min-width: 0;
 	outline: 0;
@@ -32,7 +33,8 @@
 .ui-tree-sticky {
 	position: sticky;
 	top: 0;
-	z-index: 100;
+	/* Native pins the sticky container below the hover widget's stacking */
+	z-index: 13;
 	height: 0;
 	outline: 0;
 }
@@ -210,4 +212,11 @@
 	.ui-tree-item__indent-slot--active {
 		border-color: CanvasText;
 	}
+}
+
+/* The shared hover anchors here instead of to each row's label. */
+.ui-tree-hover-anchor {
+	position: absolute;
+	pointer-events: none;
+	opacity: 0;
 }

--- a/packages/ui/src/components/Tree/Tree.stories.tsx
+++ b/packages/ui/src/components/Tree/Tree.stories.tsx
@@ -1,4 +1,11 @@
-import { expect, fireEvent, userEvent, waitFor, within } from "storybook/test";
+import {
+	expect,
+	fireEvent,
+	screen,
+	userEvent,
+	waitFor,
+	within,
+} from "storybook/test";
 
 import { PIXEL_ALL_THEMES } from "#storybook";
 
@@ -256,5 +263,101 @@ export const Nested: Story = {
 		await expect(deepLeaf).toHaveAttribute("aria-level", "5");
 		await userEvent.click(deepLeaf);
 		await expect(deepLeaf).toHaveAttribute("aria-selected", "true");
+	},
+};
+
+const LONG_NAME = "a-really-long-component-name-that-truncates.tsx";
+const HOVER_FILES: readonly TreeNode[] = [
+	branch(
+		"hover-src",
+		[
+			node("hover-index", { label: "index.ts", icon: "symbol-method" }),
+			node("hover-long", { label: LONG_NAME, icon: "symbol-class" }),
+			node("hover-actions", {
+				label: "Workspace",
+				icon: "vm",
+				action: (
+					<>
+						<IconButton icon="play" label="Start workspace" />
+						<IconButton icon="gear" label="Workspace settings" />
+					</>
+				),
+			}),
+		],
+		{ label: "src" },
+	),
+];
+
+/** Leaves room above the rows, where a hover sits. */
+const hoverTree = (ariaLabel: string, selectedItemId?: string) => (
+	<div style={{ paddingTop: "40px" }}>
+		{tree({
+			"aria-label": ariaLabel,
+			nodes: HOVER_FILES,
+			selectedItemId,
+		})}
+	</div>
+);
+
+/** The bubble takes its x from the cursor, so give the pointer a real one. */
+const hoverAt = async (element: Element): Promise<void> => {
+	// An action bar is revealed by CSS, which lands a frame after the render.
+	await waitFor(() =>
+		expect(element.getBoundingClientRect().width).toBeGreaterThan(0),
+	);
+	const bounds = element.getBoundingClientRect();
+	await userEvent.hover(element);
+	await fireEvent.pointerMove(element, {
+		clientX: bounds.left + 24,
+		clientY: bounds.top + bounds.height / 2,
+	});
+};
+
+/** The bubble is portalled, so it lands outside the story canvas. */
+const expectBubble = async (content: string): Promise<void> => {
+	const bubble = await screen.findByRole("tooltip");
+	await waitFor(() => expect(bubble).toHaveTextContent(content));
+};
+
+export const Hover: Story = {
+	render: () => hoverTree("Hovered label"),
+	play: async ({ canvasElement }) => {
+		const hovered = within(canvasElement).getByRole("treeitem", {
+			name: LONG_NAME,
+		});
+		await hoverAt(hovered.getElementsByClassName("ui-tree-item__content")[0]);
+		await expectBubble(LONG_NAME);
+	},
+};
+
+export const HoverOnAction: Story = {
+	// Selected so CSS reveals the action bar, which a synthetic hover cannot.
+	render: () => hoverTree("Hovered action", "hover-actions"),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await hoverAt(
+			canvas.getByRole("button", { name: "Start workspace", hidden: true }),
+		);
+		await expectBubble("Start workspace");
+		// Crossing the same action bar swaps the bubble without a second delay.
+		await hoverAt(
+			canvas.getByRole("button", { name: "Workspace settings", hidden: true }),
+		);
+		await expectBubble("Workspace settings");
+	},
+};
+
+export const HoverByKeyboard: Story = {
+	render: () => hoverTree("Keyboard hover"),
+	play: async ({ canvasElement }) => {
+		const treeElement = within(canvasElement).getByRole("tree");
+		treeElement.focus();
+		await waitFor(() => expect(treeElement).toHaveClass("ui-tree--focused"));
+		await fireEvent.keyDown(treeElement, { key: "ArrowDown" });
+		await fireEvent.keyDown(treeElement, { key: "ArrowDown" });
+		// VS Code binds list.showHover to this chord.
+		await fireEvent.keyDown(treeElement, { key: "k", ctrlKey: true });
+		await fireEvent.keyDown(treeElement, { key: "i", ctrlKey: true });
+		await expectBubble(LONG_NAME);
 	},
 };

--- a/packages/ui/src/components/Tree/Tree.stories.tsx
+++ b/packages/ui/src/components/Tree/Tree.stories.tsx
@@ -78,20 +78,24 @@ export default meta;
 type Story = StoryObj<typeof TreeStates>;
 
 const exerciseTree: NonNullable<Story["play"]> = async ({ canvasElement }) => {
+	// One pointer for the whole play, so the unhover at the end really lands.
+	const user = userEvent.setup();
 	const canvas = within(canvasElement);
 	const selected = canvas.getByRole("treeitem", { name: "components" });
 	const treeItem = canvas.getByRole("treeitem", { name: "Tree.tsx" });
 	await expect(selected).toHaveAttribute("aria-selected", "true");
-	await userEvent.click(
+	await user.click(
 		canvas.getByRole("button", { name: "Close Tree.tsx", hidden: true }),
 	);
 	await expect(selected).toHaveAttribute("aria-selected", "true");
 	await expect(treeItem).toHaveAttribute("aria-selected", "false");
-	await userEvent.click(treeItem);
+	await user.click(treeItem);
 	await expect(treeItem).toHaveAttribute("aria-selected", "true");
 	const readme = canvas.getByRole("treeitem", { name: "README.md" });
-	await userEvent.click(readme);
+	await user.click(readme);
 	await expect(readme).toHaveAttribute("aria-selected", "true");
+	// Clicking leaves the pointer on the row; these stories snapshot hoverless.
+	await user.unhover(readme);
 };
 
 export const States: Story = { play: exerciseTree };

--- a/packages/ui/src/components/Tree/Tree.tsx
+++ b/packages/ui/src/components/Tree/Tree.tsx
@@ -3,8 +3,11 @@ import { type ComponentPropsWithRef, useId, useRef } from "react";
 import { cx } from "#cx";
 import { setForwardedRef } from "#ref";
 
+import { TooltipScope } from "../Tooltip/Tooltip";
+
 import { StickyScroll } from "./sticky/StickyScroll";
 import "./Tree.css";
+import { TreeHover, type TreeHoverControl } from "./TreeHover";
 import { TreeRow } from "./TreeRow";
 import { useTreeAdapter, type SelectionProps } from "./useTreeAdapter";
 
@@ -62,6 +65,7 @@ export function Tree({
 	...containerProps
 }: TreeProps): React.JSX.Element {
 	const treeRef = useRef<HTMLDivElement>(null);
+	const hoverRef: TreeHoverControl = useRef(undefined);
 	const treeDomId = useId();
 	const selection: SelectionProps = multiSelect
 		? { multiSelect: true, selectedItemIds, onSelectedItemsChange }
@@ -75,65 +79,72 @@ export function Tree({
 		multiSelectModifier,
 		onKeyDown,
 		treeRef,
+		hoverControl: hoverRef,
 	});
 
 	return (
-		<div
-			{...containerProps}
-			ref={(element) => {
-				treeRef.current = element;
-				setForwardedRef(ref, element);
-			}}
-			role="tree"
-			tabIndex={0}
-			aria-activedescendant={
-				adapter.focusedId ? `${treeDomId}-${adapter.focusedId}` : undefined
-			}
-			aria-multiselectable={multiSelect ? true : undefined}
-			className={cx(
-				"ui-tree",
-				variant === "explorer" && "ui-tree--explorer",
-				adapter.hasDomFocus && "ui-tree--focused",
-				className,
-			)}
-			onFocus={(event) => {
-				onFocus?.(event);
-				if (
-					!event.defaultPrevented &&
-					ownsTarget(event.currentTarget, event.target)
-				) {
-					adapter.onFocusIn(event.target);
+		<TooltipScope>
+			<div
+				{...containerProps}
+				ref={(element) => {
+					treeRef.current = element;
+					setForwardedRef(ref, element);
+				}}
+				role="tree"
+				tabIndex={0}
+				aria-activedescendant={
+					adapter.focusedId ? `${treeDomId}-${adapter.focusedId}` : undefined
 				}
-			}}
-			onBlur={(event) => {
-				onBlur?.(event);
-				if (
-					!event.defaultPrevented &&
-					!ownsTarget(event.currentTarget, event.relatedTarget)
-				) {
-					adapter.onBlurOut();
-				}
-			}}
-			onClick={adapter.onClick}
-			onKeyDown={adapter.onKeyDown}
-		>
-			{stickyScroll ? (
-				<StickyScroll
-					maxCount={stickyScroll === true ? DEFAULT_STICKY_COUNT : stickyScroll}
-					adapter={adapter}
-					treeRef={treeRef}
-				/>
-			) : null}
-			{adapter.model.visibleRows.map((row) => (
-				<TreeRow
-					key={row.node.id}
-					id={`${treeDomId}-${row.node.id}`}
-					row={row}
-					focused={row.node.id === adapter.focusedId}
-					selected={adapter.selectedIds.has(row.node.id)}
-					guideFlags={adapter.guideFlags(row)}
-				/>
-			))}
-		</div>
+				aria-multiselectable={multiSelect ? true : undefined}
+				className={cx(
+					"ui-tree",
+					variant === "explorer" && "ui-tree--explorer",
+					adapter.hasDomFocus && "ui-tree--focused",
+					className,
+				)}
+				onFocus={(event) => {
+					onFocus?.(event);
+					if (
+						!event.defaultPrevented &&
+						ownsTarget(event.currentTarget, event.target)
+					) {
+						adapter.onFocusIn(event.target);
+					}
+				}}
+				onBlur={(event) => {
+					onBlur?.(event);
+					if (
+						!event.defaultPrevented &&
+						!ownsTarget(event.currentTarget, event.relatedTarget)
+					) {
+						adapter.onBlurOut();
+					}
+				}}
+				onClick={adapter.onClick}
+				onKeyDown={adapter.onKeyDown}
+			>
+				<TreeHover treeRef={treeRef} controlRef={hoverRef}>
+					{stickyScroll ? (
+						<StickyScroll
+							maxCount={
+								stickyScroll === true ? DEFAULT_STICKY_COUNT : stickyScroll
+							}
+							adapter={adapter}
+							treeRef={treeRef}
+						/>
+					) : null}
+					{adapter.model.visibleRows.map((row) => (
+						<TreeRow
+							key={row.node.id}
+							id={`${treeDomId}-${row.node.id}`}
+							row={row}
+							focused={row.node.id === adapter.focusedId}
+							selected={adapter.selectedIds.has(row.node.id)}
+							guideFlags={adapter.guideFlags(row)}
+						/>
+					))}
+				</TreeHover>
+			</div>
+		</TooltipScope>
 	);
 }

--- a/packages/ui/src/components/Tree/TreeHover.tsx
+++ b/packages/ui/src/components/Tree/TreeHover.tsx
@@ -1,0 +1,156 @@
+import {
+	useEffect,
+	useImperativeHandle,
+	useRef,
+	useState,
+	type ReactNode,
+	type RefObject,
+} from "react";
+
+import {
+	HoverDelegateScope,
+	Tooltip,
+	useTooltipDelay,
+	type HoverDelegate,
+	type HoverTarget,
+} from "../Tooltip/Tooltip";
+
+const GRACE_MS = 100;
+
+/** Native reopens with no delay this soon after hiding, and only for a dense
+    cluster of targets such as an action bar. */
+const INSTANT_MS = 200;
+const DENSE_CLUSTER = ".ui-tree-item__action";
+
+/** setupCustomHover offsets a cursor-placed hover by this much. */
+const CURSOR_OFFSET_PX = 10;
+
+const ROW = ".ui-tree-item";
+
+export type TreeHoverControl = RefObject<HoverDelegate | undefined>;
+
+interface Shown extends HoverTarget {
+	readonly top: number;
+	readonly left: number;
+	readonly width: number;
+	readonly height: number;
+	readonly align: "center" | "start";
+}
+
+/**
+ * One hover for the whole tree, like the native list's shared widget: rows and
+ * anything inside them report the element under the pointer, and an invisible
+ * anchor moves to it.
+ */
+export function TreeHover({
+	children,
+	treeRef,
+	controlRef,
+}: {
+	children: ReactNode;
+	treeRef: RefObject<HTMLDivElement | null>;
+	controlRef: TreeHoverControl;
+}): React.JSX.Element {
+	const delay = useTooltipDelay();
+	const [shown, setShown] = useState<Shown>();
+	const openRef = useRef(false);
+	const hiddenAtRef = useRef(0);
+	const clusterRef = useRef<Element | null>(null);
+	const pointerXRef = useRef<number | undefined>(undefined);
+	const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+	const hide = (): void => {
+		clearTimeout(timerRef.current);
+		if (openRef.current) hiddenAtRef.current = Date.now();
+		openRef.current = false;
+		setShown(undefined);
+	};
+
+	// Native centers on an action bar button and follows the cursor along a row,
+	// measuring the row so taller content cannot push the bubble off it.
+	const show = (target: HoverTarget, atPointer = true): void => {
+		const tree = treeRef.current;
+		if (!tree) return;
+		const cluster = target.element.closest(DENSE_CLUSTER);
+		const box = cluster
+			? target.element
+			: (target.element.closest(ROW) ?? target.element);
+		const bounds = tree.getBoundingClientRect();
+		const rect = box.getBoundingClientRect();
+		const cursorX = cluster || !atPointer ? undefined : pointerXRef.current;
+		openRef.current = true;
+		clusterRef.current = cluster;
+		setShown({
+			...target,
+			top: rect.top - bounds.top,
+			left:
+				(cursorX === undefined ? rect.left : cursorX + CURSOR_OFFSET_PX) -
+				bounds.left,
+			width: cursorX === undefined ? rect.width : 0,
+			height: rect.height,
+			align: cursorX === undefined ? "center" : "start",
+		});
+	};
+
+	const setTarget: HoverDelegate = (target, immediate = false) => {
+		clearTimeout(timerRef.current);
+		if (!target?.content) {
+			timerRef.current = setTimeout(hide, GRACE_MS);
+			return;
+		}
+		const cluster = target.element.closest(DENSE_CLUSTER);
+		const recent =
+			openRef.current || Date.now() - hiddenAtRef.current < INSTANT_MS;
+		if (immediate || (recent && cluster && cluster === clusterRef.current)) {
+			show(target, !immediate);
+			return;
+		}
+		hide();
+		timerRef.current = setTimeout(() => show(target), delay);
+	};
+
+	useImperativeHandle(controlRef, () => setTarget, [setTarget]);
+	useEffect(() => () => clearTimeout(timerRef.current), []);
+
+	useEffect(() => {
+		const tree = treeRef.current;
+		if (!tree) return;
+		const track = (event: PointerEvent): void => {
+			pointerXRef.current = event.clientX;
+		};
+		tree.addEventListener("pointermove", track, { passive: true });
+		return () => tree.removeEventListener("pointermove", track);
+	}, [treeRef]);
+
+	return (
+		<HoverDelegateScope delegate={setTarget}>
+			{children}
+			{/* Outside the scope, or the bubble would delegate to itself. */}
+			<HoverDelegateScope delegate={undefined}>
+				{shown ? (
+					<Tooltip
+						content={shown.content}
+						align={shown.align}
+						open
+						onOpenChange={(open) => {
+							if (!open) hide();
+						}}
+						onPointerEnter={() => clearTimeout(timerRef.current)}
+						onPointerLeave={() => setTarget(undefined)}
+					>
+						<span
+							aria-hidden="true"
+							className="ui-tree-hover-anchor"
+							style={{
+								top: shown.top,
+								left: shown.left,
+								width: shown.width,
+								height: shown.height,
+							}}
+						/>
+					</Tooltip>
+				) : null}
+			</HoverDelegateScope>
+		</HoverDelegateScope>
+	);
+}

--- a/packages/ui/src/components/Tree/TreeHover.tsx
+++ b/packages/ui/src/components/Tree/TreeHover.tsx
@@ -70,13 +70,21 @@ export function TreeHover({
 	// measuring the row so taller content cannot push the bubble off it.
 	const show = (target: HoverTarget, atPointer = true): void => {
 		const tree = treeRef.current;
-		if (!tree) return;
+		const targetRect = target.element.getBoundingClientRect();
+		if (
+			!tree?.contains(target.element) ||
+			targetRect.width <= 0 ||
+			targetRect.height <= 0
+		) {
+			hide();
+			return;
+		}
 		const cluster = target.element.closest(DENSE_CLUSTER);
 		const box = cluster
 			? target.element
 			: (target.element.closest(ROW) ?? target.element);
 		const bounds = tree.getBoundingClientRect();
-		const rect = box.getBoundingClientRect();
+		const rect = cluster ? targetRect : box.getBoundingClientRect();
 		const cursorX = cluster || !atPointer ? undefined : pointerXRef.current;
 		openRef.current = true;
 		clusterRef.current = cluster;
@@ -95,6 +103,10 @@ export function TreeHover({
 	const setTarget: HoverDelegate = (target, immediate = false) => {
 		clearTimeout(timerRef.current);
 		if (!target?.content) {
+			if (immediate) {
+				hide();
+				return;
+			}
 			timerRef.current = setTimeout(hide, GRACE_MS);
 			return;
 		}
@@ -121,6 +133,14 @@ export function TreeHover({
 		tree.addEventListener("pointermove", track, { passive: true });
 		return () => tree.removeEventListener("pointermove", track);
 	}, [treeRef]);
+
+	useEffect(() => {
+		const tree = treeRef.current;
+		if (!tree) return;
+		// Capture also dismisses hovers when an action stops propagation.
+		tree.addEventListener("pointerdown", hide, true);
+		return () => tree.removeEventListener("pointerdown", hide, true);
+	}, [treeRef, hide]);
 
 	return (
 		<HoverDelegateScope delegate={setTarget}>

--- a/packages/ui/src/components/Tree/TreeRow.tsx
+++ b/packages/ui/src/components/Tree/TreeRow.tsx
@@ -3,8 +3,9 @@ import { type CSSProperties, memo } from "react";
 import { cx } from "#cx";
 
 import { Icon } from "../Icon/Icon";
+import { Tooltip } from "../Tooltip/Tooltip";
 
-import type { TreeRowModel } from "./treeModel";
+import { rowTooltip, type TreeRowModel } from "./treeModel";
 
 interface TreeRowProps {
 	readonly row: TreeRowModel;
@@ -29,6 +30,14 @@ export const TreeRow = memo(function TreeRow({
 }: TreeRowProps): React.JSX.Element {
 	const { node, expanded } = row;
 	const level = row.pathIds.length + 1;
+	const tooltip = rowTooltip(row);
+	// Native hangs the hover off the label, not the whole row.
+	const label = (
+		<span className="ui-tree-item__content">
+			{node.icon ? <Icon name={node.icon} /> : null}
+			{typeof node.label === "string" ? <span>{node.label}</span> : node.label}
+		</span>
+	);
 	return (
 		<div
 			id={id}
@@ -66,14 +75,7 @@ export const TreeRow = memo(function TreeRow({
 						<Icon name={expanded ? "chevron-down" : "chevron-right"} />
 					)}
 				</span>
-				<span className="ui-tree-item__content">
-					{node.icon ? <Icon name={node.icon} /> : null}
-					{typeof node.label === "string" ? (
-						<span>{node.label}</span>
-					) : (
-						node.label
-					)}
-				</span>
+				{tooltip ? <Tooltip content={tooltip}>{label}</Tooltip> : label}
 				{/* Native keeps a row's actions live on plain hover; CSS reveals them. */}
 				{node.action ? (
 					<span className="ui-tree-item__action">{node.action}</span>

--- a/packages/ui/src/components/Tree/treeModel.ts
+++ b/packages/ui/src/components/Tree/treeModel.ts
@@ -14,6 +14,8 @@ type TreeNodeLabel =
 export type TreeNode = TreeNodeLabel & {
 	readonly id: string;
 	readonly icon?: CodiconName;
+	/** Hover content; defaults to the text value, `null` opts out. */
+	readonly tooltip?: ReactNode;
 	readonly action?: ReactNode;
 	readonly className?: string;
 	readonly children?: readonly TreeNode[];
@@ -38,6 +40,12 @@ export interface TreeModel {
 	readonly rows: readonly TreeRowModel[];
 	readonly rowsById: ReadonlyMap<string, TreeRowModel>;
 	readonly visibleIds: ReadonlySet<string>;
+}
+
+/** The row's hover content; empty when the node opts out. */
+export function rowTooltip(row: TreeRowModel): ReactNode {
+	const { tooltip } = row.node;
+	return tooltip === undefined ? row.textValue : tooltip;
 }
 
 export function parentId(row: TreeRowModel): string | undefined {

--- a/packages/ui/src/components/Tree/useTreeAdapter.ts
+++ b/packages/ui/src/components/Tree/useTreeAdapter.ts
@@ -1,4 +1,10 @@
-import { type KeyboardEvent, type MouseEvent, useMemo, useState } from "react";
+import {
+	type KeyboardEvent,
+	type MouseEvent,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 
 import {
 	closestRow,
@@ -9,6 +15,7 @@ import {
 import {
 	createTreeModel,
 	ROW_HEIGHT_PX,
+	rowTooltip,
 	type TreeNode,
 	type TreeRowModel,
 } from "./treeModel";
@@ -30,8 +37,16 @@ import {
 	type TreeInteractionState,
 } from "./treeTransition";
 
+import type { TreeHoverControl } from "./TreeHover";
+
 const NO_IDS: readonly string[] = [];
 const NO_GUIDES = "";
+const MODIFIER_KEYS: ReadonlySet<string> = new Set([
+	"Alt",
+	"Control",
+	"Meta",
+	"Shift",
+]);
 
 /** Single selection, or multi-selection, never a mix of the two APIs. */
 export type SelectionProps =
@@ -58,6 +73,7 @@ interface AdapterOptions {
 	readonly multiSelectModifier: TreeMultiSelectModifier;
 	readonly onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
 	readonly treeRef: React.RefObject<HTMLDivElement | null>;
+	readonly hoverControl?: TreeHoverControl;
 }
 
 function rowElement(tree: HTMLElement | null, id: string): HTMLElement | null {
@@ -90,6 +106,7 @@ export function useTreeAdapter(options: AdapterOptions & SelectionProps) {
 	);
 	const { visibleRows, rowsById } = model;
 	const selected = controlledIds(options);
+	const chordRef = useRef(false);
 	const [state, setState] = useState<TreeInteractionState>(() =>
 		initialTreeInteractionState(selected),
 	);
@@ -218,6 +235,30 @@ export function useTreeAdapter(options: AdapterOptions & SelectionProps) {
 		}
 		onPointer(row, event, hitTwistie(row, event.target), "row");
 	};
+	/** VS Code binds `list.showHover` to the Ctrl+K Ctrl+I chord. */
+	const showHoverChord = (
+		event: KeyboardEvent<HTMLDivElement>,
+	): "pending" | "show" | undefined => {
+		const held = (event.ctrlKey || event.metaKey) && !event.altKey;
+		const key = held ? event.key.toLowerCase() : "";
+		const armed = chordRef.current;
+		chordRef.current = !armed && key === "k";
+		if (chordRef.current) {
+			return "pending";
+		}
+		return armed && key === "i" ? "show" : undefined;
+	};
+	const showHover = (row: TreeRowModel | undefined): void => {
+		const element = row
+			? rowElement(treeRef.current, row.node.id)?.querySelector<HTMLElement>(
+					".ui-tree-item__content",
+				)
+			: undefined;
+		options.hoverControl?.current?.(
+			row && element ? { content: rowTooltip(row), element } : undefined,
+			true,
+		);
+	};
 	const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
 		options.onKeyDown?.(event);
 		if (event.defaultPrevented) {
@@ -230,6 +271,18 @@ export function useTreeAdapter(options: AdapterOptions & SelectionProps) {
 			visibleRows[0];
 		if (!row) {
 			return;
+		}
+		// A hover the keyboard opened stays only until the next real key.
+		if (!MODIFIER_KEYS.has(event.key)) {
+			const chord = showHoverChord(event);
+			if (chord) {
+				if (chord === "show") {
+					showHover(row);
+				}
+				event.preventDefault();
+				return;
+			}
+			showHover(undefined);
 		}
 		const interactive = nestedInteractiveTarget(
 			event.target,
@@ -273,7 +326,10 @@ export function useTreeAdapter(options: AdapterOptions & SelectionProps) {
 		isSelectionGesture: (event: MouseEvent) =>
 			isSelectionGesture(event, behavior),
 		onFocusIn,
-		onBlurOut: () => setState((current) => treeFocusChanged(current, false)),
+		onBlurOut: () => {
+			showHover(undefined);
+			setState((current) => treeFocusChanged(current, false));
+		},
 		onClick,
 		onPointer,
 		onKeyDown,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -67,6 +67,9 @@ export {
 	type KeybindingPlatform,
 } from "./keybinding";
 export {
+	type HoverDelegate,
+	HoverDelegateScope,
+	type HoverTarget,
 	Tooltip,
 	type TooltipProps,
 	TooltipProvider,

--- a/packages/ui/src/vscode-parity.stories.tsx
+++ b/packages/ui/src/vscode-parity.stories.tsx
@@ -189,10 +189,19 @@ const MenuParity = (): React.JSX.Element => (
 		}}
 	>
 		<DropdownMenu defaultOpen>
-			<DropdownMenuTrigger asChild>
-				<span />
-			</DropdownMenuTrigger>
-			<DropdownMenuContent>
+			<DropdownMenuTrigger
+				asChild
+				aria-label="Menu"
+				style={{
+					display: "block",
+					width: "100%",
+					height: 0,
+					padding: 0,
+					border: 0,
+					opacity: 0,
+				}}
+			/>
+			<DropdownMenuContent sideOffset={0}>
 				<DropdownMenuItem>Start workspace</DropdownMenuItem>
 				<DropdownMenuItem>Open logs</DropdownMenuItem>
 				<DropdownMenuSeparator />

--- a/packages/ui/src/vscode-parity.stories.tsx
+++ b/packages/ui/src/vscode-parity.stories.tsx
@@ -189,18 +189,21 @@ const MenuParity = (): React.JSX.Element => (
 		}}
 	>
 		<DropdownMenu defaultOpen>
-			<DropdownMenuTrigger
-				asChild
-				aria-label="Menu"
-				style={{
-					display: "block",
-					width: "100%",
-					height: 0,
-					padding: 0,
-					border: 0,
-					opacity: 0,
-				}}
-			/>
+			<DropdownMenuTrigger asChild aria-label="Menu">
+				{/* A zero-height button still anchors the popper, so the menu opens
+					    at the top of its grid column, level with the reference. */}
+				<button
+					type="button"
+					style={{
+						display: "block",
+						width: "100%",
+						height: 0,
+						padding: 0,
+						border: 0,
+						opacity: 0,
+					}}
+				/>
+			</DropdownMenuTrigger>
 			<DropdownMenuContent sideOffset={0}>
 				<DropdownMenuItem>Start workspace</DropdownMenuItem>
 				<DropdownMenuItem>Open logs</DropdownMenuItem>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.24
         version: 2.1.24(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
+      '@radix-ui/react-slot':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.16
         version: 1.2.16(@types/react-dom@19.2.5)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)

--- a/test/webview/ui/components.test.tsx
+++ b/test/webview/ui/components.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { createRef, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,6 +12,7 @@ import {
 	SearchInput,
 	Spinner,
 	StatusPill,
+	TooltipProvider,
 } from "@repo/ui";
 
 import { qs } from "../helpers";
@@ -46,6 +48,24 @@ describe("IconButton", () => {
 		render(<IconButton icon="refresh" label="Refresh" onClick={onClick} />);
 		fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
 		expect(onClick).toHaveBeenCalledOnce();
+	});
+	it("hovers with the label unless opted out", async () => {
+		const hoverText = async (
+			tooltip?: string | null,
+		): Promise<string | undefined> => {
+			const view = render(
+				<TooltipProvider delayDuration={0}>
+					<IconButton icon="refresh" label="Refresh" tooltip={tooltip} />
+				</TooltipProvider>,
+			);
+			await userEvent.hover(screen.getByRole("button"));
+			const text = screen.queryByRole("tooltip")?.textContent ?? undefined;
+			view.unmount();
+			return text;
+		};
+		expect(await hoverText()).toBe("Refresh");
+		expect(await hoverText("Reload the list")).toBe("Reload the list");
+		expect(await hoverText(null)).toBeUndefined();
 	});
 });
 

--- a/test/webview/ui/tree.hover.test.tsx
+++ b/test/webview/ui/tree.hover.test.tsx
@@ -1,0 +1,111 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Tree, TooltipProvider } from "@repo/ui";
+
+import { press, row, stubElementBoxes, tree } from "./treeTestHelpers";
+
+const DELAY_MS = 500;
+const label = (): Element =>
+	row("Alpha").getElementsByClassName("ui-tree-item__content")[0];
+
+const elapse = (): void => {
+	act(() => {
+		vi.advanceTimersByTime(DELAY_MS);
+	});
+};
+
+function renderHoverTree() {
+	return render(
+		<Tree
+			aria-label="Hover"
+			nodes={[
+				{
+					id: "a",
+					label: "Alpha",
+					action: (
+						<button
+							type="button"
+							onPointerDown={(event) => event.stopPropagation()}
+						>
+							Delete
+						</button>
+					),
+				},
+			]}
+		/>,
+		{
+			wrapper: ({ children }) => (
+				<TooltipProvider delayDuration={DELAY_MS}>{children}</TooltipProvider>
+			),
+		},
+	);
+}
+
+describe("Tree hover", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stubElementBoxes();
+	});
+	afterEach(() => vi.useRealTimers());
+
+	describe.each(["pending", "shown"] as const)("%s hover", (state) => {
+		it.each([
+			["a tree press", () => fireEvent.pointerDown(tree())],
+			[
+				"an action press that stops propagation",
+				() => fireEvent.pointerDown(screen.getByRole("button")),
+			],
+			["a key press", () => press("ArrowDown")],
+			[
+				"focus leaving the tree",
+				() => fireEvent.focusOut(tree(), { relatedTarget: document.body }),
+			],
+		])("dismisses on %s without reopening", (_name, dismiss) => {
+			renderHoverTree();
+			act(() => tree().focus());
+			fireEvent.pointerEnter(label());
+			if (state === "shown") {
+				elapse();
+				expect(screen.getByRole("tooltip")).toHaveTextContent("Alpha");
+			}
+			dismiss();
+			expect(screen.queryByRole("tooltip")).toBeNull();
+			elapse();
+			expect(screen.queryByRole("tooltip")).toBeNull();
+		});
+	});
+
+	it.each([
+		["pointer leave", () => fireEvent.pointerLeave(label())],
+		["pointer press", () => fireEvent.pointerDown(tree())],
+	])("permits a fresh hover after %s", (_name, dismiss) => {
+		renderHoverTree();
+		fireEvent.pointerEnter(label());
+		dismiss();
+		elapse();
+		expect(screen.queryByRole("tooltip")).toBeNull();
+		fireEvent.pointerEnter(label());
+		expect(screen.queryByRole("tooltip")).toBeNull();
+		elapse();
+		expect(screen.getByRole("tooltip")).toHaveTextContent("Alpha");
+	});
+
+	it.each(["hidden", "removed"])(
+		"does not open for a target %s during the delay",
+		(state) => {
+			const view = renderHoverTree();
+			const target = label();
+			fireEvent.pointerEnter(target);
+			if (state === "hidden") {
+				vi.spyOn(target, "getBoundingClientRect").mockReturnValue(
+					new DOMRect(),
+				);
+			} else {
+				view.rerender(<Tree aria-label="Hover" nodes={[]} />);
+			}
+			elapse();
+			expect(screen.queryByRole("tooltip")).toBeNull();
+		},
+	);
+});

--- a/test/webview/ui/tree.keyboard.test.tsx
+++ b/test/webview/ui/tree.keyboard.test.tsx
@@ -1,7 +1,13 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Tree, type TreeNode, type TreeProps } from "@repo/ui";
+import { Tree, TooltipProvider, type TreeNode, type TreeProps } from "@repo/ui";
 
 import {
 	BASIC_NODES,
@@ -171,6 +177,28 @@ describe("Tree keyboard navigation", () => {
 			press(key);
 			expect(activeRow()).toBe(active);
 		}
+	});
+
+	it("opens the focused row's hover on the show-hover chord", async () => {
+		render(
+			<TooltipProvider delayDuration={0}>
+				<Tree
+					aria-label="Chord"
+					nodes={[
+						{ id: "alpha", label: "Alpha" },
+						{ id: "beta", label: "Beta" },
+					]}
+				/>
+			</TooltipProvider>,
+		);
+		act(() => tree().focus());
+		press("k", { ctrlKey: true });
+		expect(screen.queryByRole("tooltip")).toBeNull();
+		press("i", { ctrlKey: true });
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Alpha");
+		// Any other key puts it away again.
+		press("ArrowDown");
+		await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
 	});
 
 	describe("type-ahead", () => {

--- a/test/webview/ui/tree.keyboard.test.tsx
+++ b/test/webview/ui/tree.keyboard.test.tsx
@@ -20,6 +20,7 @@ import {
 	row,
 	rowNames,
 	selectedRows,
+	stubElementBoxes,
 	tree,
 } from "./treeTestHelpers";
 
@@ -180,6 +181,7 @@ describe("Tree keyboard navigation", () => {
 	});
 
 	it("opens the focused row's hover on the show-hover chord", async () => {
+		stubElementBoxes();
 		render(
 			<TooltipProvider delayDuration={0}>
 				<Tree

--- a/test/webview/ui/tree.rows.test.tsx
+++ b/test/webview/ui/tree.rows.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { IconButton, Tree, TooltipProvider, type TreeNode } from "@repo/ui";
 
 import {
 	BASIC_NODES,
@@ -15,7 +17,9 @@ import {
 	tree,
 } from "./treeTestHelpers";
 
-import type { TreeNode } from "@repo/ui";
+/** Native hangs a row's hover off its label, so tests point at that. */
+const label = (name: string): Element =>
+	row(name).getElementsByClassName("ui-tree-item__content")[0];
 
 describe("Tree rows", () => {
 	it("renders icons, rich labels, class names, and an action slot", () => {
@@ -42,6 +46,73 @@ describe("Tree rows", () => {
 		expect(
 			screen.getByRole("button", { name: "Selected action" }).parentElement,
 		).toHaveClass("ui-tree-item__action");
+	});
+
+	it("moves one hover between labels, defaulting to the text value", async () => {
+		render(
+			<TooltipProvider delayDuration={0}>
+				<Tree
+					aria-label="Hovers"
+					nodes={[
+						{ id: "a", label: "Plain item" },
+						{ id: "b", label: <em>Rich</em>, textValue: "Rich item" },
+						{ id: "c", label: "Custom", tooltip: "The whole story" },
+						{ id: "d", label: "Quiet", tooltip: null },
+					]}
+				/>
+			</TooltipProvider>,
+		);
+		const user = userEvent.setup();
+		for (const [name, text] of [
+			["Plain item", "Plain item"],
+			["Rich item", "Rich item"],
+			["Custom", "The whole story"],
+		]) {
+			await user.hover(label(name));
+			expect(await screen.findByRole("tooltip")).toHaveTextContent(text);
+			expect(screen.getAllByRole("tooltip")).toHaveLength(1);
+		}
+		await user.unhover(label("Custom"));
+		await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+		await user.hover(label("Quiet"));
+		expect(screen.queryByRole("tooltip")).toBeNull();
+	});
+
+	it("waits for a new target but crosses an action bar at once", async () => {
+		render(
+			<TooltipProvider delayDuration={60}>
+				<Tree
+					aria-label="Handoff"
+					nodes={[
+						{
+							id: "row",
+							label: "Workspace",
+							action: (
+								<>
+									<IconButton icon="play" label="Start workspace" />
+									<IconButton icon="gear" label="Workspace settings" />
+								</>
+							),
+						},
+					]}
+				/>
+			</TooltipProvider>,
+		);
+		fireEvent.pointerEnter(label("Workspace"));
+		expect(await screen.findByRole("tooltip")).toHaveTextContent("Workspace");
+		// A different kind of target, so the bubble hides and waits again.
+		fireEvent.pointerEnter(
+			screen.getByRole("button", { name: "Start workspace" }),
+		);
+		expect(screen.queryByRole("tooltip")).toBeNull();
+		expect(await screen.findByRole("tooltip")).toHaveTextContent(
+			"Start workspace",
+		);
+		// One dense action bar is close enough to skip the delay.
+		fireEvent.pointerEnter(
+			screen.getByRole("button", { name: "Workspace settings" }),
+		);
+		expect(screen.getByRole("tooltip")).toHaveTextContent("Workspace settings");
 	});
 
 	it("treats an empty children array as a branch that has not loaded", () => {

--- a/test/webview/ui/tree.rows.test.tsx
+++ b/test/webview/ui/tree.rows.test.tsx
@@ -14,6 +14,7 @@ import {
 	row,
 	rowNames,
 	selectedRows,
+	stubElementBoxes,
 	tree,
 } from "./treeTestHelpers";
 
@@ -49,6 +50,7 @@ describe("Tree rows", () => {
 	});
 
 	it("moves one hover between labels, defaulting to the text value", async () => {
+		stubElementBoxes();
 		render(
 			<TooltipProvider delayDuration={0}>
 				<Tree
@@ -79,6 +81,7 @@ describe("Tree rows", () => {
 	});
 
 	it("waits for a new target but crosses an action bar at once", async () => {
+		stubElementBoxes();
 		render(
 			<TooltipProvider delayDuration={60}>
 				<Tree

--- a/test/webview/ui/treeTestHelpers.tsx
+++ b/test/webview/ui/treeTestHelpers.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
+import { onTestFinished, vi } from "vitest";
 
 import { Tree, type TreeNode, type TreeProps } from "@repo/ui";
 
@@ -25,6 +26,14 @@ export const BASIC_NODES: readonly TreeNode[] = [
 	},
 	{ id: "last", label: "Last" },
 ];
+
+/** jsdom has no layout; supply visible boxes for this test only. */
+export function stubElementBoxes(): void {
+	const spy = vi
+		.spyOn(Element.prototype, "getBoundingClientRect")
+		.mockImplementation(() => DOMRect.fromRect({ width: 200, height: 22 }));
+	onTestFinished(() => spy.mockRestore());
+}
 
 export const tree = (): HTMLElement => screen.getByRole("tree");
 


### PR DESCRIPTION
## Summary

Third of three stacked PRs: #1065 → #1079 → **this one**. Gives tree rows and icon buttons the hover VS Code shows, served the way the workbench serves it: one widget per list rather than one per target.

- A row hovers with its text value; `tooltip` overrides it and `null` opts out
- `IconButton` hints with its label, so a row's action bar needs no wiring
- Ctrl+K Ctrl+I opens the focused row's hover, the chord bound to `list.showHover`
- One bubble for the whole tree, placed and delayed the way native places and delays it

## Why one widget

`Tooltip` mounts a Radix root per trigger, which is right for a button and wrong for a list. Two reasons.

**Cost.** Mounting 2,000 rows took 515ms with a root each, against 134ms with no hovers at all. A shared widget brings it back to 189ms, within noise of a tree that has none.

**Correctness.** Native computes `delay = isInstantlyHovering() ? 0 : workbench.hover.delay`, where "instantly" means a hover was hidden within the last 200ms. That rule needs one place to keep the timestamp, and a root per trigger has none: trigger B cannot know that A was showing a moment ago. Radix answers this with `skipDelayDuration` on its provider, but our bubble is a controlled root and never reports its opens there, so the two would keep separate ideas of what is on screen.

So `HoverDelegateScope` hands every `Tooltip` inside it to one bubble. `Tooltip` reports its trigger and content to that delegate instead of mounting a root, `TreeHover` owns the widget, and an invisible anchor moves to whatever the pointer reached.

## Placement, from the managed-hover path

A managed hover always passes `position: { hoverPosition: 2 }`, whatever the widget's own default of 3 is, so it sits **below** its target, 2px into the bottom edge. The same line sets `showPointer: hoverDelegate.placement === "element"`, and `computeXCordinate` centers whenever a pointer is shown. That splits into two rules, both matched here:

| Target | Native placement | Result |
| --- | --- | --- |
| Action bar button | element | centered under the button |
| Row label | mouse | follows the cursor, `target.x = event.x + 10` |

Measured in Chrome: an action bubble's center lands on the button's center to the pixel, and a row bubble's left edge tracks the cursor at exactly +10 across positions. The anchor takes its y from the row rather than from whichever element reported the pointer, so a label taller than its row, which is what a status pill produces, cannot push the bubble off it.

## Matching native's timing

Native gates the zero-delay path on a per-delegate `instantHover` flag, and exactly three call sites set it: a notebook cell toolbar and two inline widgets. Never a list. So each new target waits out the delay here too, with the same exception native carves out for a dense cluster of targets, which for a tree means one row's action bar.

With `workbench.hover.delay` at its 500ms default:

| Move | Time |
| --- | ---: |
| First hover | 518ms |
| Row to another row | 511ms |
| Label to an action button | 513ms |
| Action button to action button | 19ms |

## Notes for review

- `@radix-ui/react-slot` becomes a direct dependency of `packages/ui`. It was already there transitively, and it merges the delegate's pointer handlers onto a trigger while composing any the consumer passed.
- `TooltipScope` lets a component own hovers without forcing a provider on its consumers, so `Tree` and `IconButton` work unwrapped. A private provider keeps its own skip-delay, so an app with several of them makes every hover wait the full delay; the README says to mount one provider per app.
- `TreeHover` uses plain functions rather than `useCallback`. The React Compiler covers the memoization, and the file compiles with no bailout, so the delegate a row reads stays stable without it.
- Native pins the sticky container at `z-index: 13`, below the hover widget's 40. Ours used 100, so a bubble over a row near the top of the tree was painted over by the pinned rows.
- Drive-by: the menu parity story loses its trigger button so both menus start at the same height, which the pixel diff was reading as drift.
- A tree hover is not linked to its row with `aria-describedby`. The bubble hangs off a shared anchor, and rows are reached through `aria-activedescendant` rather than focus, so the association would not be announced. The default content is the row's own accessible name.

## Diff composition

| Area | Added | Deleted |
| --- | ---: | ---: |
| Production UI source | 418 | 82 |
| Automated tests and shared helpers | 123 | 4 |
| Stories and visual fixtures | 118 | 7 |
| Documentation | 22 | 1 |
| Build and workspace configuration | 4 | 0 |
| **Total** | **685** | **94** |

## Validation

- `pnpm test:webview --reporter=dot`: 45 files, 418 tests passed, up from 414 on #1079
- Focused Tree suite: 10 files, 99 tests passed
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm storybook:ci`
- Three new stories, `Hover`, `HoverOnAction`, and `HoverByKeyboard`, drive the bubble through a play function and assert its content. Note that a synthetic pointer never triggers CSS `:hover`, so the action-bar story selects its row to reveal the buttons and the helper waits for a laid-out box before hovering.
- Verified in Chrome against a running Storybook: cursor tracking, centering on an action button, the timings above, stacking over pinned rows, and hovers on pinned sticky rows, whose coordinates come from a different container
- Every component in `packages/ui` still compiles under the React Compiler with no bailout

<sub>This pull request description was updated by Coder Agents on behalf of @EhabY.</sub>

