### PR TITLE
fix: await progress-log writes before finishing CLI download

### DIFF
--- a/src/core/cliManager.ts
+++ b/src/core/cliManager.ts
@@ -799,6 +799,8 @@ export class CliManager {
 						? "unknown"
 						: prettyBytes(contentLength);
 
+					let progressWrite: Promise<void> = Promise.resolve();
+
 					// Pipe data received from the request to the stream.
 					readStream.on("data", (buffer: Buffer) => {
 						writeStream.write(buffer, () => {
@@ -810,7 +812,7 @@ export class CliManager {
 									: (buffer.byteLength / contentLength) * 100,
 							});
 							if (onProgress) {
-								onProgress(
+								progressWrite = onProgress(
 									written,
 									Number.isNaN(contentLength) ? null : contentLength,
 								).catch((error) => {
@@ -827,27 +829,33 @@ export class CliManager {
 					return new Promise<boolean>((resolve, reject) => {
 						writeStream.on("error", (error) => {
 							readStream.destroy();
-							reject(
-								new Error(
-									`Unable to download binary: ${errToStr(error, "no reason given")}`,
+							void progressWrite.then(() =>
+								reject(
+									new Error(
+										`Unable to download binary: ${errToStr(error, "no reason given")}`,
+									),
 								),
 							);
 						});
 						readStream.on("error", (error) => {
 							writeStream.close();
-							reject(
-								new Error(
-									`Unable to download binary: ${errToStr(error, "no reason given")}`,
+							void progressWrite.then(() =>
+								reject(
+									new Error(
+										`Unable to download binary: ${errToStr(error, "no reason given")}`,
+									),
 								),
 							);
 						});
 						readStream.on("close", () => {
 							writeStream.close();
-							if (cancelled) {
-								resolve(false);
-							} else {
-								resolve(true);
-							}
+							void progressWrite.then(() => {
+								if (cancelled) {
+									resolve(false);
+								} else {
+									resolve(true);
+								}
+							});
 						});
 					});
 				},


### PR DESCRIPTION
## What

Fixes a flaky test: `redownloads when version mismatch is detected concurrently`.

## Root cause

`performBinaryDownload` writes the progress log two ways:

1. Fire-and-forget "downloading" writes from the `onProgress` callback (not awaited).
2. An awaited `clearProgress` in the `finally` block.

The final "downloading" write could land after `clearProgress` ran, re-creating `.progress.log` and leaving it behind. The ordering between the last `writeStream.write` callback and `readStream.on("close")` is non-deterministic, so the test's `vi.waitFor` occasionally timed out waiting for the file to disappear.

## Fix

Track the latest progress write and await it before resolving or rejecting the download promise (on the success `close` path and the error paths), so `clearProgress` always runs after the final write.

## Why this is safe

- The progress log is a plain `fs.writeFile`, no lock, rename, or ownership change. It never goes through `renameWithRetry`, so there is no Windows rename or backoff cost.
- The write is already `.catch`-wrapped and logged as a warning, so a slow or failing write never rejects the download.
- `writeStream.close()` flushes pending writes, firing the pending callback and resolving the tracked promise, so no deadlock.

## Testing

- `pnpm typecheck`
- `pnpm exec eslint src/core/cliManager.ts`
- `pnpm test:extension ./test/unit/core/cliManager.concurrent.test.ts ./test/unit/core/cliManager.test.ts` (67 passing)

---

🤖 Generated by Coder Agents.
