### PR TITLE
docs: add instructions for creating/installing extension from .vsix file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,13 @@ pnpm test:integration
 > this extension from a coder workspace. We currently recommend cloning the
 > repo locally
 
+To view your local changes to the extension within VS Code:
+
+1. Run `pnpm package`. This creates a file named coder-remote-VERSION.vsix in your repo directory.
+2. In the "Extensions" tab of VS Code, open the kebab menu and select "Install from VSIX...". You can also run "Extensions: Install from VSIX..." from the command palette.
+
+Alternatively:
+
 1. Run `pnpm watch` in the background.
 2. OPTIONAL: Compile the `coder` binary and place it in the equivalent of
    `os.tmpdir() + "/coder"`. If this is missing, it will download the binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,7 +191,7 @@ pnpm test:integration
 To view your local changes to the extension within VS Code:
 
 1. Run `pnpm package`. This creates a file named coder-remote-VERSION.vsix in your repo directory.
-2. In the "Extensions" tab of VS Code, open the kebab menu and select "Install from VSIX...". You can also run "Extensions: Install from VSIX..." from the command palette.
+2. In the "Extensions" tab of VS Code, open the kebab menu and select "Install from VSIX...". You can also run "Extensions: Install from VSIX..." from the command palette. Select the VSIX file created by `pnpm package`.
 
 Alternatively:
 


### PR DESCRIPTION
Added brief guidance on how to run local changes within one's own VS Code. This is helpful to me as a first-time VS Code extension developer 😄

Note: I tried running "Run Extension" per the existing instructions and got the below error. The instructions I added are a workaround for it

<img width="3680" height="2382" alt="image" src="https://github.com/user-attachments/assets/7c9665a3-7e3c-412d-9348-6d74c2582d9c" />
