### PR TITLE
ci: auto-assign PR author and lint PR titles

### DIFF
--- a/.github/workflows/pr-auto-assign.yaml
+++ b/.github/workflows/pr-auto-assign.yaml
@@ -1,0 +1,16 @@
+name: PR Auto Assign
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  assign-author:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Assign author
+        uses: toshimaru/auto-author-assign@3e19bfc990cb1cf0589dce95e9f75289bb1e22de # v3.0.3

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -1,0 +1,32 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  title:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            security


### PR DESCRIPTION
- Adds `pr-auto-assign.yaml`: assigns the PR author as assignee on open, mirroring coder/coder's `pr-auto-assign.yaml` (`toshimaru/auto-author-assign`), so the Assignee field is reliable for filtering.
- Adds `pr-title-lint.yaml`: enforces basic Conventional Commits formatting on PR titles via `amannn/action-semantic-pull-request` (used by Electron, Vite, Vercel, Firebase, etc.) — type-only, no scope/file-path validation.
- Both actions are pinned by commit SHA, following this repo's existing convention.

Considered but intentionally left out: a `community` PR label job (coder/coder's `contrib.yaml`) — the last 20 merged PRs here had ~0 external contributors, and it depends on an org-level GitHub App token that isn't confirmed to exist for this repo, so the cost/benefit didn't hold up right now.