### PR TITLE
docs: rebrand windsurf references to devin desktop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ indicates that it should connect to the provided host name using SSH.
 
 The host name takes the format
 `coder-<editor>.<domain>--<username>--<workspace>`, where `<editor>` comes from
-that product's URI scheme, such as `vscode`, `cursor`, or `devin`. The CLI is
+that product's URI scheme, such as `vscode`, `cursor`, or `devin`/`windsurf`. The CLI is
 invoked through SSH's `ProxyCommand` with this prefix so it can route SSH to the
 right workspace. A legacy `coder-vscode` authority opened in another editor is
 reopened once with that editor's prefix; legacy recent-folder entries remain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ indicates that it should connect to the provided host name using SSH.
 
 The host name takes the format
 `coder-<editor>.<domain>--<username>--<workspace>`, where `<editor>` comes from
-that product's URI scheme, such as `vscode`, `cursor`, or `windsurf`. The CLI is
+that product's URI scheme, such as `vscode`, `cursor`, or `devin`. The CLI is
 invoked through SSH's `ProxyCommand` with this prefix so it can route SSH to the
 right workspace. A legacy `coder-vscode` authority opened in another editor is
 reopened once with that editor's prefix; legacy recent-folder entries remain

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The Coder Remote extension connects your editor to
 
 - **One-click workspace access** - open workspaces from the Coder dashboard or
   the editor sidebar. Workspaces start automatically when opened.
-- **Multi-editor support** - works with VS Code, Cursor, Windsurf, and other
-  VS Code forks.
+- **Multi-editor support** - works with VS Code, Cursor, Devin Desktop
+  (formerly Windsurf), and other VS Code forks.
 - **Workspace sidebar** - browse, search, and create workspaces. View agent
   metadata and app statuses at a glance.
 - **Coder Tasks** - create, monitor, and manage AI agent tasks directly from
@@ -34,7 +34,7 @@ The Coder Remote extension connects your editor to
 > The extension builds on VS Code-provided implementations of SSH. Make sure you
 > have the correct SSH extension installed for your editor
 > (`ms-vscode-remote.remote-ssh`, `anysphere.remote-ssh` for Cursor, or
-> `codeium.windsurf-remote-openssh` for Windsurf).
+> `codeium.windsurf-remote-openssh` for Devin Desktop).
 
 ## Getting Started
 
@@ -71,7 +71,7 @@ values can depend on the specific machine or network where they were set.
 
 The extension registers a URI handler that can open workspaces from outside
 the editor, such as links on the Coder dashboard. The scheme matches the
