### PR TITLE
chore: release v1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
      from published versions since it shows up in the VS Code extension changelog
      tab and is confusing to users. Add it back between releases if needed. -->
 
-## Unreleased
+## [v1.16.2](https://github.com/coder/vscode-coder/releases/tag/v1.16.2) 2026-08-25
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "coder-remote",
 	"displayName": "Coder",
-	"version": "1.16.1",
+	"version": "1.16.2",
 	"description": "Open any workspace with a single click.",
 	"categories": [
 		"Other"


### PR DESCRIPTION
Release v1.16.2, stacked on #1092: bumps `package.json` to 1.16.2 and cuts the changelog's `Unreleased` section as the v1.16.2 release.

## Changes

- `package.json`: version 1.16.1 → 1.16.2
- `CHANGELOG.md`: `## Unreleased` → `## [v1.16.2](https://github.com/coder/vscode-coder/releases/tag/v1.16.2) 2026-08-25`

## Notes

- Based on `fix/keep-legacy-coder-authority` (#1092), so its fixes are what v1.16.2 ships. **Retarget this PR to `main` once #1092 merges.**
- The release tag must point at a commit where `package.json` reads 1.16.2 — `release.yaml` validates tag against `package.json` and requires the tag to be an ancestor of `origin/main`.

<sub>This pull request was created by Coder Agents on behalf of @EhabY.</sub>