-editor (`vscode://`, `cursor://`, `windsurf://`, etc.), followed by the
+editor (`vscode://`, `cursor://`, `devin://`, etc.), followed by the
 extension ID and a path:
 
 ```text

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ async function doActivate(
 	// This is janky, but that's alright since it provides such minimal
 	// functionality to the extension.
 	//
-	// Cursor and VSCode are covered by ms remote, and the only other is windsurf for now
+	// Cursor and VSCode are covered by ms remote, and the only other is Devin Desktop for now
 	// Means that vscodium is not supported by this for now
 
 	const remoteSshExtension = getRemoteSshExtension();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,7 @@ async function doActivate(
 	// This is janky, but that's alright since it provides such minimal
 	// functionality to the extension.
 	//
-	// Cursor and VSCode are covered by ms remote, and the only other is Devin Desktop for now
+	// Cursor and VSCode are covered by ms remote, and the only other are Devin Desktop / Windsurf for now
 	// Means that vscodium is not supported by this for now
 
 	const remoteSshExtension = getRemoteSshExtension();

--- a/src/remote/sshProcess.ts
+++ b/src/remote/sshProcess.ts
@@ -488,7 +488,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 
 /**
  * Finds the Remote SSH extension's log file path.
- * Tries extension-specific folder first (Cursor, Devin Desktop, Antigravity),
+ * Tries extension-specific folder first (Cursor, Devin Desktop / Windsurf, Antigravity),
  * then output_logging_ fallback (MS VS Code).
  */
 async function findRemoteSshLogPath(

--- a/src/remote/sshProcess.ts
+++ b/src/remote/sshProcess.ts
@@ -488,7 +488,7 @@ export class SshProcessMonitor implements vscode.Disposable {
 
 /**
  * Finds the Remote SSH extension's log file path.
- * Tries extension-specific folder first (Cursor, Windsurf, Antigravity),
+ * Tries extension-specific folder first (Cursor, Devin Desktop, Antigravity),
  * then output_logging_ fallback (MS VS Code).
  */
 async function findRemoteSshLogPath(
@@ -498,7 +498,7 @@ async function findRemoteSshLogPath(
 ): Promise<string | undefined> {
 	const logsParentDir = path.dirname(codeLogDir);
 
-	// Try extension-specific folder (for VS Code clones like Cursor, Windsurf)
+	// Try extension-specific folder (for VS Code clones like Cursor, Devin Desktop)
 	try {
 		const extensionLogDir = path.join(logsParentDir, extensionId);
 		const remoteSshLog = await findSshLogInDir(extensionLogDir);

--- a/src/supportBundle/remoteServerDataPath.ts
+++ b/src/supportBundle/remoteServerDataPath.ts
@@ -106,7 +106,7 @@ function getConfiguredServerDataPath(
 			"serverInstallPath",
 			{},
 		);
-		// Windsurf and Antigravity have no install path setting; their
+		// Devin Desktop and Antigravity have no install path setting; their
 		// servers always live in the home default.
 		let installPath: string | undefined;
 		if (extensionId === "jeanp413.open-remote-ssh") {

--- a/src/supportBundle/remoteServerDataPath.ts
+++ b/src/supportBundle/remoteServerDataPath.ts
@@ -106,7 +106,7 @@ function getConfiguredServerDataPath(
 			"serverInstallPath",
 			{},
 		);
-		// Devin Desktop and Antigravity have no install path setting; their
+		// Devin Desktop / Windsurf and Antigravity have no install path setting; their
 		// servers always live in the home default.
 		let installPath: string | undefined;
 		if (extensionId === "jeanp413.open-remote-ssh") {

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ export function findPort(text: string): number | null {
 	const lastMatch = allMatches[allMatches.length - 1];
 	// Each capture group corresponds to a different Remote SSH extension log format:
 	// [0] full match, [1] and [2] ms-vscode-remote.remote-ssh,
-	// [3] devin/open-remote-ssh/antigravity, [4] anysphere.remote-ssh
+	// [3] devin/windsurf/open-remote-ssh/antigravity, [4] anysphere.remote-ssh
 	const portStr = lastMatch[1] || lastMatch[2] || lastMatch[3] || lastMatch[4];
 	if (!portStr) {
 		return null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,7 +24,7 @@ export function findPort(text: string): number | null {
 	const lastMatch = allMatches[allMatches.length - 1];
 	// Each capture group corresponds to a different Remote SSH extension log format:
 	// [0] full match, [1] and [2] ms-vscode-remote.remote-ssh,
-	// [3] windsurf/open-remote-ssh/antigravity, [4] anysphere.remote-ssh
+	// [3] devin/open-remote-ssh/antigravity, [4] anysphere.remote-ssh
 	const portStr = lastMatch[1] || lastMatch[2] || lastMatch[3] || lastMatch[4];
 	if (!portStr) {
 		return null;

--- a/test/unit/remote/remote.test.ts
+++ b/test/unit/remote/remote.test.ts
@@ -35,8 +35,8 @@ const REMOTE_AUTHORITY =
 	"ssh-remote+coder-vscode.coder.example.com--testuser--test-workspace.main";
 const CURSOR_REMOTE_AUTHORITY =
 	"ssh-remote+coder-cursor.coder.example.com--testuser--test-workspace.main";
-const WINDSURF_REMOTE_AUTHORITY =
-	"ssh-remote+coder-windsurf.coder.example.com--testuser--test-workspace.main";
+const DEVIN_REMOTE_AUTHORITY =
+	"ssh-remote+coder-devin.coder.example.com--testuser--test-workspace.main";
 const REMOTE_SSH_EXTENSION_ID = "anysphere.remote-ssh";
 const MISMATCHED_URL =
 	"https://cursor.example.com/private?token=sensitive-url-token";
@@ -277,7 +277,7 @@ describe("Remote", () => {
 		const { remote, ensureLoggedInWithDialog, mementoManager } = createRemote();
 
 		await expect(
-			remote.setup(WINDSURF_REMOTE_AUTHORITY, "none", REMOTE_SSH_EXTENSION_ID),
+			remote.setup(DEVIN_REMOTE_AUTHORITY, "none", REMOTE_SSH_EXTENSION_ID),
 		).resolves.toBeUndefined();
 
 		expect(ensureLoggedInWithDialog).not.toHaveBeenCalled();

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -229,7 +229,7 @@ describe("findPort", () => {
 			54321,
 		],
 		[
-			"windsurf/open-remote-ssh/antigravity",
+			"devin/open-remote-ssh/antigravity",
 			"[INFO] Connection => 9999(socks) => target",
 			9999,
 		],

--- a/test/unit/util/authority.test.ts
+++ b/test/unit/util/authority.test.ts
@@ -14,8 +14,7 @@ import {
 const env = vscode.env as typeof vscode.env & { uriScheme: string };
 const CURSOR_AUTHORITY = "ssh-remote+coder-cursor.dev.coder.com--foo--bar.main";
 const LEGACY_AUTHORITY = "ssh-remote+coder-vscode.dev.coder.com--foo--bar.main";
-const WINDSURF_AUTHORITY =
-	"ssh-remote+coder-windsurf.dev.coder.com--foo--bar.main";
+const DEVIN_AUTHORITY = "ssh-remote+coder-devin.dev.coder.com--foo--bar.main";
 
 const parts = (prefix: string): AuthorityParts => ({
 	agent: "main",
@@ -82,7 +81,7 @@ describe("parseRemoteAuthority", () => {
 		expect(parseRemoteAuthority("ssh-remote+coder-vscode")).toBeNull();
 		env.uriScheme = "cursor";
 		expect(
-			parseRemoteAuthority("ssh-remote+coder-windsurf.dev.coder.com--foo"),
+			parseRemoteAuthority("ssh-remote+coder-devin.dev.coder.com--foo"),
 		).toBeNull();
 	});
 
@@ -223,7 +222,7 @@ describe("authority migration", () => {
 			authority: "ssh-remote+coder-vscode",
 			expected: false,
 		},
-		{ label: "foreign", authority: WINDSURF_AUTHORITY, expected: false },
+		{ label: "foreign", authority: DEVIN_AUTHORITY, expected: false },
 		{
 			label: "different wrapper",
 			authority: `dev-container+abc@${LEGACY_AUTHORITY}`,


### PR DESCRIPTION
Windsurf rebranded to Devin Desktop in June 2026. This updates user-facing prose and code comments in this repo to reflect the current name.

## Changes
- `README.md` / `CONTRIBUTING.md`: "Windsurf" mentions and the example `windsurf://` URI scheme updated to Devin Desktop / `devin://`.
- Code comments in `src/util.ts`, `src/extension.ts`, `src/remote/sshProcess.ts`, `src/supportBundle/remoteServerDataPath.ts`: product name references updated.
- `test/unit/util.test.ts`, `test/unit/util/authority.test.ts`, `test/unit/remote/remote.test.ts`: cosmetic test label/fixture renames only (`WINDSURF_AUTHORITY` → `DEVIN_AUTHORITY`, etc.); these were generic "foreign editor" placeholders, not Windsurf-specific test cases, so no assertions changed.

## Deliberately unchanged (functional/compat identifiers)
- `codeium.windsurf-remote-openssh` — still the actual Remote-SSH extension ID Devin Desktop ships under; confirmed both against Devin Desktop's own docs and by hands-on testing.
- `remote.devinSSH.configFile` / `remote.windsurfSSH.configFile` handling in `sshExtension.ts` — both settings namespaces exist across editor versions and are both ignored on purpose.
- `CHANGELOG.md` — historical entries are left as-is.

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test` (156 files, 2438 tests passed, 1 pre-existing skip)
- Tested in Devin Desktop with a sideloaded build of this branch: `codeium.windsurf-remote-openssh` is detected and SSH connections to a Coder workspace succeed, and the `devin://coder.coder-remote/open?...` deep link opens the workspace correctly.

> 🤖 This PR was created with the help of Coder Agents, and has been reviewed by my human.  🧑💻